### PR TITLE
Fix ExtensionPoint and RenderProvider communication

### DIFF
--- a/react/ExtensionPoint.js
+++ b/react/ExtensionPoint.js
@@ -2,14 +2,12 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import treePath from 'react-tree-path'
 
-import {getImplementation} from './utils/assets'
 import ExtensionPointComponent from './components/ExtensionPointComponent'
 
 class ExtensionPoint extends Component {
   static contextTypes = {
     extensions: PropTypes.object,
     emitter: PropTypes.object,
-    registerExtension: PropTypes.func,
     production: PropTypes.bool,
   }
 
@@ -49,10 +47,8 @@ class ExtensionPoint extends Component {
   }
 
   componentDidMount() {
-    const {registerExtension, production} = this.context
+    const {production} = this.context
     const {treePath} = this.props
-
-    registerExtension(treePath)
 
     if (!production) {
       this.subscribeToTreePath('*')
@@ -61,11 +57,9 @@ class ExtensionPoint extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {production, registerExtension} = this.context
+    const {production} = this.context
 
     if (nextProps.treePath !== this.props.treePath) {
-      registerExtension(nextProps.treePath)
-
       if (!production) {
         this.unsubscribeToTreePath(this.props.treePath)
         this.subscribeToTreePath(nextProps.treePath)
@@ -94,7 +88,6 @@ class ExtensionPoint extends Component {
   }
 
   render() {
-    const {production} = this.context
     const {children, treePath, ...parentProps} = this.props
     const {component, props: extensionProps, error, errorInfo} = this.state
 
@@ -115,23 +108,8 @@ class ExtensionPoint extends Component {
       ...parentProps,
       ...extensionProps,
     }
-    const extensionPointComponent = <ExtensionPointComponent component={component} props={props}>{children}</ExtensionPointComponent>
 
-    const root = treePath.split('/')[0]
-    const editableExtensionPointComponent = this.context.extensions[`${root}/__editable`]
-    const editableProps = {
-      treePath,
-      component,
-      props,
-    }
-    const editableExtensionPoint = editableExtensionPointComponent &&
-      <ExtensionPointComponent component={editableExtensionPointComponent.component} props={editableProps}>{extensionPointComponent}</ExtensionPointComponent>
-
-    const maybeEditable = !production && editableExtensionPoint
-      ? editableExtensionPoint
-      : extensionPointComponent
-
-    return maybeEditable
+    return <ExtensionPointComponent component={component} props={props}>{children}</ExtensionPointComponent>
   }
 }
 

--- a/react/ExtensionPoint.js
+++ b/react/ExtensionPoint.js
@@ -2,9 +2,8 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import treePath from 'react-tree-path'
 
+import {getImplementation} from './utils/assets'
 import ExtensionPointComponent from './components/ExtensionPointComponent'
-
-const EMPTY_ARRAY = []
 
 class ExtensionPoint extends Component {
   static contextTypes = {
@@ -95,6 +94,7 @@ class ExtensionPoint extends Component {
   }
 
   render() {
+    const {production} = this.context
     const {children, treePath, ...parentProps} = this.props
     const {component, props: extensionProps, error, errorInfo} = this.state
 
@@ -115,14 +115,23 @@ class ExtensionPoint extends Component {
       ...parentProps,
       ...extensionProps,
     }
+    const extensionPointComponent = <ExtensionPointComponent component={component} props={props}>{children}</ExtensionPointComponent>
 
-    const components = !component
-      ? EMPTY_ARRAY
-      : Array.isArray(component)
-        ? component
-        : [component]
+    const root = treePath.split('/')[0]
+    const editableExtensionPointComponent = this.context.extensions[`${root}/__editable`]
+    const editableProps = {
+      treePath,
+      component,
+      props,
+    }
+    const editableExtensionPoint = editableExtensionPointComponent &&
+      <ExtensionPointComponent component={editableExtensionPointComponent.component} props={editableProps}>{extensionPointComponent}</ExtensionPointComponent>
 
-    return <ExtensionPointComponent components={components} props={props}>{children}</ExtensionPointComponent>
+    const maybeEditable = !production && editableExtensionPoint
+      ? editableExtensionPoint
+      : extensionPointComponent
+
+    return maybeEditable
   }
 }
 

--- a/react/ExtensionPoint.js
+++ b/react/ExtensionPoint.js
@@ -2,137 +2,93 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import treePath from 'react-tree-path'
 
-import {fetchAssets, getComponents, getImplementations} from './utils/assets'
+import ExtensionPointComponent from './components/ExtensionPointComponent'
+
+const EMPTY_ARRAY = []
 
 class ExtensionPoint extends Component {
   static contextTypes = {
-    components: PropTypes.object,
     extensions: PropTypes.object,
     emitter: PropTypes.object,
-    updateExtension: PropTypes.func,
-    registerEmptyExtension: PropTypes.func,
+    registerExtension: PropTypes.func,
     production: PropTypes.bool,
   }
 
   static propTypes = {
-    id: PropTypes.string.isRequired,
     children: PropTypes.node,
-    treePath: PropTypes.string,
+    treePath: PropTypes.string.isRequired,
   }
 
   constructor(props, context) {
     super()
-    this.state = this.getExtensionPointState(props, context)
+    this.state = this.getExtensionPointState(props.treePath, context.extensions)
   }
 
-  getExtensionPointState = (props, context) => {
-    const {treePath} = props
-    const {extensions} = context
+  getExtensionPointState = (treePath, extensions) => {
     const extension = extensions[treePath]
     return {
-      extension,
+      component: extension ? extension.component : null,
+      props: extension ? extension.props : null,
     }
   }
 
-  updateExtensionPoint = () => {
-    this.setState(this.getExtensionPointState(this.props, this.context))
+  updateExtensionPoint = (state) => {
+    if (state && state.extensions) {
+      this.context.extensions = state.extensions
+    }
+    this.setState(this.getExtensionPointState(this.props.treePath, this.context.extensions))
   }
 
-  subscribe = (subscribe) => {
-    const {production, emitter} = this.context
-    const {extension} = this.state
-    const {treePath} = this.props
-
-    if (production) {
-      return
-    }
-
-    const events = [
-      'extension:*:update',
-      `extension:${treePath}:update`,
-    ]
-
-    if (extension && extension.component) {
-      const originalComponent = Array.isArray(extension.component) ? extension.component[0] : extension.component
-      events.push(`component:${originalComponent}:update`)
-    }
-
-    events.forEach(e => {
-      if (subscribe) {
-        emitter.addListener(e, this.updateExtensionPoint)
-      } else {
-        emitter.removeListener(e, this.updateExtensionPoint)
-      }
-    })
+  subscribeToTreePath = (treePath) => {
+    const {emitter} = this.context
+    emitter.addListener(`extension:${treePath}:update`, this.updateExtensionPoint)
   }
 
-  fetchComponentAndSubscribe = () => {
-    const {components: componentAssets} = this.context
-    const {extension} = this.state
-
-    this.subscribe(true)
-
-    if (!extension) {
-      return
-    }
-    const components = getComponents(extension)
-    const Components = getImplementations(components)
-
-    // If this component is not loaded, fetch the assets and re-render
-    if (extension &&
-        extension.component &&
-        Components.length !== components.length) {
-      fetchAssets(extension, componentAssets)
-        .then(this.updateExtensionPoint)
-        .then(() => {
-          this.context.emitter.emit(`extension:${this.props.treePath}:update:complete`)
-        })
-    }
+  unsubscribeToTreePath = (treePath) => {
+    const {emitter} = this.context
+    emitter.removeListener(`extension:${treePath}:update`, this.updateExtensionPoint)
   }
 
   componentDidMount() {
-    const {extension} = this.state
-    const {production} = global.__RUNTIME__
+    const {registerExtension, production} = this.context
+    const {treePath} = this.props
 
-    if (!extension && !production) {
-      const {treePath} = this.props
-      this.context.registerEmptyExtension(treePath)
-    }
+    registerExtension(treePath)
 
-    this.fetchComponentAndSubscribe()
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps.treePath !== this.props.treePath) {
-      this.fetchComponentAndSubscribe()
-    }
-
-    if (prevState.extension == null) {
-      return this.updateExtensionPoint()
-    }
-
-    const previousComponent = Array.isArray(prevState.extension.component) ? prevState.extension.component[0] : prevState.extension.component
-    const newComponent = Array.isArray(this.state.extension.component) ? this.state.extension.component[0] : this.state.extension.component
-    if (previousComponent !== newComponent) {
-      this.fetchComponentAndSubscribe()
+    if (!production) {
+      this.subscribeToTreePath('*')
+      this.subscribeToTreePath(treePath)
     }
   }
 
   componentWillReceiveProps(nextProps) {
+    const {production, registerExtension} = this.context
+
     if (nextProps.treePath !== this.props.treePath) {
-      this.subscribe(false)
-      this.setState(this.getExtensionPointState(nextProps, this.context))
+      registerExtension(nextProps.treePath)
+
+      if (!production) {
+        this.unsubscribeToTreePath(this.props.treePath)
+        this.subscribeToTreePath(nextProps.treePath)
+      }
+
+      this.setState(this.getExtensionPointState(nextProps.treePath, this.context.extensions))
     }
   }
 
   componentWillUnmount() {
-    this.subscribe(false)
+    const {production} = this.context
+    const {treePath} = this.props
+
+    if (!production) {
+      this.unsubscribeToTreePath('*')
+      this.unsubscribeToTreePath(treePath)
+    }
   }
 
   componentDidCatch(error, errorInfo) {
     console.error('Failed to render extension point', this.props.treePath, error, errorInfo)
     this.setState({
-      ...this.state,
       error,
       errorInfo,
     })
@@ -140,7 +96,9 @@ class ExtensionPoint extends Component {
 
   render() {
     const {children, treePath, ...parentProps} = this.props
-    const {extension, error, errorInfo} = this.state
+    const {component, props: extensionProps, error, errorInfo} = this.state
+
+    delete parentProps.id
 
     // A children of this extension point throwed an uncaught error
     if (error || errorInfo) {
@@ -153,34 +111,18 @@ class ExtensionPoint extends Component {
       )
     }
 
-    // This extension point is not configured or has no component
-    if (!extension || !extension.component) {
-      return <span className="ExtensionPoint--empty" />
-    }
-
-    // Extensions may have multiple components (HOCs)
-    const components = getComponents(extension)
-    const Components = getImplementations(components)
-
-    // This extension assets' have not loaded yet,
-    // which will be handled by componentDidMount
-    // and trigger a re-render when available.
-    if (Components.length !== components.length) {
-      return (
-        <span className="ExtensionPoint--loading">
-          {children}
-        </span>
-      )
-    }
-
     const props = {
       ...parentProps,
-      ...extension.props,
+      ...extensionProps,
     }
 
-    return Components.reduce((acc, Component) => {
-      return <Component {...props}>{acc || children}</Component>
-    }, null)
+    const components = !component
+      ? EMPTY_ARRAY
+      : Array.isArray(component)
+        ? component
+        : [component]
+
+    return <ExtensionPointComponent components={components} props={props}>{children}</ExtensionPointComponent>
   }
 }
 

--- a/react/components/ExtensionPointComponent.js
+++ b/react/components/ExtensionPointComponent.js
@@ -1,0 +1,94 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+
+import {fetchAssets, getImplementations} from '../utils/assets'
+
+export default class ExtensionPointComponent extends Component {
+  static contextTypes = {
+    components: PropTypes.object,
+    emitter: PropTypes.object,
+  }
+
+  static propTypes = {
+    children: PropTypes.node,
+    components: PropTypes.array,
+    props: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      Components: getImplementations(props.components),
+    }
+  }
+
+  updateComponents = () => {
+    const {components} = this.props
+    const Components = getImplementations(components)
+    this.setState({Components})
+  }
+
+  fetchAndRerender = () => {
+    const {components: componentAssets} = this.context
+    const {components} = this.props
+    const Components = getImplementations(components)
+
+    // We have configured components but they aren't all loaded. Let's fetch the assets and re-render.
+    if (Components.length < components.length) {
+      fetchAssets(components, componentAssets).then(this.updateComponents)
+    }
+  }
+
+  subscribeToComponents = (components) => {
+    const {emitter} = this.context
+    components.forEach(c => {
+      emitter.addListener(`component:${c}:update`, this.updateComponents)
+    })
+  }
+
+  unsubscribeToComponents = (components) => {
+    const {emitter} = this.context
+    components.forEach(c => {
+      emitter.removeListener(`component:${c}:update`, this.updateComponents)
+    })
+  }
+
+  componentDidMount() {
+    const {components} = this.props
+    this.subscribeToComponents(components)
+    this.fetchAndRerender()
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {components} = this.props
+    const {components: nextComponents} = nextProps
+    const Components = getImplementations(nextComponents)
+
+    this.unsubscribeToComponents(components)
+    this.subscribeToComponents(nextComponents)
+    this.setState({Components})
+  }
+
+  componentDidUpdate() {
+    this.fetchAndRerender()
+  }
+
+  componentWillUnmount() {
+    const {components} = this.props
+    this.unsubscribeToComponents(components)
+  }
+
+  render() {
+    const {components, props, children} = this.props
+    const {Components} = this.state
+
+    // This extension point is not configured or it's assets haven't loaded yet.
+    if (components.length === 0 || (Components.length !== components.length)) {
+      return children
+    }
+
+    return Components.reduce((acc, Component) => {
+      return <Component {...props}>{acc || children}</Component>
+    }, null)
+  }
+}

--- a/react/components/ExtensionPointComponent.js
+++ b/react/components/ExtensionPointComponent.js
@@ -1,14 +1,14 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-import {fetchAssets, getImplementation} from '../utils/assets'
+import {getImplementation} from '../utils/assets'
 
 export default class ExtensionPointComponent extends Component {
   static contextTypes = {
-    components: PropTypes.object,
     extensions: PropTypes.object,
     emitter: PropTypes.object,
     treePath: PropTypes.string,
+    fetchComponent: PropTypes.func,
   }
 
   static propTypes = {
@@ -31,13 +31,13 @@ export default class ExtensionPointComponent extends Component {
   }
 
   fetchAndRerender = () => {
-    const {components: componentAssets} = this.context
+    const {fetchComponent} = this.context
     const {component} = this.props
     const Component = getImplementation(component)
 
     // Let's fetch the assets and re-render.
     if (component && !Component) {
-      fetchAssets(componentAssets[component]).then(this.updateComponents)
+      fetchComponent(component).then(this.updateComponents)
     }
   }
 

--- a/react/components/NestedExtensionPoints.js
+++ b/react/components/NestedExtensionPoints.js
@@ -20,7 +20,8 @@ export default class NestedExtensionPoints extends PureComponent {
   getPageParams(name) {
     const path = canUseDOM ? window.location.pathname : global.__pathname__
     const pagePath = getPagePath(name, this.context.pages)
-    return pagePath && getParams(pagePath, path) || EMPTY_OBJECT
+    const pagePathWithRest = pagePath && /\*\w$/.test(pagePath) ? pagePath : pagePath.replace(/\/?$/, '*_rest')
+    return pagePath && getParams(pagePathWithRest, path) || EMPTY_OBJECT
   }
 
   render() {

--- a/react/components/RenderProvider.js
+++ b/react/components/RenderProvider.js
@@ -29,7 +29,6 @@ class RenderProvider extends Component {
     getSettings: PropTypes.func,
     updateRuntime: PropTypes.func,
     updateExtension: PropTypes.func,
-    registerExtension: PropTypes.func,
     onPageChanged: PropTypes.func,
     prefetchPage: PropTypes.func,
     production: PropTypes.bool,
@@ -51,8 +50,6 @@ class RenderProvider extends Component {
       // backwards compatibility
       global.browserHistory = history
     }
-
-    this.emptyExtensions = []
 
     this.state = {
       components,
@@ -76,16 +73,6 @@ class RenderProvider extends Component {
       emitter.addListener('localesUpdated', this.onLocalesUpdated)
       emitter.addListener('extensionsUpdated', this.updateRuntime)
     }
-
-    const {extensions} = this.state
-    this.emptyExtensions.forEach((name) => {
-      extensions[name] = {
-        component: null,
-      }
-    })
-    this.setState({
-      extensions,
-    })
   }
 
   componentWillUnmount() {
@@ -119,7 +106,6 @@ class RenderProvider extends Component {
       onPageChanged: this.onPageChanged,
       prefetchPage: this.prefetchPage,
       updateExtension: this.updateExtension,
-      registerExtension: this.registerExtension,
     }
   }
 
@@ -220,13 +206,6 @@ class RenderProvider extends Component {
         [name]: extension,
       },
     }, () => global.__RUNTIME__.emitter.emit(`extension:${name}:update`, this.state))
-  }
-
-  registerExtension = (name) => {
-    const {extensions} = this.state
-    if (!extensions[name]) {
-      this.emptyExtensions.push(name)
-    }
   }
 
   render() {

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "exenv": "^1.2.2",
     "graphql": "^0.12.3",
     "history": "^4.7.2",
-    "myvtex-sse": "^1.0.0",
+    "myvtex-sse": "^1.1.1",
     "prop-types": "^15.6.0",
     "qs": "^6.5.1",
     "react": "^16.2.0",

--- a/react/utils/assets.js
+++ b/react/utils/assets.js
@@ -1,3 +1,5 @@
+const EMPTY_ARRAY = []
+
 function getExtension(path) {
   return /\.\w+$/.exec(path)[0]
 }
@@ -62,8 +64,7 @@ function shouldAddStyleToPage(path, idx, arr) {
   return isStyle(path) && !styleOnPage(path) && arr.map(({path: pt}) => pt).indexOf(path) === idx
 }
 
-function getAssetsForComponent(extension, componentAssets) {
-  const components = getComponents(extension)
+function getAllAssets(components, componentAssets) {
   return components.reduce((acc, value) => {
     acc = acc.concat(componentAssets[value])
     return acc
@@ -74,16 +75,12 @@ function getImplementation(component) {
   return global.__RENDER_6_COMPONENTS__[component]
 }
 
-export function getComponents(extension) {
-  return Array.isArray(extension.component) ? extension.component : [extension.component]
-}
-
-export function getImplementations(components) {
+export function getImplementations(components = EMPTY_ARRAY) {
   return components.map(getImplementation).filter((c) => c != null)
 }
 
-export function fetchAssets(extension, componentAssets) {
-  const assets = getAssetsForComponent(extension, componentAssets)
+export function fetchAssets(components, componentAssets) {
+  const assets = getAllAssets(components, componentAssets)
   const scripts = assets.filter(shouldAddScriptToPage)
   const styles = assets.filter(shouldAddStyleToPage)
   styles.forEach(addStyleToPage)

--- a/react/utils/assets.js
+++ b/react/utils/assets.js
@@ -1,5 +1,3 @@
-const EMPTY_ARRAY = []
-
 function getExtension(path) {
   return /\.\w+$/.exec(path)[0]
 }
@@ -64,23 +62,11 @@ function shouldAddStyleToPage(path, idx, arr) {
   return isStyle(path) && !styleOnPage(path) && arr.map(({path: pt}) => pt).indexOf(path) === idx
 }
 
-function getAllAssets(components, componentAssets) {
-  return components.reduce((acc, value) => {
-    acc = acc.concat(componentAssets[value])
-    return acc
-  }, [])
-}
-
-function getImplementation(component) {
+export function getImplementation(component) {
   return global.__RENDER_6_COMPONENTS__[component]
 }
 
-export function getImplementations(components = EMPTY_ARRAY) {
-  return components.map(getImplementation).filter((c) => c != null)
-}
-
-export function fetchAssets(components, componentAssets) {
-  const assets = getAllAssets(components, componentAssets)
+export function fetchAssets(assets) {
   const scripts = assets.filter(shouldAddScriptToPage)
   const styles = assets.filter(shouldAddStyleToPage)
   styles.forEach(addStyleToPage)

--- a/react/utils/events.js
+++ b/react/utils/events.js
@@ -14,9 +14,16 @@ if (module.hot && canUseDOM) {
   const {account, workspace, emitter} = global.__RUNTIME__
   const sseReact1Path = 'vtex.builder-hub:*:react1'
   const ssePages0Path = 'vtex.builder-hub:*:pages0'
+  let reload = false
 
   myvtexSSE(account, workspace, sseReact1Path, {verbose: true}, function(event) {
+    // Skip any events after reload was issued
+    if (reload) {
+      return false
+    }
+
     const {body: {type, appId, hash, locales}} = event
+
     switch (type) {
       case 'hmr':
         console.log(`[react1] Received update. app=${appId} hash=${hash}`)
@@ -24,6 +31,7 @@ if (module.hot && canUseDOM) {
         break
       case 'reload':
         console.log(`[react1] Received reload. app=${appId}`)
+        reload = true
         location.reload(true)
         break
       case 'locales':
@@ -34,7 +42,13 @@ if (module.hot && canUseDOM) {
   })
 
   myvtexSSE(account, workspace, ssePages0Path, {verbose: true}, function(event) {
+    // Skip any events after reload was issued
+    if (reload) {
+      return false
+    }
+
     const {body: {type}} = event
+
     switch (type) {
       case 'changed':
         console.log('[pages0] Extensions changed.')

--- a/react/utils/messages.js
+++ b/react/utils/messages.js
@@ -6,6 +6,26 @@ const acceptJson = canUseDOM && new Headers({
   'Accept': 'application/json',
 })
 
+const acceptAndContentJson = canUseDOM && new Headers({
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+})
+
+export const fetchMessagesForApp = (app, locale) =>
+  fetch('?vtex.render-resource=graphql', {
+    credentials: 'same-origin',
+    headers: acceptAndContentJson,
+    method: 'POST',
+    body: JSON.stringify({
+      query: `{ messages(app: "${app}", locale: "${locale}") }`,
+    }),
+  })
+  .then(res => res.json())
+  .then(data => {
+    const messagesJSON = data.data.messages
+    return JSON.parse(messagesJSON)
+  })
+
 export const fetchMessages = () =>
   fetch('?vtex.render-resource=messages', {
     credentials: 'same-origin',

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -10,15 +10,6 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
 
-ajv@^5.2.3:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 apollo-cache-inmemory@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz#74111367fd59caee120197ef663dcb2516971300"
@@ -79,10 +70,6 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -104,14 +91,6 @@ eventemitter3@^3.0.0:
 exenv@^1.2.1, exenv@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-
-fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fbjs@^0.8.16:
   version "0.8.16"
@@ -200,10 +179,6 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
-
 lodash.flowright@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/lodash.flowright/-/lodash.flowright-3.5.0.tgz#2b5fff399716d7e7dc5724fe9349f67065184d67"
@@ -212,19 +187,15 @@ lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
-lodash.topath@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 
-myvtex-sse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/myvtex-sse/-/myvtex-sse-1.0.0.tgz#d08c36ce94f2efc462f6a4e2994045707a9e80fe"
+myvtex-sse@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/myvtex-sse/-/myvtex-sse-1.1.1.tgz#20b9217fd4d11169f8d39825c13c4fd2fbbb57f7"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -291,15 +262,6 @@ react-intl@^2.4.0:
     intl-messageformat "^2.1.0"
     intl-relativeformat "^2.0.0"
     invariant "^2.1.1"
-
-react-jsonschema-form@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.0.tgz#53ce38384a5df08e9ddc0d83b435af255c063078"
-  dependencies:
-    ajv "^5.2.3"
-    lodash.topath "^4.5.2"
-    prop-types "^15.5.8"
-    setimmediate "^1.0.5"
 
 react-side-effect@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
- Refactor ExtensionPoint and RenderProvider so they don't rely on context mutation to work
- Inject `pages-editor` components directly if they're available in the pre-determined extension points
- Extract component fetching logic into `ExtensionPointComponent`