### PR TITLE
Enables GET for Persisted Queries

### DIFF
--- a/react/utils/client.js
+++ b/react/utils/client.js
@@ -34,7 +34,7 @@ export const getClient = (runtime) => {
     const persistedQueryLink = createPersistedQueryLink({
       generateHash: ({documentId}) => documentId,
       disable: () => true,
-      useGETForHashedQueries: false
+      useGETForHashedQueries: true
     })
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({


### PR DESCRIPTION
As simple as activating `useGETForHashedQueries` in `persistedQueryLink`