### PR TITLE
Fix ExtensionContainer props

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/ExtensionContainer.tsx
+++ b/react/ExtensionContainer.tsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react'
 import ExtensionPoint from './ExtensionPoint'
 import {getDirectChildren} from './utils/treePath'
 
-// eslint-disable-next-line
 class ExtensionContainer extends Component {
   public static contextTypes = {
     extensions: PropTypes.object,
@@ -16,7 +15,13 @@ class ExtensionContainer extends Component {
   public render() {
     const {extensions, treePath} = this.context
     const children = getDirectChildren(extensions, treePath)
-    return <div>{children.map(id => <ExtensionPoint key={id} id={id} />)}</div>
+    return (
+      <div>
+        {children.map(id =>
+          <ExtensionPoint {...this.props} key={id} id={id} />
+        )}
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
Pass down the props passed to an Extension Point that is an ExtensionContainer.

Example:

```js
render() {
  return (
    <div>
      <ExtensionPoint id="order-actions" order={order} />
    </div>
  )
}
```

```json
"my-orders/order-actions": {
  "component": "vtex.render-runtime/ExtensionContainer"
}
```

