### PR TITLE
Use Fragment instead of div

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.5.11",
+  "version": "7.5.12",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/ExtensionContainer.tsx
+++ b/react/ExtensionContainer.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {Component} from 'react'
+import React, {Component, Fragment} from 'react'
 
 import ExtensionPoint from './ExtensionPoint'
 import {getDirectChildren} from './utils/treePath'
@@ -16,11 +16,11 @@ class ExtensionContainer extends Component {
     const {extensions, treePath} = this.context
     const children = getDirectChildren(extensions, treePath)
     return (
-      <div>
+      <Fragment>
         {children.map(id =>
           <ExtensionPoint {...this.props} key={id} id={id} />
         )}
-      </div>
+      </Fragment>
     )
   }
 }


### PR DESCRIPTION
We are trying to add an ExtensionContainer inside a list.

Example:

```html
<ul>
  <li>App code</li>
  <li>Extension 1</li>
  <li>Extension 2</li>
</ul>
```

But this is not possible since ExtensionContainer renders a `<div>` to wrap the extensions.

```html
<ul>
  <li>App code</li>
  <div>
    <li>Extension 1</li>
    <li>Extension 2</li>
  </div>
</ul>
```

This PR makes use of Fragment to avoid rendering this `<div>` element.