### PR TITLE
Fix: re-render all extensions when changing RenderProvider props

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.6.6",
+  "version": "7.6.7",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -121,9 +121,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public componentWillReceiveProps(nextProps: Props) {
     // If RenderProvider is being re-rendered, the global runtime might have changed
-    // so we must update the root extension.
+    // so we must update the all extensions.
     if (this.rendered) {
-      this.updateExtension(nextProps.root, nextProps.runtime.extensions[nextProps.root])
+      const {runtime: {extensions, emitter}} = nextProps
+      this.setState({extensions}, () => emitter.emit('extension:*:update', this.state))
     }
   }
 


### PR DESCRIPTION
Workspaces in production mode were not receiving new props when `render` was being called using render-extension-loader.

After a long debugging, we found out that extension points do not subscribe to `extension:{id}:update` in production mode. When `RenderProvider` is re-rendered an event is emitted specifically to the _root_ component, but it is not listening.

There are two options: 
1 - Make all extension points listen to `extension:{id}:update`
2 - Emit the event to all extension points (`extension:*:update`)

This PR takes the latter approach. One benefit is that it avoids creating more listeners that will only be used in _legacy-extensions_ scenarios. Also, if `RenderProvider` is receiving new props, we don't have any guarantees that only the _root_ extension have changed and we should update all of them for consistency.