### PR TITLE
Log client-side errors to Kibana

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.7.4",
+  "version": "7.8.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, {ErrorInfo, PureComponent, ReactElement} from 'react'
 
 import {getImplementation} from '../utils/assets'
+import logEvent from '../utils/logger'
 
 interface Props {
   component: string | null
@@ -19,10 +20,12 @@ const componentPromiseMap: any = {}
 
 export default class ExtensionPointComponent extends PureComponent<Props, State> {
   public static contextTypes = {
+    account: PropTypes.string,
     emitter: PropTypes.object,
     extensions: PropTypes.object,
     fetchComponent: PropTypes.func,
     treePath: PropTypes.string,
+    workspace: PropTypes.string
   }
 
   public static propTypes = {
@@ -97,7 +100,24 @@ export default class ExtensionPointComponent extends PureComponent<Props, State>
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Failed to render extension point', this.context.treePath)
+    const {account, treePath: path, workspace} = this.context
+    const {message, stack} = error
+    const {componentStack} = errorInfo
+    const event = {
+      data: {
+        account,
+        componentStack,
+        message,
+        path,
+        stack,
+        workspace
+      },
+      name: 'JSError'
+    }
+
+    console.error('Failed to render extension point', path)
+    logEvent(event)
+
     this.setState({
       error,
       errorDetails: false,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -42,6 +42,11 @@ declare global {
     [name: string]: Extension
   }
 
+  interface LogEvent {
+    name: string
+    data?: any
+  }
+
   interface Culture {
     availableLocales: string[]
     locale: string

--- a/react/utils/logger.ts
+++ b/react/utils/logger.ts
@@ -1,0 +1,17 @@
+const KIBANA_NAMESPACE = 'renderruntime'
+const KIBANA_VALUE = 1
+
+const logEvent = (event: LogEvent) => {
+  // defaultData contains remaining fields required by sendMetric
+  const defaultData = {
+    namespace: KIBANA_NAMESPACE,
+    value: KIBANA_VALUE
+  }
+  const formattedEvent = Object.assign(defaultData, event)
+
+  if (vtex.NavigationCapture && vtex.NavigationCapture.sendMetric) {
+    vtex.NavigationCapture.sendMetric(formattedEvent)
+  }
+}
+
+export default logEvent


### PR DESCRIPTION
#### What is the purpose of this pull request?
Log client-side errors to Kibana.

#### How should this be manually tested?
- Link this `render-runtime` branch.
- Link an app containing an error within an Extension Point (such that, when rendering a page with this component, it will display the message `Error rendering extension point [path]`).
- Search for the log at Kibana within `metric-renderruntime-*` or `metric-renderruntime-jserror-*`. It should display the corresponding `account`, `workspace`, `message`, `path`, `stack` and `componentStack`.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
