### PR TITLE
Fix prepend uniq

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -1,5 +1,5 @@
 const prependUniq = (arrOne: any[], arrTwo: any[]) => {
-  return [...arrOne.filter(item => !arrTwo.includes(item)), ...arrTwo]
+  return [...arrOne, ...arrTwo.filter(item => !arrOne.includes(item))]
 }
 
 export const traverseComponent = (components: Components | Record<string, string[]>, component: string): ComponentTraversalResult => {


### PR DESCRIPTION
Without that `common.js` is coming after other scripts when you have multiple imports like: 

```
import { IconSearch, IconShoppingBag, IconUser } from 'gocommerce.styleguide-store'
```