### PR TITLE
Automatic cache control split

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.11.5",
+  "version": "7.11.6",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -36,6 +36,7 @@ interface Props {
 
 export interface RenderProviderState {
   appsEtag: RenderRuntime['appsEtag']
+  cacheHints: RenderRuntime['cacheHints']
   components: RenderRuntime['components']
   culture: RenderRuntime['culture']
   extensions: RenderRuntime['extensions']
@@ -45,7 +46,6 @@ export interface RenderProviderState {
   production: RenderRuntime['production']
   query: RenderRuntime['query']
   settings: RenderRuntime['settings']
-  cacheHints: RenderRuntime['cacheHints']
 }
 
 class RenderProvider extends Component<Props, RenderProviderState> {
@@ -82,7 +82,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   constructor(props: Props) {
     super(props)
-    const {appsEtag, culture, messages, components, extensions, pages, page, query, production, settings, cacheHints} = props.runtime
+    const {appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings} = props.runtime
     const {history, baseURI, cacheControl} = props
 
     if (history) {
@@ -295,7 +295,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const {page, production, culture: {locale}} = this.state
 
     return fetchRuntime(this.apolloClient, page, production, locale, renderMajor)
-      .then(({appsEtag, components, extensions, messages, pages, settings, cacheHints}) => {
+      .then(({appsEtag, cacheHints, components, extensions, messages, pages, settings}) => {
         this.setState({
           appsEtag,
           cacheHints,
@@ -310,12 +310,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public createRuntimeContextLink() {
     return new ApolloLink((operation: Operation, forward?: NextLink) => {
-      const {appsEtag, components, extensions, messages, pages} = this.state
+      const {appsEtag, cacheHints, components, extensions, messages, pages} = this.state
       operation.setContext((currentContext: Record<string, any>) => {
         return {
           ...currentContext,
           runtime: {
             appsEtag,
+            cacheHints,
             components,
             extensions,
             messages,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -45,6 +45,7 @@ export interface RenderProviderState {
   production: RenderRuntime['production']
   query: RenderRuntime['query']
   settings: RenderRuntime['settings']
+  cacheHints: RenderRuntime['cacheHints']
 }
 
 class RenderProvider extends Component<Props, RenderProviderState> {
@@ -81,7 +82,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   constructor(props: Props) {
     super(props)
-    const {appsEtag, culture, messages, components, extensions, pages, page, query, production, settings} = props.runtime
+    const {appsEtag, culture, messages, components, extensions, pages, page, query, production, settings, cacheHints} = props.runtime
     const {history, baseURI, cacheControl} = props
 
     if (history) {
@@ -95,6 +96,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.apolloClient = getClient(props.runtime, baseURI, runtimeContextLink, cacheControl)
     this.state = {
       appsEtag,
+      cacheHints,
       components,
       culture,
       extensions,
@@ -293,9 +295,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const {page, production, culture: {locale}} = this.state
 
     return fetchRuntime(this.apolloClient, page, production, locale, renderMajor)
-      .then(({appsEtag, components, extensions, messages, pages, settings}) => {
+      .then(({appsEtag, components, extensions, messages, pages, settings, cacheHints}) => {
         this.setState({
           appsEtag,
+          cacheHints,
           components,
           extensions,
           messages,

--- a/react/package.json
+++ b/react/package.json
@@ -27,8 +27,8 @@
     "react-hot-loader": "^4.1.2",
     "react-intl": "^2.4.0",
     "react-no-ssr": "^1.1.0",
-    "route-parser": "^0.0.5",
-    "vtex-graphql-utils": "^0.1.0"
+    "react-tree-path": "^0.2.0",
+    "route-parser": "^0.0.5"
   },
   "devDependencies": {
     "@types/graphql": "^0.12.5",

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,6 @@
     "react-hot-loader": "^4.1.2",
     "react-intl": "^2.4.0",
     "react-no-ssr": "^1.1.0",
-    "react-tree-path": "^0.2.0",
     "route-parser": "^0.0.5"
   },
   "devDependencies": {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -128,6 +128,7 @@ interface RenderComponent<P={}, S={}> {
     pagesJSON: string
     appsSettingsJSON: string
     appsEtag: string
+    cacheHintsJSON: string
   }
 
   interface ParsedPageQueryResponse {
@@ -137,6 +138,7 @@ interface RenderComponent<P={}, S={}> {
     pages: RenderRuntime['pages']
     appsEtag: RenderRuntime['appsEtag']
     settings: RenderRuntime['settings']
+    cacheHints: RenderRuntime['cacheHints']
   }
 
   type Rendered = ClientRendered | Promise<NamedServerRendered>
@@ -178,6 +180,15 @@ interface RenderComponent<P={}, S={}> {
     start: boolean
     settings: {
       [app: string]: any;
+    }
+    cacheHints: CacheHints
+  }
+
+  interface CacheHints {
+    [hash: string]: {
+      scope: string
+      maxAge: string
+      version: number
     }
   }
 

--- a/react/utils/client/generateHash.ts
+++ b/react/utils/client/generateHash.ts
@@ -1,6 +1,10 @@
 import {ArgumentNode, BREAK, DocumentNode, visit} from 'graphql'
 
 export const generateHash = (query: DocumentNode) => {
+  if (query.documentId) {
+    return query.documentId
+  }
+
   const asset = {hash: ''}
   visit(query, {
     Argument(node: ArgumentNode) {

--- a/react/utils/client/generateHash.ts
+++ b/react/utils/client/generateHash.ts
@@ -1,8 +1,14 @@
-import {DocumentNode} from 'graphql'
+import {ArgumentNode, BREAK, DocumentNode, visit} from 'graphql'
 
 export const generateHash = (query: DocumentNode) => {
-  if (query.documentId) {
-    return query.documentId
-  }
-  return null
+  const asset = {hash: ''}
+  visit(query, {
+    Argument(node: ArgumentNode) {
+      if (node.name.value === 'hash') {
+        asset.hash = node.value.value
+        return BREAK
+      }
+    }
+  })
+  return asset.hash
 }

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -46,15 +46,12 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
       credentials: 'include',
     })
 
-    const persistedQueryLink = createPersistedQueryLink({
-      disable: () => true,
-      generateHash
-    })
+    const persistedQueryLink = createPersistedQueryLink({generateHash})
 
-    const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
+    const uriSwitchLink = createUriSwitchLink(baseURI, runtime)
     const link = cacheControl
-      ? ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, uriSwitchLink, cachingLink(cacheControl), persistedQueryLink, httpLink])
-      : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, uriSwitchLink, persistedQueryLink, httpLink])
+      ? ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, persistedQueryLink, uriSwitchLink, cachingLink(cacheControl), httpLink])
+      : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, persistedQueryLink, uriSwitchLink, httpLink])
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({
       cache: canUseDOM ? cache.restore(window.__STATE__) : cache,

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -48,7 +48,7 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const persistedQueryLink = createPersistedQueryLink({generateHash})
 
-    const uriSwitchLink = createUriSwitchLink(baseURI, runtime)
+    const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
     const link = cacheControl
       ? ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, persistedQueryLink, uriSwitchLink, cachingLink(cacheControl), httpLink])
       : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, persistedQueryLink, uriSwitchLink, httpLink])

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -46,7 +46,10 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
       credentials: 'include',
     })
 
-    const persistedQueryLink = createPersistedQueryLink({generateHash})
+    const persistedQueryLink = createPersistedQueryLink({
+      disable: () => true,
+      generateHash
+    })
 
     const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
     const link = cacheControl

--- a/react/utils/client/links/runtimeContextLink.ts
+++ b/react/utils/client/links/runtimeContextLink.ts
@@ -1,6 +1,4 @@
-import {ApolloLink, NextLink, Observable, Operation, RequestHandler} from 'apollo-link'
-import {canUseDOM} from 'exenv'
-import {ArgumentNode, DirectiveNode, DocumentNode, OperationDefinitionNode, visit} from 'graphql'
+import {ApolloLink, NextLink, Operation} from 'apollo-link'
 
 export const createRuntimeContextLink = () =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -20,12 +20,12 @@ interface OperationContext {
 
 const hashFromExtensions = ext => ext && ext.persistedQuery && ext.persistedQuery.sha256Hash
 
-export const createUriSwitchLink = (baseURI: string) =>
+export const createUriSwitchLink = (baseURI: string, workspace: string) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
     const hash = hashFromExtensions(operation.extensions)
     const {operationType} = assetsFromQuery(operation.query)
     const protocol = canUseDOM ? 'https:' : 'http:'
-    operation.setContext(({ fetchOptions = {}, runtime: {appsEtag, cacheHints, workspace} } : OperationContext) => {
+    operation.setContext(({ fetchOptions = {}, runtime: {appsEtag, cacheHints} } : OperationContext) => {
       const {maxAge = 'LONG', scope = 'PUBLIC', version = 1} = cacheHints[hash] || {}
       const method = (scope.toLowerCase() === 'public' && operationType.toLowerCase() === 'query') ? 'GET' : 'POST'
       return {

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -20,14 +20,13 @@ interface OperationContext {
 
 const hashFromExtensions = ext => ext && ext.persistedQuery && ext.persistedQuery.sha256Hash
 
-export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
+export const createUriSwitchLink = (baseURI: string) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
-    const {workspace, cacheHints} = runtime
     const hash = hashFromExtensions(operation.extensions)
-    const {maxAge = 'LONG', scope = 'PUBLIC', version = 1} = cacheHints[hash] || {}
     const {operationType} = assetsFromQuery(operation.query)
     const protocol = canUseDOM ? 'https:' : 'http:'
-    operation.setContext(({ fetchOptions = {}, runtime: {appsEtag} } : OperationContext) => {
+    operation.setContext(({ fetchOptions = {}, runtime: {appsEtag, cacheHints, workspace} } : OperationContext) => {
+      const {maxAge = 'LONG', scope = 'PUBLIC', version = 1} = cacheHints[hash] || {}
       const method = (scope.toLowerCase() === 'public' && operationType.toLowerCase() === 'query') ? 'GET' : 'POST'
       return {
         ...operation.getContext(),

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -31,9 +31,6 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
     const {workspace, cacheHints} = runtime
     const hash = hashFromExtensions(operation.extensions)
     const {maxAge, scope, version} = cacheHints[hash] || defaultAssets
-
-    console.log('these are the assets', maxAge, scope, version)
-
     const {operationType} = assetsFromQuery(operation.query)
     const protocol = canUseDOM ? 'https:' : 'http:'
     operation.setContext(({ fetchOptions = {}, runtime: {appsEtag} } : OperationContext) => {

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -1,33 +1,15 @@
 import {ApolloLink, NextLink, Observable, Operation, RequestHandler} from 'apollo-link'
 import {canUseDOM} from 'exenv'
-import {ArgumentNode, DirectiveNode, DocumentNode, OperationDefinitionNode, visit} from 'graphql'
-
-const assetsVisitor = (assets: any) => ({
-  Directive (node: DirectiveNode) {
-    if (node.name.value === 'context' && node.arguments) {
-      node.arguments.forEach((argNode: ArgumentNode) => {
-        if (argNode.name.value === 'scope') {
-          assets.scope = argNode.value.value
-        }
-        else if (argNode.name.value === 'version') {
-          assets.version = argNode.value.value
-        }
-        else if (argNode.name.value === 'maxAge') {
-          assets.maxAge = argNode.value.value
-        }
-      })
-    }
-  },
-  OperationDefinition (node: OperationDefinitionNode) {
-    if (!assets.operation) {
-      assets.operation = node.operation
-    }
-  }
-})
+import {ArgumentNode, BREAK, DirectiveNode, DocumentNode, OperationDefinitionNode, visit} from 'graphql'
 
 const assetsFromQuery = (query: DocumentNode) => {
-  const assets = {version: '1', scope: 'public', maxAge: 'long', operation: undefined}
-  visit(query, assetsVisitor(assets))
+  const assets = {operationType: 'mutation'}
+  visit(query, {
+    OperationDefinition (node: OperationDefinitionNode) {
+      assets.operationType = node.operation
+      return BREAK
+    }
+  })
   return assets
 }
 
@@ -36,17 +18,30 @@ interface OperationContext {
   runtime: RenderRuntime,
 }
 
-export const createUriSwitchLink = (baseURI: string, workspace: string) =>
+const defaultAssets = {
+  maxAge: 'LONG',
+  scope: 'public',
+  version: 1
+}
+
+const hashFromExtensions = ext => ext && ext.persistedQuery && ext.persistedQuery.sha256Hash
+
+export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
-    const {query} = operation
-    const assets = assetsFromQuery(operation.query)
+    const {workspace, cacheHints} = runtime
+    const hash = hashFromExtensions(operation.extensions)
+    const {maxAge, scope, version} = cacheHints[hash] || defaultAssets
+
+    console.log('these are the assets', maxAge, scope, version)
+
+    const {operationType} = assetsFromQuery(operation.query)
     const protocol = canUseDOM ? 'https:' : 'http:'
     operation.setContext(({ fetchOptions = {}, runtime: {appsEtag} } : OperationContext) => {
-      const method = (assets.scope === 'public' && assets.operation === 'query') ? 'GET' : 'POST'
+      const method = (scope.toLowerCase() === 'public' && operationType.toLowerCase() === 'query') ? 'GET' : 'POST'
       return {
         ...operation.getContext(),
         fetchOptions: {...fetchOptions, method},
-        uri: `${protocol}//${baseURI}/_v/graphql/${assets.scope}/v${assets.version}?workspace=${workspace}&maxAge=${assets.maxAge}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/graphql/${scope}/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
       }
     })
     return forward ? forward(operation) : null

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -18,19 +18,13 @@ interface OperationContext {
   runtime: RenderRuntime,
 }
 
-const defaultAssets = {
-  maxAge: 'LONG',
-  scope: 'public',
-  version: 1
-}
-
 const hashFromExtensions = ext => ext && ext.persistedQuery && ext.persistedQuery.sha256Hash
 
 export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
     const {workspace, cacheHints} = runtime
     const hash = hashFromExtensions(operation.extensions)
-    const {maxAge, scope, version} = cacheHints[hash] || defaultAssets
+    const {maxAge = 'LONG', scope = 'PUBLIC', version = 1} = cacheHints[hash] || {}
     const {operationType} = assetsFromQuery(operation.query)
     const protocol = canUseDOM ? 'https:' : 'http:'
     operation.setContext(({ fetchOptions = {}, runtime: {appsEtag} } : OperationContext) => {
@@ -38,7 +32,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
       return {
         ...operation.getContext(),
         fetchOptions: {...fetchOptions, method},
-        uri: `${protocol}//${baseURI}/_v/graphql/${scope}/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/graphql/${scope.toLowerCase()}/v${version}?workspace=${workspace}&maxAge=${maxAge.toLowerCase()}&appsEtag=${appsEtag}`,
       }
     })
     return forward ? forward(operation) : null

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -1,13 +1,20 @@
-import {ApolloLink, NextLink, Observable, Operation, RequestHandler} from 'apollo-link'
+import {ApolloLink, NextLink, Operation} from 'apollo-link'
 import {canUseDOM} from 'exenv'
-import {ArgumentNode, BREAK, DirectiveNode, DocumentNode, OperationDefinitionNode, visit} from 'graphql'
+import {ASTNode, DirectiveDefinitionNode, OperationDefinitionNode, visit} from 'graphql'
 
-const assetsFromQuery = (query: DocumentNode) => {
-  const assets = {operationType: 'mutation'}
+const assetsFromQuery = (query: ASTNode) => {
+  const assets = {operationType: 'mutation', queryScope: undefined}
   visit(query, {
     OperationDefinition (node: OperationDefinitionNode) {
       assets.operationType = node.operation
-      return BREAK
+    },
+    Directive (node: DirectiveDefinitionNode) {
+      if (node.name.value === 'context') {
+        const scopeArg = node.arguments && node.arguments.find((argNode) => argNode.name.value === 'scope')
+        if (scopeArg) {
+          assets.queryScope = scopeArg.value.value
+        }
+      }
     }
   })
   return assets
@@ -20,18 +27,37 @@ interface OperationContext {
 
 const hashFromExtensions = ext => ext && ext.persistedQuery && ext.persistedQuery.sha256Hash
 
+const equals = (a: string, b: string) => a && b && a.toLowerCase() === b.toLowerCase()
+
+const extractHints = (query: ASTNode, meta) => {
+  const {operationType, queryScope} = assetsFromQuery(query)
+
+  let hints
+  if (meta) {
+    hints = equals(operationType, 'query') ? meta : {...meta, scope: 'private'}
+  } else {
+    hints = {scope: queryScope}
+  }
+
+  const {maxAge = 'long', scope = 'public', version = 1} = hints
+  return {
+    maxAge: maxAge.toLowerCase(),
+    method: (equals(scope, 'public') && equals(operationType, 'query')) ? 'GET' : 'POST',
+    scope: scope.toLowerCase(),
+    version,
+  }
+}
+
 export const createUriSwitchLink = (baseURI: string, workspace: string) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
-    const hash = hashFromExtensions(operation.extensions)
-    const {operationType} = assetsFromQuery(operation.query)
-    const protocol = canUseDOM ? 'https:' : 'http:'
     operation.setContext(({ fetchOptions = {}, runtime: {appsEtag, cacheHints} } : OperationContext) => {
-      const {maxAge = 'LONG', scope = 'PUBLIC', version = 1} = cacheHints[hash] || {}
-      const method = (scope.toLowerCase() === 'public' && operationType.toLowerCase() === 'query') ? 'GET' : 'POST'
+      const hash = hashFromExtensions(operation.extensions)
+      const protocol = canUseDOM ? 'https:' : 'http:'
+      const {maxAge, scope, version, method} = extractHints(operation.query, cacheHints[hash])
       return {
         ...operation.getContext(),
         fetchOptions: {...fetchOptions, method},
-        uri: `${protocol}//${baseURI}/_v/graphql/${scope.toLowerCase()}/v${version}?workspace=${workspace}&maxAge=${maxAge.toLowerCase()}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/graphql/${scope}/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
       }
     })
     return forward ? forward(operation) : null

--- a/react/utils/runtime.graphql
+++ b/react/utils/runtime.graphql
@@ -6,5 +6,6 @@ query Runtime ($page: String!, $production: Boolean!, $locale: String!, $renderV
     extensionsJSON
     appsEtag
     appsSettingsJSON
+    cacheHintsJSON
   }
 }

--- a/react/utils/runtime.ts
+++ b/react/utils/runtime.ts
@@ -4,8 +4,9 @@ import {canUseDOM} from 'exenv'
 import runtimeQuery from './runtime.graphql'
 
 const parsePageQueryResponse = (response: PageQueryResponse): ParsedPageQueryResponse => {
-  const {componentsJSON, extensionsJSON, messagesJSON, pagesJSON, appsSettingsJSON, appsEtag} = response
-  const [components, extensions, messages, pages, settings] = [
+  const {cacheHintsJSON, componentsJSON, extensionsJSON, messagesJSON, pagesJSON, appsSettingsJSON, appsEtag} = response
+  const [cacheHints, components, extensions, messages, pages, settings] = [
+    cacheHintsJSON,
     componentsJSON,
     extensionsJSON,
     messagesJSON,
@@ -15,6 +16,7 @@ const parsePageQueryResponse = (response: PageQueryResponse): ParsedPageQueryRes
 
   return {
     appsEtag,
+    cacheHints,
     components,
     extensions,
     messages,


### PR DESCRIPTION
Users `cacheHints` exported by `runtime` to correctly switch the endpoint for each query