### PR TITLE
Merge locale custom messages from components

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.8.2",
+  "version": "7.9.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,6 @@
   ],
   "settingsSchema": {},
   "scripts": {
-    "postreleasy": "vtex publish --public"
+    "postreleasy": "vtex publish --verbose"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -98,8 +98,13 @@ declare global {
     treePath: string
   }
 
+interface RenderComponent<P={}, S={}> {
+  new(): Component<P,S>
+  getCustomMessages?: (locale: string) => any
+}
+
   interface ComponentsRegistry {
-    [component: string]: new() => Component<any, any>
+    [component: string]: RenderComponent<any, any>
   }
 
   interface HotEmitterRegistry {

--- a/react/typings/node.d.ts
+++ b/react/typings/node.d.ts
@@ -12,3 +12,5 @@ declare module '*.graphql' {
   const value: DocumentNode;
   export default value;
 }
+
+declare var vtex: any

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -35,7 +35,7 @@ function getExistingScriptSrcs() {
 function getExistingStyleHrefs() {
   const hrefs: string[] = []
   for (let i = 0; i < document.styleSheets.length; i++) {
-    const href = document.styleSheets.item(i).href
+    const href = document.styleSheets.item(i)!.href
     if (href) {
       hrefs.push(href)
     }
@@ -68,7 +68,7 @@ function shouldAddStyleToPage(path: string) {
 }
 
 export function getImplementation<P={}, S={}>(component: string) {
-  return window.__RENDER_7_COMPONENTS__[component] as new() => Component<P, S>
+  return window.__RENDER_7_COMPONENTS__[component] as RenderComponent<P, S>
 }
 
 export function fetchAssets(assets: string[]) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Merge "custom" locale messages from components (i.e. messages not included in the `react/locales` folder) before rendering.

The component that provides the "custom messages" should have a static method `getCustomMessages`, which receives a string representing the locale (e.g. `pt-BR`) and returns an object with key-value pairs corresponding to the id's and messages.

#### How should this be manually tested?
- Link this `render-runtime` branch.
- Link a component containing a static method `getCustomMessages` that returns some messages whose id's / messages are not contained in the files at `react/locales`.
- Use some of those "new" id's (with a `FormattedMessage` component, for example), and check if they are adequately rendered.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
