### PR TITLE
Always use window instead of global

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/NestedExtensionPoints.tsx
+++ b/react/components/NestedExtensionPoints.tsx
@@ -23,7 +23,7 @@ export default class NestedExtensionPoints extends PureComponent<Props> {
   }
 
   public getPageParams(name: string) {
-    const path = canUseDOM ? window.location.pathname : global.__pathname__
+    const path = canUseDOM ? window.location.pathname : window.__pathname__
     const pagePath = getPagePath(name, this.context.pages)
     const pagePathWithRest = pagePath && /\*\w+$/.test(pagePath) ? pagePath : pagePath.replace(/\/?$/, '*_rest')
     return pagePath && getParams(pagePathWithRest, path) || EMPTY_OBJECT

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -86,7 +86,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       const renderLocation = {...history.location, state: {renderRouting: true}}
       history.replace(renderLocation)
       // backwards compatibility
-      global.browserHistory = history
+      window.browserHistory = global.browserHistory = history
     }
 
     const runtimeContextLink = this.createRuntimeContextLink()
@@ -211,7 +211,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     const {components, culture: {locale}} = this.state
     const {apps, assets} = traverseComponent(components, component)
-    const unfetchedApps = apps.filter(app => !Object.keys(global.__RENDER_7_COMPONENTS__).some(c => c.startsWith(app)))
+    const unfetchedApps = apps.filter(app => !Object.keys(window.__RENDER_7_COMPONENTS__).some(c => c.startsWith(app)))
     if (unfetchedApps.length === 0) {
       return fetchAssets(assets)
     }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -17,23 +17,23 @@ import {getBaseURI} from '../utils/host'
 import {addLocaleData} from '../utils/locales'
 import withHMR from '../utils/withHMR'
 
-if (global.IntlPolyfill) {
-  if (!global.Intl) {
-    global.Intl = global.IntlPolyfill
+if (window.IntlPolyfill) {
+  if (!window.Intl) {
+    window.Intl = window.IntlPolyfill
   } else if (!canUseDOM) {
-    global.Intl.NumberFormat = global.IntlPolyfill.NumberFormat
-    global.Intl.DateTimeFormat = global.IntlPolyfill.DateTimeFormat
+    window.Intl.NumberFormat = window.IntlPolyfill.NumberFormat
+    window.Intl.DateTimeFormat = window.IntlPolyfill.DateTimeFormat
   }
 }
 
 function renderToStringWithData(component: ReactElement<any>): Promise<ServerRendered> {
-  const startGetDataFromTree = global.hrtime()
+  const startGetDataFromTree = window.hrtime()
   return require('react-apollo').getDataFromTree(component).then(() => {
-    const endGetDataFromTree = global.hrtime(startGetDataFromTree)
+    const endGetDataFromTree = window.hrtime(startGetDataFromTree)
 
-    const startRenderToString = global.hrtime()
+    const startRenderToString = window.hrtime()
     const markup = require('react-dom/server').renderToString(component)
-    const endRenderToString = global.hrtime(startRenderToString)
+    const endRenderToString = window.hrtime(startRenderToString)
     return {
       markup,
       renderTimeMetric: {
@@ -98,7 +98,7 @@ function getRenderableExtensionPointNames(rootName: string, extensions: Extensio
 }
 
 function start() {
-  const runtime = global.__RUNTIME__
+  const runtime = window.__RUNTIME__
   const renderableExtensionPointNames = getRenderableExtensionPointNames(runtime.page, runtime.extensions)
 
   try {
@@ -107,7 +107,7 @@ function start() {
     console.log('Welcome to Render! Want to look under the hood? http://lab.vtex.com/careers/')
     if (!canUseDOM) {
       // Expose render promises to global context.
-      global.rendered = Promise.all(renderPromises as Array<Promise<NamedServerRendered>>).then(results => ({
+      window.rendered = Promise.all(renderPromises as Array<Promise<NamedServerRendered>>).then(results => ({
         extensions: results.reduce(
           (acc, {markups}) => (markups.forEach(({name, markup}) => acc[name] = markup), acc),
           {} as RenderedSuccess['extensions'],
@@ -124,7 +124,7 @@ function start() {
   } catch (error) {
     console.error('Unexpected error rendering:', error)
     if (!canUseDOM) {
-      global.rendered = {error}
+      window.rendered = {error}
     }
   }
 }

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,13 +1,18 @@
 import * as runtimeGlobals from './core/main'
 
-global.__RENDER_7_RUNTIME__ = {...runtimeGlobals}
+window.__RENDER_7_RUNTIME__ = {...runtimeGlobals}
+
+// compatibility
+window.__RENDER_7_COMPONENTS__ = window.__RENDER_7_COMPONENTS__ || global.__RENDER_7_COMPONENTS__
+window.__RENDER_7_HOT__ = window.__RENDER_7_HOT__ || global.__RENDER_7_HOT__
+global.__RUNTIME__ = window.__RUNTIME__
 
 if (module.hot) {
   module.hot.accept('./core/main', () => {
     const hotGlobals = require('./core/main')
-    global.__RENDER_7_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
-    global.__RENDER_7_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint
-    global.__RENDER_7_RUNTIME__.Link = hotGlobals.Link
+    window.__RENDER_7_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
+    window.__RENDER_7_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint
+    window.__RENDER_7_RUNTIME__.Link = hotGlobals.Link
     runtimeGlobals.start()
   })
 }

--- a/react/start.ts
+++ b/react/start.ts
@@ -1,5 +1,5 @@
 import {canUseDOM} from 'exenv'
 
-if (global.__RUNTIME__.start) {
-  global.__RENDER_7_RUNTIME__.start()
+if (window.__RUNTIME__.start) {
+  window.__RENDER_7_RUNTIME__.start()
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -178,7 +178,7 @@ declare global {
     withHMR: any
   }
 
-  interface RenderGlobal extends NodeJS.Global {
+  interface Window extends Window {
     __RENDER_7_RUNTIME__: RuntimeExports
     __RENDER_7_COMPONENTS__: ComponentsRegistry
     __RENDER_7_HOT__: HotEmitterRegistry
@@ -190,6 +190,7 @@ declare global {
     browserHistory: History
     ReactIntlLocaleData: any
     IntlPolyfill: any
+    Intl: any
     hrtime: NodeJS.Process['hrtime']
     rendered: Promise<RenderedSuccess> | RenderedFailure
   }

--- a/react/typings/node.d.ts
+++ b/react/typings/node.d.ts
@@ -2,7 +2,7 @@ interface Module {
   hot: any
 }
 
-declare var global: RenderGlobal
+declare var global: Window
 
 declare var module: Module
 

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -68,7 +68,7 @@ function shouldAddStyleToPage(path: string) {
 }
 
 export function getImplementation<P={}, S={}>(component: string) {
-  return global.__RENDER_7_COMPONENTS__[component] as new() => Component<P, S>
+  return window.__RENDER_7_COMPONENTS__[component] as new() => Component<P, S>
 }
 
 export function fetchAssets(assets: string[]) {

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -54,7 +54,7 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
       : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, uriSwitchLink, persistedQueryLink, httpLink])
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({
-      cache: canUseDOM ? cache.restore(global.__STATE__) : cache,
+      cache: canUseDOM ? cache.restore(window.__STATE__) : cache,
       link,
       ssrMode: !canUseDOM,
     })

--- a/react/utils/dom.tsx
+++ b/react/utils/dom.tsx
@@ -18,7 +18,7 @@ const portalWrapper = (name: string, markup: string) =>
   `<span id="${portalWrapperId(name)}">${markup}</span>`
 
 export const createPortal = (children: ReactElement<any>, name: string, hydrate: boolean) => {
-  global.__hasPortals__ = true
+  window.__hasPortals__ = true
 
   if (!hydrate) {
     return canUseDOM
@@ -43,7 +43,7 @@ export const createPortal = (children: ReactElement<any>, name: string, hydrate:
 export const getMarkups = (pageName: string, pageMarkup: string): NamedMarkup[] => {
   const markups: NamedMarkup[] = []
 
-  let matches = global.__hasPortals__ && portalPattern.exec(pageMarkup)
+  let matches = window.__hasPortals__ && portalPattern.exec(pageMarkup)
   let strippedMarkup = pageMarkup
   while (matches) {
     const [matched, name, markup] = matches

--- a/react/utils/events.ts
+++ b/react/utils/events.ts
@@ -19,7 +19,7 @@ interface EmittersRegistry {
 const emittersByWorkspace: EmittersRegistry = {}
 
 const initSSE = (account: string, workspace: string, baseURI: string) => {
-  if (Object.keys(global.__RENDER_7_HOT__).length > 0) {
+  if (Object.keys(window.__RENDER_7_HOT__).length > 0) {
     require('eventsource-polyfill')
     const myvtexSSE = require('myvtex-sse')
     const path = `vtex.builder-hub:*:react2,pages0,build.status?workspace=${workspace}`
@@ -50,8 +50,8 @@ const initSSE = (account: string, workspace: string, baseURI: string) => {
       switch (type) {
         case 'hmr':
           console.log(`[react2] Received update. app=${subject} hash=${hash}`)
-          if (global.__RENDER_7_HOT__[subject]) {
-            global.__RENDER_7_HOT__[subject].emit('webpackHotUpdate', hash)
+          if (window.__RENDER_7_HOT__[subject]) {
+            window.__RENDER_7_HOT__[subject].emit('webpackHotUpdate', hash)
           }
           break
         case 'reload':

--- a/react/utils/locales.ts
+++ b/react/utils/locales.ts
@@ -12,7 +12,7 @@ const loadReactIntlData = (locale: string) => {
 
 const loadIntlData = (locale: string) => {
   const path = `https://unpkg.com/intl@1.2.5/locale-data/jsonp/${locale}.js`
-  return global.IntlPolyfill && shouldAddScriptToPage(path) ? addScriptToPage(path) : Promise.resolve()
+  return window.IntlPolyfill && shouldAddScriptToPage(path) ? addScriptToPage(path) : Promise.resolve()
 }
 
 export const loadLocaleData = (locale: string) => {
@@ -24,6 +24,6 @@ export const loadLocaleData = (locale: string) => {
 
 export const addLocaleData = (locale: string) => {
   const lang = getLang(locale)
-  addReactLocaleData(global.ReactIntlLocaleData[lang])
+  addReactLocaleData(window.ReactIntlLocaleData[lang])
 }
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -11,7 +11,7 @@ function getScore(path: string) {
 }
 
 function isHost(hostname: string) {
-  return hostname === (canUseDOM ? window.location.hostname : global.__hostname__)
+  return hostname === (canUseDOM ? window.location.hostname : window.__hostname__)
 }
 
 function trimEndingSlash(token: string) {


### PR DESCRIPTION
We were using `global` as it was always `=== window`, but it can be overwritten by other developers.