### PR TITLE
Register any entrypoint export

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/withHMR.tsx
+++ b/react/utils/withHMR.tsx
@@ -1,17 +1,13 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import PropTypes from 'prop-types'
-import React, {Component, ComponentType, ErrorInfo} from 'react'
+import React, {Component, ComponentType} from 'react'
 
 const isComponentType = (Arg: any): Arg is ComponentType => {
   return typeof Arg === 'function' || (Arg.prototype && Arg.prototype.render)
 }
 
 export default (module: Module, InitialImplementer: any) => {
-  if (!isComponentType(InitialImplementer)) {
-    return null
-  }
-
-  if (!module.hot) {
+  if (!isComponentType(InitialImplementer) || !module.hot) {
     return InitialImplementer
   }
 


### PR DESCRIPTION
Some developers need to share functions between apps, using our "dynamic code dependency" AKA calling functions from `__RENDER_7_COMPONENTS__` registry.

But if you export a function, we assume that it is a react functional component and we wrap it with our `HRMComponent` HOC.

The solution is to export an object with your function, but we are returning `null` to `__RENDER_7_COMPONENTS__` if you are not exporting a react class ou function. This PR removes this restriction.