### PR TITLE
Fix sorting direct children with numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- Fix sorting direct children with numeric values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.11.2] - 2018-6-21
 ### Fixed
 - Fix sorting direct children with numeric values.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.11.1",
+  "version": "7.11.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/treePath.tsx
+++ b/react/utils/treePath.tsx
@@ -8,11 +8,25 @@ const isDirectChild = (id: string, parent: string) => {
   return id !== parent && (new RegExp(`^${parent}/[a-zA-Z0-9-]+$`)).test(id)
 }
 
+const parseId = (id: string) => {
+  const [, text, numericText] = /^(.*?)(\d+)?$/.exec(id)!
+  const numbericValue = numericText ? parseInt(numericText, 10) : 0
+  return [text, numbericValue]
+}
+
 export const getDirectChildren = (extensions: Extensions, treePath: string) => {
   return Object.entries(extensions)
     .filter(([id, extension]) => extension.component && isDirectChild(id, treePath))
     .map(([id]) => relative(treePath, id))
-    .sort()
+    .sort((idA, idB) => {
+      const [textA, numberA] = parseId(idA)
+      const [textB, numberB] = parseId(idB)
+      const [valueA, valueB] = (textA === textB)
+        ? [numberA, numberB]
+        : [textA, textB]
+
+      return valueA < valueB ? -1 : 1
+    })
 }
 
 export const TreePathContext = React.createContext<TreePathProps>({treePath: ''})


### PR DESCRIPTION
This enables sorting numeric treePaths or ending with numbers properly
Ex: ['b20', 'a0', 'a10', 'a1', '11', 'b2', '2', '1', '10'] becomes ['1', '2', '10', '11', 'a0', 'a1', 'a10', 'a11', 'b2']

Fixes #67 