### PR TITLE
Removes hash generation from directives

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.11.3",
+  "version": "7.11.4",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/client/generateHash.ts
+++ b/react/utils/client/generateHash.ts
@@ -1,19 +1,8 @@
-import {ArgumentNode, DocumentNode, visit} from 'graphql'
-
-const hashFromQuery = (asset: any) => ({
-  Argument(node: ArgumentNode) {
-    if (node.name.value === 'hash') {
-      asset.hash = node.value.value
-    }
-  }
-})
+import {DocumentNode} from 'graphql'
 
 export const generateHash = (query: DocumentNode) => {
   if (query.documentId) {
     return query.documentId
   }
-
-  const asset = {hash: ''}
-  visit(query, hashFromQuery(asset))
-  return asset.hash
+  return null
 }


### PR DESCRIPTION
Removes hash generation from directives to force error and send the correct query while this PR #62 is not merged