### PR TITLE
Fix link props passed to DOM element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix link props being directly passed to `a` tag.
 
 ## [7.11.3] - 2018-6-21
 ### Removed

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -53,9 +53,9 @@ class Link extends Component<Props & RenderContextProps> {
   }
 
   public render() {
-    const {page, params, to, runtime: {pages}} = this.props
+    const {page, params, to, runtime: {pages}, ...linkProps} = this.props
     const href = to || page && pathFromPageName(page, pages, params) || '#'
-    return <a href={href} {...this.props} onClick={this.handleClick} />
+    return <a href={href} {...linkProps} onClick={this.handleClick} />
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix link props passed to DOM element

#### What problem is this solving?
Link props were being passed to the `a` element, resulting in things like

```html
<a href="/login" to="/login" runtime="[object Object]">...</a>
```

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
