### PR TITLE
Deep clone copies streams

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.12.6",
+  "version": "7.12.7",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",


### PR DESCRIPTION
Remove keys doesn't work because react/apollo use Object.freeze. 

The solution was to revive the object and manually copy streams with deepCopyFiles