### PR TITLE
Fix loading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.16.4] - 2018-7-19
+
 ## [7.16.1] - 2018-07-18
 ### Added
 - Uses cacheId to cache

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.16.3",
+  "version": "7.16.4",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/Loading.tsx
+++ b/react/components/Loading.tsx
@@ -1,22 +1,28 @@
-import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
-import {getComponentFromExtensions} from '../utils/assets'
+import {getExtensionImplementation} from '../utils/assets'
+import {RenderContextProps, withRuntimeContext} from './RenderContext'
 
 interface Props {
   useDefault?: boolean
 }
 
-export default class Loading extends PureComponent<Props> {
-  
+const defaultLoading = (
+  <svg width="26px" height="26px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+    <circle cx="50" opacity="0.4" cy="50" fill="none" stroke="#F71963" strokeWidth="14" r="40"></circle>
+    <circle cx="50" cy="50" fill="none" stroke="#F71963" strokeWidth="12" r="40" strokeDasharray="60 900" strokeLinecap="round" transform="rotate(96 50 50)">
+      <animateTransform attributeName="transform" type="rotate" calcMode="linear" values="0 50 50;360 50 50" keyTimes="0;1" dur="0.7s" begin="0s" repeatCount="indefinite"></animateTransform>
+    </circle>
+  </svg>
+)
+
+class Loading extends PureComponent<Props & RenderContextProps> {
+
   public render() {
-    const LoadingExtension = getComponentFromExtensions('loading')
-    return LoadingExtension && !this.props.useDefault ? <LoadingExtension /> : (
-      <svg width="26px" height="26px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
-        <circle cx="50" opacity="0.4" cy="50" fill="none" stroke="#F71963" strokeWidth="14" r="40"></circle>
-        <circle cx="50" cy="50" fill="none" stroke="#F71963" strokeWidth="12" r="40" strokeDasharray="60 900" strokeLinecap="round" transform="rotate(96 50 50)">
-          <animateTransform attributeName="transform" type="rotate" calcMode="linear" values="0 50 50;360 50 50" keyTimes="0;1" dur="0.7s" begin="0s" repeatCount="indefinite"></animateTransform>
-        </circle>
-      </svg>
-    )
+    const {useDefault, runtime: {extensions}} = this.props
+    const LoadingExtension = getExtensionImplementation(extensions, 'store/__loading')
+
+    return LoadingExtension && !useDefault ? <LoadingExtension /> : defaultLoading
   }
 }
+
+export default withRuntimeContext(Loading)

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -71,14 +71,14 @@ export function getImplementation<P={}, S={}>(component: string) {
   return window.__RENDER_7_COMPONENTS__[component] as RenderComponent<P, S>
 }
 
+export function getExtensionImplementation<P={}, S={}>(extensions: Extensions, name: string) {
+  const extension = extensions[name]
+  return extension && extension.component ? getImplementation<P, S>(extension.component) : null
+}
+
 export function fetchAssets(assets: string[]) {
   const scripts = assets.filter(shouldAddScriptToPage)
   const styles = assets.filter(shouldAddStyleToPage)
   styles.forEach(addStyleToPage)
   return Promise.all(scripts.map(addScriptToPage)).then(() => { return })
-}
-
-export function getComponentFromExtensions(name: string) {
-  const extension = window.__RUNTIME__.extensions[`store/__${name}`]
-  return extension ? getImplementation(extension.component) : null
 }


### PR DESCRIPTION
The `store/__loading` implementation was being fetched using `window.__RUNTIME__.extensions`, but that is not available to legacy-extensions.

![screen shot 2018-07-19 at 16 10 00](https://user-images.githubusercontent.com/2726345/42966868-d1ee8174-8b74-11e8-94a8-980cc9beedd2.png)
