### PR TITLE
Adding cache-and-network policy for faster page loading

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -282,7 +282,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       path: pathname,
       production,
       renderMajor,
-    }).then(({
+    }).subscribe(({
       appsEtag,
       cacheHints,
       components,
@@ -290,7 +290,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       messages,
       pages,
       settings
-    }: ParsedPageQueryResponse) => {
+    }: any) => {
       this.setState({
         appsEtag,
         cacheHints,
@@ -401,7 +401,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       production,
       renderMajor,
       ...options,
-    }).then(({
+    }).subscribe(({
       appsEtag,
       cacheHints,
       components,
@@ -409,7 +409,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       messages,
       pages,
       settings
-    }: ParsedPageQueryResponse) => {
+    }: any) => {
       this.setState({
         appsEtag,
         cacheHints,


### PR DESCRIPTION
Today, it takes a huge time for the page to load due to conditions. This adds cache-and-network policy to the graphql query for faster page loading