### PR TITLE
Add data-extension-point hint to DOM element if component is editable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.16.6",
+  "version": "7.17.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/ExtensionPoint.tsx
+++ b/react/ExtensionPoint.tsx
@@ -42,7 +42,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     return [parentTreePath, currentId].filter(id => !!id).join('/')
   }
 
-  private component?: string
+  private component?: string | null
 
   constructor (props: ExtendedProps) {
     super(props)
@@ -83,7 +83,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     const component = extension ? extension.component : null
     const extensionProps = extension ? extension.props : null
 
-    this.component = component || undefined
+    this.component = component
 
     const props = {
       ...parentProps,
@@ -103,7 +103,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     const ComponentImpl = this.component && getImplementation(this.component)
     const isEditable = ComponentImpl && (ComponentImpl.hasOwnProperty('schema') || ComponentImpl.hasOwnProperty('getSchema'))
 
-    if (!isEditable) {
+    if (this.component && !isEditable) {
       return
     }
 

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {ErrorInfo, PureComponent, ReactElement} from 'react'
+import React, {ErrorInfo, PureComponent} from 'react'
 
 import {getImplementation} from '../utils/assets'
 import logEvent from '../utils/logger'
@@ -32,14 +32,12 @@ class ExtensionPointComponent extends PureComponent<Props & RenderContextProps, 
   // tslint:disable-next-line:variable-name
   private _isMounted!: boolean
   private emptyExtensionPoint: Extension
-  private editableExtensionPoint: Extension
 
   constructor(props: Props & RenderContextProps) {
     super(props)
 
     const root = props.treePath && props.treePath.split('/')[0]
     this.emptyExtensionPoint = props.runtime.extensions[`${root}/__empty`]
-    this.editableExtensionPoint = props.runtime.extensions[`${root}/__editable`]
     this.state = {}
   }
 
@@ -134,25 +132,14 @@ class ExtensionPointComponent extends PureComponent<Props & RenderContextProps, 
     }
 
     const EmptyExtensionPoint = this.emptyExtensionPoint && getImplementation(this.emptyExtensionPoint.component)
-    const EditableExtensionPoint = this.editableExtensionPoint && getImplementation<EditableExtensionPointProps>(this.editableExtensionPoint.component)
 
     // This extension point is not configured.
     if (!component && !production && this.emptyExtensionPoint) {
-      return <EditableExtensionPoint treePath={treePath} component={this.emptyExtensionPoint.component}><EmptyExtensionPoint /></EditableExtensionPoint>
+      return <EmptyExtensionPoint />
     }
 
-    const isEditable = Component && (Component.hasOwnProperty('schema') || Component.hasOwnProperty('getSchema'))
-    const configuredComponent = Component ? <Component {...props}>{children}</Component> : children || null
-    return this.editableExtensionPoint && isEditable
-      ? <EditableExtensionPoint treePath={treePath} component={component}>{configuredComponent}</EditableExtensionPoint>
-      : configuredComponent
+    return Component ? <Component {...props}>{children}</Component> : children || null
   }
-}
-
-interface EditableExtensionPointProps {
-  treePath: string
-  component: string | null
-  props?: any
 }
 
 export default ExtensionPointComponent

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -13,7 +13,7 @@ const absoluteRegex = /^https?:\/\/|^\/\//i
 const isAbsoluteUrl = (url: string) => absoluteRegex.test(url)
 
 interface Props extends NavigateOptions {
-  onClick: () => void
+  onClick: (event: any) => void
 }
 
 // eslint-disable-next-line
@@ -40,7 +40,7 @@ class Link extends Component<Props & RenderContextProps> {
       return
     }
 
-    this.props.onClick()
+    this.props.onClick(event)
 
     const options: NavigateOptions = {page, params, query, to, scrollOptions, fallbackToWindowLocation: false}
     if (navigate(options)) {


### PR DESCRIPTION
And stop adding `EditableExtensionPoint` around extension points.