### PR TITLE
Uses route info for generating params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.20.0] - 2018-08-21
+
 ## [7.19.0] - 2018-08-17
 
 ## [7.18.1] - 2018-8-15

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.19.0",
+  "version": "7.20.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/NestedExtensionPoints.tsx
+++ b/react/components/NestedExtensionPoints.tsx
@@ -23,6 +23,9 @@ export default class NestedExtensionPoints extends PureComponent<Props> {
 
   public getPageParams(runtime: RenderContext, name: string) {
     const path = canUseDOM ? window.location.pathname : window.__pathname__
+    if (runtime.route.id === name && runtime.route.canonical === path) {
+      return runtime.route.params
+    }
     const pagePath = getPagePath(name, runtime.pages)
     const pagePathWithRest = pagePath && /\*\w+$/.test(pagePath) ? pagePath : pagePath.replace(/\/?$/, '*_rest')
     return pagePath && getParams(pagePathWithRest, path) || EMPTY_OBJECT

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -49,6 +49,7 @@ export interface RenderProviderState {
   production: RenderRuntime['production']
   query: RenderRuntime['query']
   settings: RenderRuntime['settings']
+  route: RenderRuntime['route']
 }
 
 const SEND_INFO_DEBOUNCE_MS = 100
@@ -71,6 +72,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     pages: PropTypes.object,
     prefetchPage: PropTypes.func,
     production: PropTypes.bool,
+    route: PropTypes.object,
     setDevice: PropTypes.func,
     updateComponentAssets: PropTypes.func,
     updateExtension: PropTypes.func,
@@ -98,7 +100,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   constructor(props: Props) {
     super(props)
-    const {appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings} = props.runtime
+    const {appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings, route} = props.runtime
     const {history, baseURI, cacheControl} = props
 
     if (history) {
@@ -122,6 +124,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       pages,
       production,
       query,
+      route,
       settings,
     }
   }
@@ -168,7 +171,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public getChildContext() {
     const {history, runtime} = this.props
-    const {components, extensions, page, pages, settings, culture, device} = this.state
+    const {components, extensions, page, pages, settings, culture, device, route} = this.state
     const {account, emitter, production, workspace} = runtime
 
     return {
@@ -187,6 +190,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       pages,
       prefetchPage: this.prefetchPage,
       production,
+      route,
       setDevice: this.handleSetDevice,
       updateComponentAssets: this.updateComponentAssets,
       updateExtension: this.updateExtension,
@@ -256,7 +260,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public onPageChanged = (location: RenderHistoryLocation) => {
     const {runtime: {renderMajor}} = this.props
-    const {culture: {locale}, pages: pagesState, production, device} = this.state
+    const {culture: {locale}, pages: pagesState, production, device, route} = this.state
     const {pathname, state} = location
 
     // Make sure this is our navigation
@@ -316,6 +320,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         page,
         pages,
         query,
+        route,
         settings,
       }, () => this.afterPageChanged(page))
     })
@@ -407,7 +412,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public updateRuntime = (options?: PageContextOptions) => {
     const {runtime: {renderMajor}} = this.props
-    const {page, production, culture: {locale}} = this.state
+    const {page, production, culture: {locale}, route} = this.state
     const {pathname} = window.location
 
     return fetchRoutes({
@@ -435,6 +440,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         messages,
         page,
         pages,
+        route,
         settings,
       })
     })

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -19,7 +19,7 @@ import {traverseComponent} from '../utils/components'
 import {RENDER_CONTAINER_CLASS, ROUTE_CLASS_PREFIX, routeClass} from '../utils/dom'
 import {loadLocaleData} from '../utils/locales'
 import {createLocaleCookie, fetchMessages, fetchMessagesForApp} from '../utils/messages'
-import {navigate as pageNavigate, NavigateOptions} from '../utils/pages'
+import {getRouteFromPath, navigate as pageNavigate, NavigateOptions} from '../utils/pages'
 import {fetchRoutes} from '../utils/routes'
 import {TreePathContext} from '../utils/treePath'
 
@@ -100,8 +100,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   constructor(props: Props) {
     super(props)
-    const {appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings, route} = props.runtime
+    const {appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings} = props.runtime
     const {history, baseURI, cacheControl} = props
+    const path = canUseDOM ? window.location.pathname : window.__pathname__
+    const route = props.runtime.route || getRouteFromPath(path, pages)
 
     if (history) {
       const renderLocation = {...history.location, state: {renderRouting: true, route}}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -74,7 +74,7 @@ declare global {
   interface Route {
     canonical?: string
     path?: string
-    params?: Record<string, any>
+    params?: Record<string, string>
     id: string
   }
 
@@ -82,6 +82,7 @@ declare global {
 
   interface RenderHistoryLocation extends Location {
     state?: {
+      route: Route
       renderRouting?: true
       scrollOptions?: RenderScrollOptions
     }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -71,6 +71,13 @@ declare global {
     conditional?: boolean
   }
 
+  interface Route {
+    canonical?: string
+    path?: string
+    params?: Record<string, any>
+    id: string
+  }
+
   type RenderScrollOptions = ScrollToOptions | false
 
   interface RenderHistoryLocation extends Location {
@@ -123,6 +130,7 @@ declare global {
     updateExtension: (name: string, extension: Extension) => void,
     updateRuntime: (options?: PageContextOptions) => Subscription,
     workspace: RenderRuntime['workspace'],
+    route: RenderRuntime['route']
   }
 
   interface PageContextOptions {
@@ -210,6 +218,7 @@ interface RenderComponent<P={}, S={}> {
     disableSSR: boolean
     hints: any
     page: string
+    route: Route
     version: string
     culture: Culture
     pages: Pages

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -84,7 +84,7 @@ function getRouteFromPageName(id: string, pages: Pages, params: any) : Route | n
   return path ? {id, path, params} : null
 }
 
-function getRouteFromPath(path: string, pages: Pages) : Route | null {
+export function getRouteFromPath(path: string, pages: Pages) : Route | null {
   const id = routeIdFromPath(path, pages)
   return id ? {id, path, params: getPageParams(id, path, pages)} : null
 }

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -102,7 +102,7 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
 }
 
 export function routeIdFromPath(path: string, routes: Pages) {
-  let routeId: string | undefined
+  let id: string | undefined
   let score: number
   let highScore: number = Number.NEGATIVE_INFINITY
 
@@ -121,11 +121,11 @@ export function routeIdFromPath(path: string, routes: Pages) {
       }
 
       highScore = score
-      routeId = name
+      id = name
     }
   }
 
-  return routeId
+  return id
 }
 
 export interface NavigateOptions {


### PR DESCRIPTION
Currently, the url is the source of truth for generating the route params. For example, if we are under a product's path template (`/:slug/p`), and under the url `/tesla-3/p`, the params generated for this route will be: `{slug: tesla-3}`.  

From now on, this will no longer be the truth, since canonical routes change the url. In order to generate correctly the parameters for a route, we retrieve it from the new field available in the runtime called `route`, containing all route metadata necessary to generate the params. Note that we only need it in canonical routes, and navigation will not be affected since navigation is done by using system routes