### PR TITLE
Should use post on persisted query not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.20.7] - 2018-08-27
+
 ## [7.20.6] - 2018-8-24
 
 ## [7.20.5] - 2018-8-22

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -234,15 +234,17 @@ interface RenderComponent<P={}, S={}> {
     settings: {
       [app: string]: any;
     }
-    cacheHints: CacheHints
+    cacheHints: CacheHintsMap
   }
 
   interface CacheHints {
-    [hash: string]: {
-      scope: string
-      maxAge: string
-      version: number
-    }
+    scope?: string
+    maxAge?: string
+    version?: number
+  }
+
+  interface CacheHintsMap {
+    [hash: string]: CacheHints
   }
 
   interface RuntimeExports {

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -62,6 +62,7 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const httpLink = createHttpLink({
       credentials: 'include',
+      useGETForQueries: false,
     })
 
     const uploadLink = createUploadLink({
@@ -70,7 +71,10 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const fetcherLink = createIOFetchLink(httpLink, uploadLink)
 
-    const persistedQueryLink = createPersistedQueryLink({generateHash})
+    const persistedQueryLink = createPersistedQueryLink({
+      generateHash,
+      useGETForHashedQueries: true,
+    })
 
     const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
 

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -49,9 +49,9 @@ const extractHints = (query: ASTNode, meta: CacheHints) => {
 
 export const createUriSwitchLink = (baseURI: string, workspace: string) =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {
-    operation.setContext(({ fetchOptions = {}, runtime: {appsEtag, cacheHints} } : OperationContext) => {
-      const oldContext = operation.getContext()
-      const oldMethod = (oldContext.fetchOptions && oldContext.fetchOptions.method) || 'POST'
+    operation.setContext((oldContext: OperationContext) => {
+      const { fetchOptions = {}, runtime: {appsEtag, cacheHints} } = oldContext
+      const oldMethod = fetchOptions.method || 'POST'
       const hash = generateHash(operation.query)
       const protocol = canUseDOM ? 'https:' : 'http:'
       const {maxAge, scope, version, operationType} = extractHints(operation.query, cacheHints[hash])


### PR DESCRIPTION
Currently, when a `PersistedQueryNotFound` error is thrown, the system redos the query using the same HTTP verb with the whole stringified version of the query. If it turned out to be a public graphql query, the whole query text will be stringified into the request's querystring, putting too much pressure into the browser and our systems. 

This PR solves this issue by using GET in the first fetch, and POST in case of error