### PR TITLE
Adds batched queries support

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -29,8 +29,7 @@
     "react-hot-loader": "^4.1.2",
     "react-intl": "^2.4.0",
     "react-no-ssr": "^1.1.0",
-    "route-parser": "^0.0.5",
-    "url": "^0.11.0"
+    "route-parser": "^0.0.5"
   },
   "devDependencies": {
     "@types/debounce": "^1.0.0",

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "apollo-cache-inmemory": "^1.2.5",
     "apollo-client": "^2.3.5",
-    "apollo-link-http": "^1.5.4",
+    "apollo-link-batch-http": "^1.2.2",
     "apollo-link-persisted-queries": "^0.2.1",
     "apollo-upload-client": "^8.1.0",
     "apollo-utilities": "^1.0.16",
@@ -29,7 +29,8 @@
     "react-hot-loader": "^4.1.2",
     "react-intl": "^2.4.0",
     "react-no-ssr": "^1.1.0",
-    "route-parser": "^0.0.5"
+    "route-parser": "^0.0.5",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@types/debounce": "^1.0.0",

--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,9 @@
     "react-hot-loader": "^4.1.2",
     "react-intl": "^2.4.0",
     "react-no-ssr": "^1.1.0",
-    "route-parser": "^0.0.5"
+    "route-parser": "^0.0.5",
+    "url": "^0.11.0",
+    "url-search-params": "^1.1.0"
   },
   "devDependencies": {
     "@types/apollo-upload-client": "^8.1.0",
@@ -46,6 +48,7 @@
     "@types/react-hot-loader": "^4.1.0",
     "@types/react-intl": "^2.3.5",
     "@types/route-parser": "^0.1.1",
+    "@types/url-search-params": "^0.10.2",
     "tslint": "^5.2.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.1.0",

--- a/react/package.json
+++ b/react/package.json
@@ -32,6 +32,7 @@
     "route-parser": "^0.0.5"
   },
   "devDependencies": {
+    "@types/apollo-upload-client": "^8.1.0",
     "@types/debounce": "^1.0.0",
     "@types/graphql": "^0.13.3",
     "@types/history": "^4.6.2",

--- a/react/utils/cacheControl.ts
+++ b/react/utils/cacheControl.ts
@@ -16,7 +16,7 @@ const parseCacheControl = (cacheControl: string) => {
 }
 
 const getMaxAge = (response: Response) => {
-  const cacheControlHeader = response.headers.get('cache-control')
+  const cacheControlHeader = response.headers && response.headers.get('cache-control')
   if (!cacheControlHeader) {
     return DEFAULT_MAX_AGE_S
   }

--- a/react/utils/client/batchKey.ts
+++ b/react/utils/client/batchKey.ts
@@ -1,11 +1,15 @@
 import { Operation } from 'apollo-link'
 import { BREAK, DocumentNode, FieldNode, visit } from 'graphql'
 
+// GraphQL's AST is made in such a way that the root fields are
+// in depth equals 5 when visiting it.
+const ROOT_FIELD_DEPTH = 5
+
 const assetsFromQuery = (query: DocumentNode) => {
   const assets = {name: ''}
   visit(query, {
     Field(node: FieldNode, _, __, path) {
-      if (path.length === 5) {
+      if (path.length === ROOT_FIELD_DEPTH) {
         assets.name = node.name.value
         return BREAK
       }

--- a/react/utils/client/batchKey.ts
+++ b/react/utils/client/batchKey.ts
@@ -1,0 +1,22 @@
+import { Operation } from 'apollo-link'
+import { BREAK, DocumentNode, FieldNode, visit } from 'graphql'
+
+const assetsFromQuery = (query: DocumentNode) => {
+  const assets = {name: ''}
+  visit(query, {
+    Field(node: FieldNode, _, __, path) {
+      if (path.length === 5) {
+        assets.name = node.name.value
+        return BREAK
+      }
+      return undefined
+    }
+  })
+  return assets
+}
+
+export const batchKey = (operation: Operation): string => {
+  const {uri, fetchOptions: {method}} = operation.getContext()
+  const {name} = assetsFromQuery(operation.query as DocumentNode)
+  return [uri, method, name].join('_')
+}

--- a/react/utils/client/fetch.ts
+++ b/react/utils/client/fetch.ts
@@ -9,7 +9,7 @@ export const IOFetch = async (uri: string | Request, init?: RequestInit): Promis
     const parsedUri = parse(uri, true)
 
     delete parsedUri.search
-    parsedUri.query = {...parsedUri.query, query: body}
+    parsedUri.query = {...parsedUri.query, batch: body}
 
     delete formattedInit.body
     formattedInit.method = 'GET'

--- a/react/utils/client/fetch.ts
+++ b/react/utils/client/fetch.ts
@@ -1,19 +1,23 @@
 import {format, parse} from 'url'
+import URLSearchParams from 'url-search-params'
+
+const separator = '@@'
+
+const graphqlStringify = (obj: any) => [obj.operationName, JSON.stringify(obj.variables || {}), JSON.stringify(obj.extensions || {})].join(separator)
 
 export const IOFetch = async (urlOrRequest: string | Request, init?: RequestInit): Promise<Response> => {
   const {useGetInBatch = false, body} = init || {} as any
   const formattedInit: RequestInit = {...init}
-  let formattedUrl = (typeof urlOrRequest === 'string') ? urlOrRequest : urlOrRequest.url
+  let formattedUrl = typeof urlOrRequest === 'string' ? urlOrRequest : urlOrRequest.url
 
   if (useGetInBatch && formattedInit) {
     const parsedUri = parse(formattedUrl, true)
-
-    delete parsedUri.search
-    parsedUri.query = {...parsedUri.query, batch: body}
-
-    delete formattedInit.body
+    const formattedBody = JSON.parse(body || '{}')
+    const searchParams = new URLSearchParams(parsedUri.search)
+    formattedBody.forEach((obj: any) => searchParams.append('batch', graphqlStringify(obj)))
+    parsedUri.search = searchParams.toString()
+    formattedInit.body = undefined
     formattedInit.method = 'GET'
-
     formattedUrl = format(parsedUri)
   }
 

--- a/react/utils/client/fetch.ts
+++ b/react/utils/client/fetch.ts
@@ -1,12 +1,12 @@
 import {format, parse} from 'url'
 
-export const IOFetch = async (uri: string | Request, init?: RequestInit): Promise<Response> => {
+export const IOFetch = async (urlOrRequest: string | Request, init?: RequestInit): Promise<Response> => {
   const {useGetInBatch = false, body} = init || {} as any
-  const formattedInit = {...init}
-  let formattedUri = uri
+  const formattedInit: RequestInit = {...init}
+  let formattedUrl = (typeof urlOrRequest === 'string') ? urlOrRequest : urlOrRequest.url
 
-  if (useGetInBatch && typeof uri === 'string' && formattedInit) {
-    const parsedUri = parse(uri, true)
+  if (useGetInBatch && formattedInit) {
+    const parsedUri = parse(formattedUrl, true)
 
     delete parsedUri.search
     parsedUri.query = {...parsedUri.query, batch: body}
@@ -14,8 +14,8 @@ export const IOFetch = async (uri: string | Request, init?: RequestInit): Promis
     delete formattedInit.body
     formattedInit.method = 'GET'
 
-    formattedUri = format(parsedUri)
+    formattedUrl = format(parsedUri)
   }
 
-  return fetch(formattedUri, formattedInit)
+  return fetch(formattedUrl, formattedInit)
 }

--- a/react/utils/client/fetch.ts
+++ b/react/utils/client/fetch.ts
@@ -1,0 +1,21 @@
+import {format, parse} from 'url'
+
+export const IOFetch = async (uri: string | Request, init?: RequestInit): Promise<Response> => {
+  const {useGetInBatch = false, body} = init || {} as any
+  const formattedInit = {...init}
+  let formattedUri = uri
+
+  if (useGetInBatch && typeof uri === 'string' && formattedInit) {
+    const parsedUri = parse(uri, true)
+
+    delete parsedUri.search
+    parsedUri.query = {...parsedUri.query, query: body}
+
+    delete formattedInit.body
+    formattedInit.method = 'GET'
+
+    formattedUri = format(parsedUri)
+  }
+
+  return fetch(formattedUri, formattedInit)
+}

--- a/react/utils/client/generateHash.ts
+++ b/react/utils/client/generateHash.ts
@@ -1,15 +1,15 @@
 import {ArgumentNode, BREAK, DocumentNode, visit} from 'graphql'
 
 export const generateHash = (query: DocumentNode) => {
-  if (query.documentId) {
-    return query.documentId
+  if ((query as any).documentId) {
+    return (query as any).documentId
   }
 
   const asset = {hash: ''}
   visit(query, {
     Argument(node: ArgumentNode) {
       if (node.name.value === 'hash') {
-        asset.hash = node.value.value
+        asset.hash = (node.value as any).value
         return BREAK
       }
     }

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -1,11 +1,13 @@
 import {HeuristicFragmentMatcher, InMemoryCache, NormalizedCacheObject} from 'apollo-cache-inmemory'
 import {ApolloClient} from 'apollo-client'
 import {ApolloLink} from 'apollo-link'
-import {createHttpLink} from 'apollo-link-http'
+import {BatchHttpLink} from 'apollo-link-batch-http'
 import {createPersistedQueryLink} from 'apollo-link-persisted-queries'
 import {createUploadLink} from 'apollo-upload-client'
 import {canUseDOM} from 'exenv'
 import PageCacheControl from '../cacheControl'
+import {batchKey} from './batchKey'
+import {IOFetch} from './fetch'
 import {generateHash} from './generateHash'
 import {cachingLink} from './links/cachingLink'
 import {createIOFetchLink} from './links/ioFetchLink'
@@ -60,9 +62,11 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
       fragmentMatcher: new HeuristicFragmentMatcher()
     })
 
-    const httpLink = createHttpLink({
+    const httpLink = new BatchHttpLink({
+      batchKey,
       credentials: 'include',
-      useGETForQueries: false,
+      fetch: IOFetch as any,
+      includeExtensions: true,
     })
 
     const uploadLink = createUploadLink({
@@ -78,9 +82,11 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
 
+    const baseLink = [omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink]
+
     const link = cacheControl
-      ? ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink, cachingLink(cacheControl), fetcherLink])
-      : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink, fetcherLink])
+      ? ApolloLink.from([...baseLink, cachingLink(cacheControl), fetcherLink])
+      : ApolloLink.from([...baseLink, fetcherLink])
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({
       cache: canUseDOM ? cache.restore(window.__STATE__) : cache,

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -82,11 +82,9 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
 
-    const baseLink = [omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink]
+    const htmlCachingLink = cacheControl ? [cachingLink(cacheControl)] : []
 
-    const link = cacheControl
-      ? ApolloLink.from([...baseLink, cachingLink(cacheControl), fetcherLink])
-      : ApolloLink.from([...baseLink, fetcherLink])
+    const link = ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink, ...htmlCachingLink , fetcherLink])
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({
       cache: canUseDOM ? cache.restore(window.__STATE__) : cache,

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -62,8 +62,8 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
       fragmentMatcher: new HeuristicFragmentMatcher()
     })
 
-    const httpLink = new BatchHttpLink({
-      batchKey,
+    const httpLink: any = new BatchHttpLink({
+      batchKey: batchKey as any,
       credentials: 'include',
       fetch: IOFetch as any,
       includeExtensions: true,

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -9,6 +9,14 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@types/apollo-upload-client@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/apollo-upload-client/-/apollo-upload-client-8.1.0.tgz#688fd68d15da59aacbd56951dedfa9a3ab5302cf"
+  dependencies:
+    "@types/extract-files" "*"
+    apollo-link "^1.0.0"
+    apollo-link-http-common "^0.2.4"
+
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -16,6 +24,10 @@
 "@types/debounce@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.0.0.tgz#417560200331e1bb84d72da85391102c2fcd61b7"
+
+"@types/extract-files@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/extract-files/-/extract-files-3.1.0.tgz#a93ce5b82b81a9b420f3a6d14b9bfc043779fd2b"
 
 "@types/graphql@0.12.6":
   version "0.12.6"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -99,6 +99,10 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@types/route-parser/-/route-parser-0.1.1.tgz#24b69588c68249f695122c230e547d3d6c8be095"
 
+"@types/url-search-params@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@types/url-search-params/-/url-search-params-0.10.2.tgz#bf7587e67953906ea67a8ff0ddbcb6f4482ebaa3"
+
 "@types/zen-observable@^0.5.3":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
@@ -602,9 +606,17 @@ prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
 qs@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 react-apollo@^2.1.6:
   version "2.1.6"
@@ -809,6 +821,17 @@ typescript@^2.8.3:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+url-search-params@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-1.1.0.tgz#865669a6e4e9e5543f86fc972b27c91485375326"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 value-equal@^0.4.0:
   version "0.4.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -133,6 +133,20 @@ apollo-client@^2.3.5:
   optionalDependencies:
     "@types/async" "2.0.49"
 
+apollo-link-batch-http@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.2.tgz#4dc98e16dca063cc66db3311cc71a855a4bac9c9"
+  dependencies:
+    apollo-link "^1.2.2"
+    apollo-link-batch "^1.1.3"
+    apollo-link-http-common "^0.2.4"
+
+apollo-link-batch@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.3.tgz#c1d04256ef41af43e23854fab72cd3986a7648ad"
+  dependencies:
+    apollo-link "^1.2.2"
+
 apollo-link-dedup@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.8.tgz#8c3028cf32557bd040ab6ba8856f38067bdacead"
@@ -144,13 +158,6 @@ apollo-link-http-common@^0.2.4:
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz#877603f7904dc8f70242cac61808b1f8d034b2c3"
   dependencies:
     apollo-link "^1.2.2"
-
-apollo-link-http@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
-  dependencies:
-    apollo-link "^1.2.2"
-    apollo-link-http-common "^0.2.4"
 
 apollo-link-persisted-queries@^0.2.1:
   version "0.2.1"
@@ -583,9 +590,17 @@ prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
 qs@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 react-apollo@^2.1.6:
   version "2.1.6"
@@ -790,6 +805,13 @@ typescript@^2.8.3:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 value-equal@^0.4.0:
   version "0.4.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -590,17 +590,9 @@ prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-
 qs@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 react-apollo@^2.1.6:
   version "2.1.6"
@@ -805,13 +797,6 @@ typescript@^2.8.3:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
-
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 value-equal@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR not only adds batched queries support, but also defines a standard for sending batched queries in a `GET` request.

The usual way of sending a GraphQL query in an http request is by parsing the query object into the url's querystring. For instance, suppose we have the following query object:

```
{
'operationName': 'GetProducts',
'query': 'query GetProducst {products {slug}}',
'variables': {}
}
```

The corresponding url's querystring for this request is:

`?operationName='GetProducts'&query='query GetProducst {products {slug}}'&variables={}'`

The problem in using this approach for sending batched queries is that the query object is an array, and the url's querystring does not support array objects. To overcome this problem the batched query object should not be parsed directly, but rather inserted under a key named `batch`. This key can be repeated many times, each one indicating a new query object. Also, to avoid duplication of keys, the query object fields are separated by `@@` in the following order: operationName, variables and extensions. To illustrate how the stringification works, suppose we have following query objects

```
[{
'operationName': 'GetProducts1',
'extensions': 'extensions: { persistedQuery{ sha256: "3123123123123"}}',
'variables': {}
},
{
'operationName': 'GetProducts2',
'extensions': 'extensions{ persistedQuery{ sha256: "gfdgdfgdfgdfg"}}',
'variables': {}
}]
```

The corresponding url's querystring for this request is:
`?batch='GetProducts1'@@{}@@extensions{ persistedQuery{ sha256: "gfdgdfgdfgdfg"}}'&batch=batch='GetProducts1'@@{}@@extensions{ persistedQuery{ sha256: "3123123123123"}}`

This way, the query is correctly sent and `graphql-server` can parse back the query object