### PR TITLE
Change withEmitter HOC to return a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.22.1] - 2018-9-17
+
 ## [7.22.0] - 2018-09-06
 ### Changed
 - Update `MaybeAuth` to work just by the session.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.22.0",
+  "version": "7.22.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderContext.tsx
+++ b/react/components/RenderContext.tsx
@@ -17,6 +17,15 @@ export const withRuntimeContext = <TOriginalProps extends {} = {}>(Component: Co
 }
 
 export const withEmitter = <TOriginalProps extends {} = {}>(Component: ComponentType<TOriginalProps & EmitterProps>): ComponentType<TOriginalProps> => {
-  const ExtendedComponent = (props: TOriginalProps) => <RenderContext.Consumer>{runtime => <Component {...props} __emitter={runtime.emitter} />}</RenderContext.Consumer>
-  return hoistNonReactStatics<TOriginalProps, EmitterProps>(ExtendedComponent, Component)
+  class WithEmitter extends React.Component<TOriginalProps> {
+    public static get displayName(): string {
+      return `WithEmitter(${Component.displayName || Component.name || 'Component'})`
+    }
+
+    public render() {
+      return <RenderContext.Consumer>{runtime => <Component {...this.props} __emitter={runtime.emitter} />}</RenderContext.Consumer>
+    }
+  }
+
+  return hoistNonReactStatics<TOriginalProps, EmitterProps>(WithEmitter, Component)
 }


### PR DESCRIPTION
It fixes this issue with refs: "Warning: Stateless function components cannot be given refs. Attempts to access this ref will fail."