### PR TITLE
Adds app version to Persisted Query request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.22.4] - 2018-09-21
+
 ## [7.22.3] - 2018-09-21
 <<<<<<< HEAD
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [7.22.3] - 2018-09-21
+<<<<<<< HEAD
 ### Fixed
 - Infinity calls when using `fetchWithRetry` in `initializeSession` and `patchSession`.
+=======
+>>>>>>> Release v7.22.3
 
 ## [7.22.2] - 2018-9-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [7.22.4] - 2018-09-21
 
 ## [7.22.3] - 2018-09-21
-<<<<<<< HEAD
 ### Fixed
 - Infinity calls when using `fetchWithRetry` in `initializeSession` and `patchSession`.
-=======
->>>>>>> Release v7.22.3
 
 ## [7.22.2] - 2018-9-19
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.22.3",
+  "version": "7.22.4",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -10,6 +10,7 @@ import {generateHash} from './generateHash'
 import {cachingLink} from './links/cachingLink'
 import {createIOFetchLink} from './links/ioFetchLink'
 import {omitTypenameLink} from './links/omitVariableTypenameLink'
+import {persistedQueryVersionLink} from './links/persistedQueryVersionLink'
 import {createUriSwitchLink} from './links/uriSwitchLink'
 import {versionSplitterLink} from './links/versionSplitterLink'
 
@@ -78,9 +79,19 @@ export const getClient = (runtime: RenderRuntime, baseURI: string, runtimeContex
 
     const uriSwitchLink = createUriSwitchLink(baseURI, workspace)
 
-    const link = cacheControl
-      ? ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink, cachingLink(cacheControl), fetcherLink])
-      : ApolloLink.from([omitTypenameLink, versionSplitterLink, runtimeContextLink, ensureSessionLink, persistedQueryLink, uriSwitchLink, fetcherLink])
+    const cacheLink = cacheControl ? [cachingLink(cacheControl)] : []
+
+    const link = ApolloLink.from([
+      omitTypenameLink,
+      versionSplitterLink,
+      runtimeContextLink,
+      ensureSessionLink,
+      persistedQueryLink,
+      persistedQueryVersionLink,
+      uriSwitchLink,
+      ...cacheLink,
+      fetcherLink
+    ])
 
     clientsByWorkspace[`${account}/${workspace}`] = new ApolloClient({
       cache: canUseDOM ? cache.restore(window.__STATE__) : cache,

--- a/react/utils/client/links/persistedQueryVersionLink.ts
+++ b/react/utils/client/links/persistedQueryVersionLink.ts
@@ -1,0 +1,23 @@
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
+import { ArgumentNode, BREAK, visit } from 'graphql'
+
+const persistedQueryVersion = (extensions: any) =>
+  extensions && extensions.persistedQuery && extensions.persistedQuery.version
+
+export const persistedQueryVersionLink = new ApolloLink((operation: Operation, forward?: NextLink) => {
+  const {extensions, query} = operation
+  const version = persistedQueryVersion(extensions)
+  if (version) {
+    let senderApp
+    visit(query, {
+      Argument(node: ArgumentNode) {
+        if (node.name.value === 'sender') {
+          senderApp = (node.value as any).value
+          return BREAK
+        }
+      }
+    })
+    extensions.persistedQuery.version = senderApp || version
+  }
+  return forward ? forward(operation) : null
+})


### PR DESCRIPTION
This PR replaces the Apollo persisted query version from 1 to the app that is sending that specific request. It does so with the help of an apollo link strategically placed after an Apollo's `PersistedQueryLink` and replacing it's content with the app available inside the query