### PR TITLE
Log component error only to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.27.1] - 2018-10-05
+
 ## [7.27.0] - 2018-10-04
 
 ## [7.26.0] - 2018-10-2

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.27.0",
+  "version": "7.27.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/start.ts
+++ b/react/start.ts
@@ -5,6 +5,7 @@ if (canUseDOM && window.__RUNTIME__.production) {
   const { config = null, version = '' } = window.__RUNTIME__.runtimeMeta || {}
   const dsn = config && config.sentryDSN
   Sentry.init({
+    beforeSend: (event: Sentry.SentryEvent) => event.tags && event.tags.component ? event : null,
     defaultIntegrations: true,
     dsn,
     environment: canUseDOM ? 'browser' : 'ssr',


### PR DESCRIPTION
We will soon exceed our quota in sentry.io. 

This PR makes the runtime to log component related errors only