### PR TITLE
Feature - Page context

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -563,7 +563,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.setState({
       extensions: {
         ...extensions,
-        [name]: extension,
+        [name]: {
+          ...extensions[name],
+          component: extension.component,
+          props: extension.props,
+        },
       },
     }, () => {
       if (name !== 'store/__overlay') {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -42,6 +42,7 @@ export interface RenderProviderState {
   appsEtag: RenderRuntime['appsEtag']
   cacheHints: RenderRuntime['cacheHints']
   components: RenderRuntime['components']
+  context: RenderRuntime['context']
   culture: RenderRuntime['culture']
   device: ConfigurationDevice
   extensions: RenderRuntime['extensions']
@@ -62,6 +63,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
     account: PropTypes.string,
     components: PropTypes.object,
+    context: PropTypes.object,
     culture: PropTypes.object,
     device: PropTypes.string,
     emitter: PropTypes.object,
@@ -107,7 +109,20 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   constructor(props: Props) {
     super(props)
-    const { appsEtag, cacheHints, culture, messages, components, extensions, pages, page, query, production, settings } = props.runtime
+    const {
+      appsEtag,
+      cacheHints,
+      context,
+      culture,
+      messages,
+      components,
+      extensions,
+      pages,
+      page,
+      query,
+      production,
+      settings,
+    } = props.runtime
     const { history, baseURI, cacheControl } = props
     const path = canUseDOM ? window.location.pathname : window.__pathname__
     const route = props.runtime.route || getRouteFromPath(path, pages)
@@ -129,6 +144,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
+      context,
       culture,
       device: 'any',
       extensions,
@@ -182,15 +198,24 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     }
   }
 
-
   public getChildContext() {
     const { history, runtime } = this.props
-    const { components, extensions, page, pages, culture, device, route } = this.state
+    const {
+      components,
+      context,
+      extensions,
+      page,
+      pages,
+      culture,
+      device,
+      route,
+    } = this.state
     const { account, emitter, hints, production, workspace } = runtime
 
     return {
       account,
       components,
+      context,
       culture,
       device,
       emitter,
@@ -333,6 +358,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
+      context,
       extensions,
       messages,
       pages,
@@ -350,6 +376,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         appsEtag,
         cacheHints,
         components,
+        context,
         extensions,
         loadingRoute: null,
         messages,
@@ -466,6 +493,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
+      context,
       extensions,
       messages,
       pages,
@@ -475,6 +503,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         appsEtag,
         cacheHints,
         components,
+        context,
         extensions,
         messages,
         page,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -42,13 +42,13 @@ export interface RenderProviderState {
   appsEtag: RenderRuntime['appsEtag']
   cacheHints: RenderRuntime['cacheHints']
   components: RenderRuntime['components']
-  context: RenderRuntime['context']
   culture: RenderRuntime['culture']
   device: ConfigurationDevice
   extensions: RenderRuntime['extensions']
   loadingRoute: string | null
   messages: RenderRuntime['messages']
   page: RenderRuntime['page']
+  pageContext: RenderRuntime['pageContext']
   pages: RenderRuntime['pages']
   production: RenderRuntime['production']
   query: RenderRuntime['query']
@@ -63,7 +63,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
     account: PropTypes.string,
     components: PropTypes.object,
-    context: PropTypes.object,
     culture: PropTypes.object,
     device: PropTypes.string,
     emitter: PropTypes.object,
@@ -76,6 +75,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     navigate: PropTypes.func,
     onPageChanged: PropTypes.func,
     page: PropTypes.string,
+    pageContext: PropTypes.object,
     pages: PropTypes.object,
     patchSession: PropTypes.func,
     prefetchPage: PropTypes.func,
@@ -112,13 +112,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const {
       appsEtag,
       cacheHints,
-      context,
       culture,
       messages,
       components,
       extensions,
-      pages,
       page,
+      pageContext,
+      pages,
       query,
       production,
       settings,
@@ -144,13 +144,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
-      context,
       culture,
       device: 'any',
       extensions,
       loadingRoute: null,
       messages,
       page,
+      pageContext,
       pages,
       production,
       query,
@@ -202,9 +202,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const { history, runtime } = this.props
     const {
       components,
-      context,
       extensions,
       page,
+      pageContext,
       pages,
       culture,
       device,
@@ -215,7 +215,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     return {
       account,
       components,
-      context,
       culture,
       device,
       emitter,
@@ -228,6 +227,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       navigate: this.navigate,
       onPageChanged: this.onPageChanged,
       page,
+      pageContext,
       pages,
       patchSession: this.patchSession,
       prefetchPage: this.prefetchPage,
@@ -376,11 +376,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         appsEtag,
         cacheHints,
         components,
-        context,
         extensions,
         loadingRoute: null,
         messages,
         page,
+        pageContext: context,
         pages,
         query,
         route,
@@ -505,10 +505,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         appsEtag,
         cacheHints,
         components,
-        context,
         extensions,
         messages,
         page,
+        pageContext: context,
         pages,
         route,
         settings,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -480,11 +480,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const { runtime: { renderMajor } } = this.props
     const { page, production, culture: { locale }, route } = this.state
     const { pathname } = window.location
+    const { params } = route
 
     return fetchRoutes({
       apolloClient: this.apolloClient,
       locale,
       page,
+      params: JSON.stringify(params),
       path: pathname,
       production,
       renderMajor,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -358,9 +358,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
-      context,
       extensions,
       messages,
+      pageContext,
       pages,
       settings
     }: ParsedPageQueryResponse) => {
@@ -380,7 +380,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         loadingRoute: null,
         messages,
         page,
-        pageContext: context,
+        pageContext,
         pages,
         query,
         route,
@@ -495,9 +495,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       appsEtag,
       cacheHints,
       components,
-      context,
       extensions,
       messages,
+      pageContext,
       pages,
       settings
     }: ParsedPageQueryResponse) => {
@@ -508,7 +508,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         extensions,
         messages,
         page,
-        pageContext: context,
+        pageContext,
         pages,
         route,
         settings,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -119,7 +119,6 @@ declare global {
   interface RenderContext {
     account: RenderRuntime['account'],
     components: RenderRuntime['components'],
-    context: RenderRuntime['context']
     culture: RenderRuntime['culture'],
     device: ConfigurationDevice,
     emitter: RenderRuntime['emitter'],
@@ -132,6 +131,7 @@ declare global {
     navigate: (options: NavigateOptions) => boolean,
     onPageChanged: (location: RenderHistoryLocation) => void,
     page: RenderRuntime['page'],
+    pageContext: RenderRuntime['pageContext']
     pages: RenderRuntime['pages'],
     patchSession: (data?: any) => Promise<void>,
     prefetchPage: (name: string) => void,
@@ -184,7 +184,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface PageQueryResponse {
     componentsJSON: string
-    context: RenderRuntime['context']
+    context: RenderRuntime['pageContext']
     extensionsJSON: string
     messagesJSON: string
     pagesJSON: string
@@ -195,7 +195,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface ParsedPageQueryResponse {
     components: RenderRuntime['components']
-    context: RenderRuntime['context']
+    context: RenderRuntime['pageContext']
     extensions: RenderRuntime['extensions']
     messages: RenderRuntime['messages']
     pages: RenderRuntime['pages']
@@ -251,7 +251,7 @@ interface RenderComponent<P={}, S={}> {
     }
     cacheHints: CacheHintsMap
     segmentToken: string
-    context: PageContext
+    pageContext: PageContext
   }
 
   interface CacheHints {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -119,6 +119,7 @@ declare global {
   interface RenderContext {
     account: RenderRuntime['account'],
     components: RenderRuntime['components'],
+    context: RenderRuntime['context']
     culture: RenderRuntime['culture'],
     device: ConfigurationDevice,
     emitter: RenderRuntime['emitter'],
@@ -144,7 +145,6 @@ declare global {
   }
 
   interface PageContextOptions {
-    scope?: string
     device?: string
     conditions?: string[]
     template?: string
@@ -184,6 +184,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface PageQueryResponse {
     componentsJSON: string
+    context: RenderRuntime['context']
     extensionsJSON: string
     messagesJSON: string
     pagesJSON: string
@@ -194,6 +195,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface ParsedPageQueryResponse {
     components: RenderRuntime['components']
+    context: RenderRuntime['context']
     extensions: RenderRuntime['extensions']
     messages: RenderRuntime['messages']
     pages: RenderRuntime['pages']
@@ -249,6 +251,7 @@ interface RenderComponent<P={}, S={}> {
     }
     cacheHints: CacheHintsMap
     segmentToken: string
+    context: PageContext
   }
 
   interface CacheHints {
@@ -300,5 +303,17 @@ interface RenderComponent<P={}, S={}> {
     Intl: any
     hrtime: NodeJS.Process['hrtime']
     rendered: Promise<RenderedSuccess> | RenderedFailure
+  }
+
+  interface PageContext {
+    id: string
+    type:
+      | 'brand'
+      | 'category'
+      | 'department'
+      | 'product'
+      | 'search'
+      | 'subcategory'
+      | 'url'
   }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -184,7 +184,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface PageQueryResponse {
     componentsJSON: string
-    context: RenderRuntime['pageContext']
+    pageContext: RenderRuntime['pageContext']
     extensionsJSON: string
     messagesJSON: string
     pagesJSON: string
@@ -195,7 +195,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface ParsedPageQueryResponse {
     components: RenderRuntime['components']
-    context: RenderRuntime['pageContext']
+    pageContext: RenderRuntime['pageContext']
     extensions: RenderRuntime['extensions']
     messages: RenderRuntime['messages']
     pages: RenderRuntime['pages']

--- a/react/utils/Page.graphql
+++ b/react/utils/Page.graphql
@@ -8,7 +8,6 @@ query Page (
   $production: Boolean,
   $query: String,
   $renderMajor: Int,
-  $scope: String,
   $template: String,
 ) {
   page(
@@ -21,13 +20,16 @@ query Page (
     production: $production,
     query: $query,
     renderMajor: $renderMajor,
-    scope: $scope,
     template: $template,
   ) {
     appsEtag
     appsSettingsJSON
     cacheHintsJSON
     componentsJSON
+    context {
+      id
+      type
+    }
     extensionsJSON
     messagesJSON
     pagesJSON

--- a/react/utils/Page.graphql
+++ b/react/utils/Page.graphql
@@ -26,12 +26,12 @@ query Page (
     appsSettingsJSON
     cacheHintsJSON
     componentsJSON
-    context {
+    extensionsJSON
+    messagesJSON
+    pageContext {
       id
       type
     }
-    extensionsJSON
-    messagesJSON
     pagesJSON
   }
 }

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -6,6 +6,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     appsSettingsJSON,
     cacheHintsJSON,
     componentsJSON,
+    context,
     extensionsJSON,
     messagesJSON,
     pagesJSON,
@@ -24,6 +25,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     appsEtag,
     cacheHints,
     components,
+    context,
     extensions,
     messages,
     pages,
@@ -41,7 +43,6 @@ export const fetchRoutes = ({
   path,
   production,
   renderMajor,
-  scope,
   template,
 }: FetchRoutesInput) => apolloClient.query<{page: PageQueryResponse}>({
   fetchPolicy: production ? 'cache-first' : 'network-only',
@@ -55,7 +56,6 @@ export const fetchRoutes = ({
     path,
     production,
     renderMajor,
-    scope,
     template,
   }
 }).then<ParsedPageQueryResponse>(({data: {page: pageData}, errors}: PageQueryResult) =>

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -6,9 +6,9 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     appsSettingsJSON,
     cacheHintsJSON,
     componentsJSON,
-    context,
     extensionsJSON,
     messagesJSON,
+    pageContext,
     pagesJSON,
   } = page
 
@@ -25,9 +25,9 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     appsEtag,
     cacheHints,
     components,
-    context,
     extensions,
     messages,
+    pageContext,
     pages,
     settings
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Add context to `RenderProvider` and remove route scope;
- Pass `params` to `fetchRoutes` @ `updateRuntime`;
- Change `updateExtension` behavior to merge old and new configs instead of just overwriting the old ones. The `component` and `props` properties, however, still get overwritten.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The page context must be accessed by Storefront when editing configurations.

#### How should this be manually tested?
Workspace: https://byid--lojadaju.myvtex.com/.

#### Types of changes
- New feature (a non-breaking change which adds functionality)