### PR TITLE
Update iframe messages on locale change and HMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.28.1] - 2018-11-07
 ### Added
 - **`RenderProvider`**
  - Add `this.sendInfoFromIframe` call to `setState` callbacks after locale update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`RenderProvider`**
+ - Add `this.sendInfoFromIframe` call to `setState` callbacks after locale update.
+
+### Fixed
+- **`RenderProvider#getCustomMessage`**
+  - Considers `WrappedComponent` when getting custom message.
 
 ## [7.28.0] - 2018-11-07
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.28.0",
+  "version": "7.28.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -412,8 +412,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     // Current locale is one of the updated ones
     if (locales.indexOf(this.state.culture.locale) !== -1) {
       fetchMessages(this.apolloClient, page, production, locale, renderMajor)
-        .then(messages => {
-          this.setState({ messages })
+        .then(newMessages => {
+          this.setState(prevState => ({
+            ...prevState,
+            messages: { ...prevState.messages, ...newMessages },
+          }), () => {
+            this.sendInfoFromIframe()
+          })
         })
         .catch(e => {
           console.log('Failed to fetch new locale file.')
@@ -432,13 +437,16 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         fetchMessages(this.apolloClient, page, production, locale, renderMajor),
         loadLocaleData(locale),
       ])
-        .then(([messages]) => {
-          this.setState({
+        .then(([newMessages]) => {
+          this.setState(prevState => ({
+            ...prevState,
             culture: {
               ...this.state.culture,
               locale,
             },
-            messages,
+            messages: { ...prevState.messages, ...newMessages },
+          }), () => {
+            this.sendInfoFromIframe()
           })
         })
         .then(() => window.postMessage({ key: 'cookie.locale', body: { locale } }, '*'))

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -163,6 +163,7 @@ declare global {
 interface RenderComponent<P={}, S={}> {
   new(): Component<P,S>
   getCustomMessages?: (locale: string) => any
+  WrappedComponent?: RenderComponent
 }
 
   interface ComponentsRegistry {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Update iframe messages on locale change and HMR.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Outer runtime (running `admin`) had no way to know that the iframe runtime i18n messages changed.

#### How should this be manually tested?
Workspace: https://fixruntimecustommessages--lojadaju.myvtex.com/admin/cms/storefront.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)