### PR TITLE
Fix locale HMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.28.2] - 2018-11-08
+
 ## [7.28.1] - 2018-11-07
 ### Added
 - **`RenderProvider`**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.28.1",
+  "version": "7.28.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -413,9 +413,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const { runtime: { renderMajor } } = this.props
     const { page, production, culture: { locale } } = this.state
 
-    // Current locale is one of the updated ones
-    if (locales.indexOf(this.state.culture.locale) !== -1) {
-      fetchMessages(this.apolloClient, page, production, locale, renderMajor)
+    // Current locale is one or a subset of the updated ones
+    if (locales.indexOf(locale) !== -1 || locales.indexOf(locale.split('-')[0]) !== -1) {
+      fetchMessages(this.apolloClient, page, production, locale, renderMajor, true)
         .then(newMessages => {
           this.setState(prevState => ({
             ...prevState,

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -12,8 +12,8 @@ export const fetchMessagesForApp = (apolloClient: ApolloClient<NormalizedCacheOb
       errors ? Promise.reject(errors) : JSON.parse(data.messages)
     )
 
-export const fetchMessages = (apolloClient: ApolloClient<NormalizedCacheObject>, page: string, production: boolean, locale: string, renderMajor: number) => {
-  return apolloClient.query<{page: PageQueryResponse}>({query: pageMessagesQuery, variables: {page, production, locale, renderMajor}})
+export const fetchMessages = (apolloClient: ApolloClient<NormalizedCacheObject>, page: string, production: boolean, locale: string, renderMajor: number, ignoreCache : boolean = false) => {
+  return apolloClient.query<{ page: PageQueryResponse }>({ query: pageMessagesQuery, variables: { page, production, locale, renderMajor }, fetchPolicy: ignoreCache ? 'no-cache' : 'cache-first' })
     .then<RenderRuntime['messages']>(({data, errors}) =>
       errors ? Promise.reject(errors) : JSON.parse(data.page.messagesJSON)
     )


### PR DESCRIPTION
Locale HMR is not working because:
- Locale comparison is done incorrectly. We are trying to check if `pt` equals `pt-BR`
- GraphQL cache is used by `render-runtime` after update, so it sees no changes.

This PR remove both issues and fixed locale HMR.