### PR TITLE
Fix replace route class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.27.4] - 2018-10-22
+
 ## [7.27.3] - 2018-10-19
 
 ## [7.27.2] - 2018-10-16

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.27.3",
+  "version": "7.27.4",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -257,10 +257,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       Array.prototype.forEach.call(
         containers,
         (e: Element) => {
-          e.classList.add(newRouteClass)
           if (currentRouteClass) {
             e.classList.remove(currentRouteClass)
           }
+          e.classList.add(newRouteClass)
         }
       )
     } catch (e) {


### PR DESCRIPTION
Route class was deleted when navigating from/to routes with same category.
This PR fix this issue. 