### PR TITLE
Above the fold and preview props on LayoutContainer

### DIFF
--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -3,27 +3,49 @@ import React, { Component } from 'react'
 
 import ExtensionPoint from './ExtensionPoint'
 
-type Element = string | any[]
+type Element = string | ElementArray
+interface ElementArray extends Array<Element> {}
 
 interface LayoutContainerProps {
-  elements: Element[]
+  aboveTheFold?: number
+  elements: Element
 }
 
 interface ContainerProps {
+  aboveTheFold?: number
   elements: Element
   isRow: boolean
 }
 
+interface ContainerState {
+  elementsToRender: number
+}
+
 const elementPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired
 
-class Container extends Component<ContainerProps> {
+class Container extends Component<ContainerProps, ContainerState> {
   public static propTypes = {
+    aboveTheFold: PropTypes.number,
     elements: elementPropType,
     isRow: PropTypes.bool
   }
 
+  public constructor(props: ContainerProps) {
+    super(props)
+    const { aboveTheFold } = this.props
+    this.state = {
+      elementsToRender: aboveTheFold != null
+        ? aboveTheFold
+        : this.props.elements.length
+    }
+  }
+
+  public componentDidMount() {
+    this.setState({ elementsToRender: this.props.elements.length })
+  }
+
   public render() {
-    const { isRow, elements, children, ...props } = this.props
+    const { isRow, elements, children, aboveTheFold, ...props } = this.props
 
     const className = `flex flex-grow-1 w-100 ${isRow ? 'flex-row' : 'flex-column'}`
     if (typeof elements === 'string') {
@@ -37,9 +59,9 @@ class Container extends Component<ContainerProps> {
       )
     }
 
-    const returnValue: JSX.Element[] = elements.map((element: Element) => {
+    const returnValue: JSX.Element[] = elements.slice(0, this.state.elementsToRender).map((element: Element) => {
       return (
-        <Container key={element.toString()} elements={element} isRow={!isRow} {...props} >
+        <Container key={element.toString()} elements={element} isRow={!isRow} {...props}>
           {children}
         </Container>
       )
@@ -56,7 +78,8 @@ class Container extends Component<ContainerProps> {
 // tslint:disable-next-line
 class LayoutContainer extends Component<LayoutContainerProps> {
   public static propTypes = {
-    elements: elementPropType
+    aboveTheFold: PropTypes.number,
+    elements: elementPropType,
   }
 
   public render() {

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -9,12 +9,14 @@ interface ElementArray extends Array<Element> {}
 interface LayoutContainerProps {
   aboveTheFold?: number
   elements: Element
+  preview?: boolean
 }
 
 interface ContainerProps {
   aboveTheFold?: number
   elements: Element
   isRow: boolean
+  preview?: boolean
 }
 
 interface ContainerState {
@@ -27,7 +29,8 @@ class Container extends Component<ContainerProps, ContainerState> {
   public static propTypes = {
     aboveTheFold: PropTypes.number,
     elements: elementPropType,
-    isRow: PropTypes.bool
+    isRow: PropTypes.bool,
+    preview: PropTypes.bool,
   }
 
   public constructor(props: ContainerProps) {
@@ -41,11 +44,13 @@ class Container extends Component<ContainerProps, ContainerState> {
   }
 
   public componentDidMount() {
-    this.setState({ elementsToRender: this.props.elements.length })
+    if (!this.props.preview) {
+      this.setState({ elementsToRender: this.props.elements.length })
+    }
   }
 
   public render() {
-    const { isRow, elements, children, aboveTheFold, ...props } = this.props
+    const { isRow, elements, children, aboveTheFold, preview, ...props } = this.props
 
     const className = `flex flex-grow-1 w-100 ${isRow ? 'flex-row' : 'flex-column'}`
     if (typeof elements === 'string') {
@@ -80,6 +85,7 @@ class LayoutContainer extends Component<LayoutContainerProps> {
   public static propTypes = {
     aboveTheFold: PropTypes.number,
     elements: elementPropType,
+    preview: PropTypes.bool,
   }
 
   public render() {


### PR DESCRIPTION
Completing @firstdoit work on above the fold.

If the `aboveTheFold : number` prop is set on any `LayoutContainer` it'll render only it's first `aboveTheFold` elements on the server side. Once the component is rendered on client side it'll render the other elements.

The last commit introduces the `preview : boolean` prop. If set to `true`, it won't render elements that are below the fold on the client side.

@brunoabreu and @tlgimenes, I'm not sure we'll need the preview prop. I've added it anyway and if we don't need it I'll just strip the commit.