### PR TITLE
Fix scroll related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.28.0] - 2018-11-07
+
 ## [7.27.4] - 2018-10-22
 
 ## [7.27.3] - 2018-10-19

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.27.4",
+  "version": "7.28.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -19,7 +19,7 @@ import { traverseComponent } from '../utils/components'
 import { RENDER_CONTAINER_CLASS, ROUTE_CLASS_PREFIX, routeClass } from '../utils/dom'
 import { loadLocaleData } from '../utils/locales'
 import { createLocaleCookie, fetchMessages, fetchMessagesForApp } from '../utils/messages'
-import { getRouteFromPath, navigate as pageNavigate, NavigateOptions } from '../utils/pages'
+import { getRouteFromPath, navigate as pageNavigate, NavigateOptions, scrollTo as pageScrollTo } from '../utils/pages'
 import { fetchRoutes } from '../utils/routes'
 import { initializeSession, patchSession } from '../utils/session'
 import { TreePathContext } from '../utils/treePath'
@@ -275,7 +275,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       }
 
       const options = scrollOptions || { top: 0, left: 0 }
-      setTimeout(() => window.scrollTo(options), 0)
+      setTimeout(() => pageScrollTo(options), 0)
     }
     catch (e) {
       console.warn('Failed to scroll after page navigation.')

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -358,7 +358,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         query,
         route,
         settings,
-      }, () => this.afterPageChanged(page))
+      }, () => this.afterPageChanged(page, state.scrollOptions))
     })
   }
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -125,6 +125,17 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
   return false
 }
 
+export function scrollTo(options: ScrollToOptions) {
+  try {
+    window.scrollTo(options)
+  }
+  catch (e) {
+    const x = options.left == null ? window.scrollX : options.left
+    const y = options.top == null ? window.scrollY : options.top
+    window.scrollTo(x,y)
+  }
+}
+
 function routeIdFromPath(path: string, routes: Pages) {
   let id: string | undefined
   let score: number


### PR DESCRIPTION
There are two bug fixes here. This version is linked [here](https://fixscrolltopolyfill--boticario.myvtex.com/).

# Boticario legacy bug
There's a bug report where, in an old chrome version, people would click links that should result in a `window.scrollTo({left: 0, top: 0})` call but don't. That happens because on those versions (60 or less) the `window.scrollTo` function with an object, like that, doesn't exist, the only available is `window.scrollTo(x,y)`. This pull request fixes that bug.

## Testing
The bug was verified through [browserling](https://www.browserling.com/) and the fix was tested both there and by the person who reported the bug.

# Avoid ignoring scrolloptions
When the page should scroll, if `shouldFetchNavigationData` is true, the `afterPageChanged` function called was not passing the `scrollOptions` through.

This second fix also depends on some [fixes on the `boticario` repo](https://bitbucket.org/corebiz_ag/boticario-store/branch/fix/extra-scroll) itself which are linked in the same workspace.

## Testing
On [the account page](https://www.boticario.com.br/account/summary) in production, switching modes, from "About me" to "Orders", for example, causes a scroll. We don't want it to, the `LinkRouter` component reffering to those tabs has a `scrollOptions={false}`, on the [linked workspace](https://fixscrolltopolyfill--boticario.myvtex.com/account/orders) it works correctly.