### PR TITLE
Feature/preview above the fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.31.0] - 2018-11-30
+
 ## [7.30.0] - 2018-11-30
 
 ## [7.29.1] - 2018-11-22

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.30.0",
+  "version": "7.31.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -93,11 +93,16 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       query,
     }
 
+    let loading = null
+    if (runtime.preview) {
+      loading = <Loading runtime={runtime} />
+    }
+
     return component
       ? <TreePathContext.Provider value={{ treePath: newTreePath }}>
         <ExtensionPointComponent component={component} props={props} runtime={runtime} treePath={newTreePath}>{children}</ExtensionPointComponent>
       </TreePathContext.Provider>
-      : <Loading runtime={runtime}/>
+      : loading
   }
 
   private addDataToElementIfEditable = () => {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -49,6 +49,7 @@ export interface RenderProviderState {
   messages: RenderRuntime['messages']
   page: RenderRuntime['page']
   pages: RenderRuntime['pages']
+  preview: RenderRuntime['preview']
   production: RenderRuntime['production']
   query: RenderRuntime['query']
   settings: RenderRuntime['settings']
@@ -98,6 +99,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     patchSession: PropTypes.func,
     prefetchDefaultPages: PropTypes.func,
     prefetchPage: PropTypes.func,
+    preview: PropTypes.bool,
     production: PropTypes.bool,
     route: PropTypes.object,
     setDevice: PropTypes.func,
@@ -157,6 +159,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       messages,
       page,
       pages,
+      preview: false,
       production,
       query,
       route,
@@ -205,7 +208,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public getChildContext() {
     const { history, runtime } = this.props
-    const { components, extensions, page, pages, culture, device, route, defaultExtensions } = this.state
+    const { components, extensions, page, pages, preview, culture, device, route, defaultExtensions } = this.state
     const { account, emitter, hints, production, workspace } = runtime
 
     return {
@@ -228,6 +231,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       patchSession: this.patchSession,
       prefetchDefaultPages: this.prefetchDefaultPages,
       prefetchPage: this.prefetchPage,
+      preview,
       production,
       route,
       setDevice: this.handleSetDevice,
@@ -339,6 +343,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.setState({
       extensions: replaceExtensionsWithDefault(this.state.extensions, page, defaultExtensions),
       page,
+      preview: true,
       query,
       route
     }, () => {
@@ -385,6 +390,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         messages,
         page,
         pages,
+        preview: false,
         query,
         route,
         settings,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -138,6 +138,7 @@ declare global {
     pages: RenderRuntime['pages'],
     patchSession: (data?: any) => Promise<void>,
     prefetchPage: (name: string) => void,
+    preview: RenderRuntime['preview'],
     production: RenderRuntime['production'],
     setDevice: (device: ConfigurationDevice) => void,
     updateComponentAssets: (availableComponents: Components) => void,
@@ -266,6 +267,7 @@ interface RenderComponent<P={}, S={}> {
     culture: Culture
     pages: Pages
     extensions: Extensions
+    preview: boolean
     production: boolean
     publicEndpoint: string
     messages: Record<string, string>


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Rebased the following PRs related to the above the fold feature: https://github.com/vtex-apps/render-runtime/pull/158, https://github.com/vtex-apps/render-runtime/pull/157. Please, attention if you change the branches of these PRs.
- Added a preview flag as a state in RenderProvider.
- Fixed the loading issue with undefined components.

Maybe we should add the following behavior: add a loading component indicating that the specific template is being fetched.
What do you think?

#### How should this be manually tested?
Add the "aboveTheFold": number prop in the product template of dreamstore.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
