### PR TITLE
Feature/path from route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.35.0] - 2018-12-03
+
 ## [7.34.3] - 2018-12-03
 ### Fixed
 - Fix workspace not being passed when changing url host to vteximg

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.34.3",
+  "version": "7.35.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/NestedExtensionPoints.tsx
+++ b/react/components/NestedExtensionPoints.tsx
@@ -5,6 +5,7 @@ import React, {PureComponent} from 'react'
 import {getPageParams} from '../utils/pages'
 import ExtensionPoint from './ExtensionPoint'
 
+import Loading from './Loading'
 import MaybeAuth from './MaybeAuth'
 import MaybeContext from './MaybeContext'
 import {RenderContext} from './RenderContext'

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -322,7 +322,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public onPageChanged = (location: RenderHistoryLocation) => {
     const { runtime: { renderMajor } } = this.props
     const { culture: { locale }, pages: pagesState, production, device, defaultExtensions } = this.state
-    const { pathname, state } = location
+    const { state } = location
 
     // Make sure this is our navigation
     if (!state || !state.renderRouting) {
@@ -330,7 +330,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     }
 
     const { route } = state
-    const { id: page, params } = route
+    const { id: page, params, path } = route
     const shouldFetchNavigationData = page.startsWith('store') || pagesState[page] && pagesState[page].conditional
     const query = parse(location.search.substr(1))
 
@@ -364,7 +364,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       locale,
       page,
       params: JSON.stringify(params),
-      path: pathname,
+      path,
       production,
       renderMajor,
     }).then(({


### PR DESCRIPTION
Runtime should not pick the path directly from the browser's history, but from the route. By applying this change, we will be able to replace the browser's history and show canonical routes, instead of system ones. To understand more about what this PR will enable, please check [this PR](https://github.com/vtex-apps/store/pull/118)