### PR TITLE
Avoid MaybeAuth navigate to the login page when it is already navigating to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid `MaybeAuth` navigate to the login page when it is already navigating to it.
 
 ## [7.28.2] - 2018-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.28.3] - 2018-11-14
 ### Fixed
 - Avoid `MaybeAuth` navigate to the login page when it is already navigating to it.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.28.2",
+  "version": "7.28.3",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/MaybeAuth.tsx
+++ b/react/components/MaybeAuth.tsx
@@ -32,7 +32,7 @@ export default class MaybeAuth extends PureComponent<Props, State> {
   }
 
   public redirectToLogin() {
-    const pathName = this.props.page.replace('store', '')
+    const pathName = window.location.pathname.replace(/\/$/, '')
     if (this.props.page !== 'store/login' && pathName !== LOGIN_PATH) {
       this.props.navigate({
         fallbackToWindowLocation: false,

--- a/react/components/MaybeAuth.tsx
+++ b/react/components/MaybeAuth.tsx
@@ -32,8 +32,8 @@ export default class MaybeAuth extends PureComponent<Props, State> {
   }
 
   public redirectToLogin() {
-    if (this.props.page !== 'store/login') {
-      const pathName = window.location.pathname.replace(/\/$/, '')
+    const pathName = this.props.page.replace('store', '')
+    if (this.props.page !== 'store/login' && pathName !== LOGIN_PATH) {
       this.props.navigate({
         fallbackToWindowLocation: false,
         to: LOGIN_PATH,


### PR DESCRIPTION
Before, when the user not logged went to account page, it redirected to the login page and the returnUrl was setted to the login page instead of the account one. So I fixed it. [Check it out.](https://waza--storecomponents.myvtex.com/)