### PR TITLE
Create flag to update runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.28.4] - 2018-11-16
+
 ## [7.28.3] - 2018-11-14
 ### Fixed
 - Avoid `MaybeAuth` navigate to the login page when it is already navigating to it.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.28.3",
+  "version": "7.28.4",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -95,10 +95,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     runtime: PropTypes.object,
   }
 
-  public sendInfoFromIframe = debounce(() => {
+  public sendInfoFromIframe = debounce((shouldUpdateRuntime?: boolean) => {
     if (isStorefrontIframe) {
       const { messages } = this.state
-      window.top.__provideRuntime(this.getChildContext(), messages)
+      window.top.__provideRuntime(this.getChildContext(), messages, shouldUpdateRuntime)
     }
   }, SEND_INFO_DEBOUNCE_MS)
 
@@ -397,7 +397,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     const messagesPromises = Promise.all(unfetchedApps.map(app => fetchMessagesForApp(this.apolloClient, app, locale)))
     const assetsPromise = fetchAssets(assets)
-    assetsPromise.then(this.sendInfoFromIframe)
+    assetsPromise.then(() => {
+      this.sendInfoFromIframe(true)
+    })
 
     return Promise.all([messagesPromises, assetsPromise]).then(([messages]) => {
       this.setState({
@@ -421,7 +423,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             ...prevState,
             messages: { ...prevState.messages, ...newMessages },
           }), () => {
-            this.sendInfoFromIframe()
+            this.sendInfoFromIframe(true)
           })
         })
         .catch(e => {
@@ -450,7 +452,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             },
             messages: { ...prevState.messages, ...newMessages },
           }), () => {
-            this.sendInfoFromIframe()
+            this.sendInfoFromIframe(true)
           })
         })
         .then(() => window.postMessage({ key: 'cookie.locale', body: { locale } }, '*'))

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -294,7 +294,7 @@ interface RenderComponent<P={}, S={}> {
     __REQUEST_ID__: string
     __APP_ID__: string
     __hasPortals__: boolean
-    __provideRuntime: (runtime: RenderContext | null, messages?: Record<string, string>) => void
+    __provideRuntime: (runtime: RenderContext | null, messages?: Record<string, string>, shouldUpdateRuntime?: boolean) => void
     browserHistory: History
     ReactIntlLocaleData: any
     IntlPolyfill: any


### PR DESCRIPTION
This PR fixes the component editor form UX.

The flag was necessary because otherwise we were needlessly updating the whole application and making the UX really terrible.