### PR TITLE
Scroll element into view when elementId is passed to scroll options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `baseElementId` to navigate to allow scroll relative to an element.
 
 ## [7.28.5] - 2018-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.29.0] - 2018-11-22
 ### Added
 - Add `baseElementId` to navigate to allow scroll relative to an element.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.29.1] - 2018-11-22
+
 ## [7.29.0] - 2018-11-22
 ### Added
 - Add `baseElementId` to navigate to allow scroll relative to an element.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.28.5",
+  "version": "7.29.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -78,7 +78,11 @@ declare global {
     id: string
   }
 
-  type RenderScrollOptions = ScrollToOptions | false
+  interface RenderScrollToOptions extends ScrollToOptions {
+    elementId?: string
+  }
+
+  type RenderScrollOptions = RenderScrollToOptions | false
 
   interface RenderHistoryLocation extends Location {
     state?: {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -78,11 +78,11 @@ declare global {
     id: string
   }
 
-  interface RenderScrollToOptions extends ScrollToOptions {
-    elementId?: string
+  interface RelativeScrollToOptions extends ScrollToOptions {
+    baseElementId?: string
   }
 
-  type RenderScrollOptions = RenderScrollToOptions | false
+  type RenderScrollOptions = RelativeScrollToOptions | false
 
   interface RenderHistoryLocation extends Location {
     state?: {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,7 +1,6 @@
 import {canUseDOM} from 'exenv'
 import {History, LocationDescriptorObject} from 'history'
 import * as RouteParser from 'route-parser'
-import { element } from 'prop-types';
 
 const EMPTY_OBJECT = Object.freeze && Object.freeze({}) || {}
 
@@ -126,23 +125,29 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
   return false
 }
 
-export function scrollTo(options: RenderScrollToOptions) {
-  const { elementId } = options
-  if (elementId) {
-    const scrollAnchor = document.querySelector(`#${elementId}`)
-    if (scrollAnchor) {
-      scrollAnchor.scrollIntoView()
-      return
-    }
+export function scrollTo(options: RelativeScrollToOptions) {
+  const { baseElementId } = options
+  const scrollAnchor = baseElementId && document.querySelector(`#${baseElementId}`)
+
+  if (!scrollAnchor) {
+    return polyfillScrollTo(options)
   }
 
+  const { top, left } = scrollAnchor.getBoundingClientRect()
+  polyfillScrollTo({
+    left: left + window.scrollX + (options.left || 0),
+    top: top + window.scrollY + (options.top || 0)
+  })
+}
+
+function polyfillScrollTo(options: ScrollToOptions) {
   try {
     window.scrollTo(options)
   }
   catch (e) {
     const x = options.left == null ? window.scrollX : options.left
     const y = options.top == null ? window.scrollY : options.top
-    window.scrollTo(x,y)
+    window.scrollTo(x, y)
   }
 }
 
@@ -178,6 +183,6 @@ export interface NavigateOptions {
   params?: any
   query?: any
   to?: string
-  scrollOptions?: ScrollOptions
+  scrollOptions?: RenderScrollOptions
   fallbackToWindowLocation?: boolean
 }

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -126,7 +126,7 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
 }
 
 export function scrollTo(options: RelativeScrollToOptions) {
-  const { baseElementId } = options
+  const { baseElementId = null } = options || {}
   const scrollAnchor = baseElementId && document.querySelector(`#${baseElementId}`)
 
   if (!scrollAnchor) {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,6 +1,7 @@
 import {canUseDOM} from 'exenv'
 import {History, LocationDescriptorObject} from 'history'
 import * as RouteParser from 'route-parser'
+import { element } from 'prop-types';
 
 const EMPTY_OBJECT = Object.freeze && Object.freeze({}) || {}
 
@@ -125,7 +126,16 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
   return false
 }
 
-export function scrollTo(options: ScrollToOptions) {
+export function scrollTo(options: RenderScrollToOptions) {
+  const { elementId } = options
+  if (elementId) {
+    const scrollAnchor = document.querySelector(`#${elementId}`)
+    if (scrollAnchor) {
+      scrollAnchor.scrollIntoView()
+      return
+    }
+  }
+
   try {
     window.scrollTo(options)
   }


### PR DESCRIPTION
Allow scroll after navigate to target elements and not just absolute positions.