### PR TITLE
Adding eventsource-polyfill as dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.32.0] - 2018-11-30
+
 ## [7.32.0-beta] - 2018-11-30
 
 ## [7.31.0] - 2018-11-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.32.0-beta] - 2018-11-30
+
 ## [7.31.0] - 2018-11-30
 
 ## [7.30.0] - 2018-11-30

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.31.0",
+  "version": "7.32.0-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.32.0-beta",
+  "version": "7.32.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/package.json
+++ b/react/package.json
@@ -51,6 +51,7 @@
     "@types/react-hot-loader": "^4.1.0",
     "@types/react-intl": "^2.3.5",
     "@types/route-parser": "^0.1.1",
+    "eventsource-polyfill": "^0.9.6",
     "tslint": "^5.2.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.1.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -396,6 +396,10 @@ eventemitter3@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.0.1.tgz#4ce66c3fc5b5a6b9f2245e359e1938f1ab10f960"
 
+eventsource-polyfill@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz#10e0d187f111b167f28fdab918843ce7d818f13c"
+
 exenv@^1.2.1, exenv@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"


### PR DESCRIPTION
`eventsource-polyfill` was being used by a dependency leak in builder-hub. After version 0.45.0, there are no more dependency leaks, and thus, the necessity of adding this library. Since it is only used in dev time for hot module replacement, this dependency is added as a `devDependency`