### PR TITLE
Forbid external links to receive current window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Fetch components assets from `vteximg`.
+- Make sure links with target="_blank" have rel="noopener"
 
 ## [7.33.0] - 2018-12-01
 

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -104,6 +104,16 @@ function start() {
     const ReactCreateElement = React.createElement
     const vtexImgHost = getVTEXImgHost(runtime.account)
     React.createElement = function patchedCreateElement (type: any, props: any) {
+      if (type === 'a') {
+        if (props.target && !props.href) {
+          props.target = undefined
+        }
+        // Follow Google's security recommendations concerning target blank
+        // https://developers.google.com/web/tools/lighthouse/audits/noopener
+        if (props.target === '_blank' && !(props.rel === 'noopener' || props.rel === 'noreferrer')) {
+          props.rel = 'noopener'
+        }
+      }
       if (type === 'img') {
         props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
       }


### PR DESCRIPTION
Adds `rel="noopener"` for any `target="_blank"` anchors.

Read more: https://developers.google.com/web/tools/lighthouse/audits/noopener

![image](https://user-images.githubusercontent.com/1633518/49342948-a5878380-f648-11e8-993e-d67628f5a0b5.png)
