### PR TITLE
Fix/infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.0-beta] - 2018-12-04
+
 ## [7.35.0] - 2018-12-03
 
 ## [7.34.3] - 2018-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.0-beta.0] - 2018-12-04
+
 ## [7.36.0-beta] - 2018-12-04
 
 ## [7.35.0] - 2018-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.0] - 2018-12-04
+
 ## [7.36.0-beta.0] - 2018-12-04
 
 ## [7.36.0-beta] - 2018-12-04

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.0-beta",
+  "version": "7.36.0-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.35.0",
+  "version": "7.36.0-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.0-beta.0",
+  "version": "7.36.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -69,12 +69,10 @@ class ExtensionPointComponent extends PureComponent<
     // Let's fetch the assets and re-render.
     if (component && !Component) {
       // Prevent looping indefinitely after failing to fetch assets
-      if (componentPromiseMap.hasOwnProperty(component)) {
+      if (component in componentPromiseMap) {
         throw new Error(`Unable to fetch component ${component}`)
       } else {
-        if (!componentPromiseMap[component]) {
-          componentPromiseMap[component] = fetchComponent(component)
-        }
+        componentPromiseMap[component] = fetchComponent(component)
         componentPromiseMap[component].then(() => this.updateComponentsWithEvent(component))
       }
     }

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -68,10 +68,15 @@ class ExtensionPointComponent extends PureComponent<
 
     // Let's fetch the assets and re-render.
     if (component && !Component) {
-      if (!componentPromiseMap[component]) {
-        componentPromiseMap[component] = fetchComponent(component)
+      // Prevent looping indefinitely after failing to fetch assets
+      if (componentPromiseMap.hasOwnProperty(component)) {
+        throw new Error(`Unable to fetch component ${component}`)
+      } else {
+        if (!componentPromiseMap[component]) {
+          componentPromiseMap[component] = fetchComponent(component)
+        }
+        componentPromiseMap[component].then(() => this.updateComponentsWithEvent(component))
       }
-      componentPromiseMap[component].then(() => this.updateComponentsWithEvent(component))
     }
   }
 

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -1,5 +1,6 @@
 function getExtension(path: string) {
-  const result = /\.\w+$/.exec(path)
+  const adjPath = path.split('?')[0]
+  const result = /\.\w+$/.exec(adjPath)
   return result ? result[0] : ''
 }
 


### PR DESCRIPTION
This PR:
- fixes the `isScript` check when URLs from `vteximg` host may have querystrings
- prevents an infinite loop in `ExtensionPointComponent`'s `fetchAndRerender` is repeatedly unable to `getImplementation` for the component