### PR TITLE
Do not throw error until fetchComponent promise has been resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.1] - 2018-12-04
+
 ## [7.36.0] - 2018-12-04
 
 ## [7.36.0-beta.0] - 2018-12-04

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.0",
+  "version": "7.36.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",


### PR DESCRIPTION
This PR fixes displaying an error message before the fetched script has been executed - specifically, before the component has registered itself to the `__RENDER_7_COMPONENTS__` global variable. Apparently, this happens because we may re-enter `componentDidUpdate` several times before the component script has been fetched/executed.

Therefore, this PR displays an error message only when both:
- the promise for fetching the script has been resolved
- there was still no corresponding implementation for the component