### PR TITLE
Fix/bugs from previous versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.2-beta.0] - 2018-12-06
+
 ## [7.36.2-beta] - 2018-12-05
 
 ## [7.36.1] - 2018-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.2] - 2018-12-10
+
 ## [7.36.2-beta.0] - 2018-12-06
 
 ## [7.36.2-beta] - 2018-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.36.2-beta] - 2018-12-05
+
 ## [7.36.1] - 2018-12-04
 
 ## [7.36.0] - 2018-12-04

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.1",
+  "version": "7.36.2-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.2-beta",
+  "version": "7.36.2-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.36.2-beta.0",
+  "version": "7.36.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -387,7 +387,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       this.setState({
         appsEtag,
         cacheHints,
-        components,
+        components: {...this.state.components, ...components},
         extensions,
         messages,
         page,
@@ -431,7 +431,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     }))
 
     this.setState(({components, messages}) => ({
-      components: {...defaultComponents, ...components},
+      components: {...defaultComponents, ...this.state.components, ...components},
       defaultExtensions,
       messages: {...defaultMessages, ...messages}
     }))

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -387,9 +387,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       this.setState({
         appsEtag,
         cacheHints,
-        components: {...this.state.components, ...components},
-        extensions,
-        messages,
+        components: { ...this.state.components, ...components },
+        extensions: { ...this.state.extensions, ...extensions},
+        messages: { ...this.state.messages, ...messages },
         page,
         pages,
         preview: false,
@@ -433,7 +433,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.setState(({components, messages}) => ({
       components: {...defaultComponents, ...this.state.components, ...components},
       defaultExtensions,
-      messages: {...defaultMessages, ...messages}
+      messages: {...defaultMessages, ...this.state.messages, ...messages}
     }))
   }
 

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -12,9 +12,9 @@ export const getVTEXImgHost = (account: string) => {
   return `https://${account}.vteximg.com.br`
 }
 
-const getAbsoluteURL = (account: string, url: string, workspace: string, production: boolean) => {
+const getAbsoluteURL = (account: string, url: string, production: boolean) => {
   return isRelative(url) && production
-    ? `${getVTEXImgHost(account)}${url}?workspace=${workspace}`
+    ? `${getVTEXImgHost(account)}${url}`
     : url
 }
 
@@ -132,8 +132,8 @@ export function getExtensionImplementation<P={}, S={}>(extensions: Extensions, n
 }
 
 export function fetchAssets(runtime: RenderRuntime, assets: string[]) {
-  const { account, workspace, production } = runtime
-  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, workspace, production))
+  const { account, production } = runtime
+  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, production))
   const existingScripts = getExistingScriptSrcs()
   const existingStyles = getExistingStyleHrefs()
   const scripts = absoluteAssets.filter((a) => shouldAddScriptToPage(a, existingScripts))
@@ -143,8 +143,8 @@ export function fetchAssets(runtime: RenderRuntime, assets: string[]) {
 }
 
 export function preloadAssets(runtime: RenderRuntime, assets: string[]) {
-  const { account, workspace, production } = runtime
-  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, workspace, production))
+  const { account, production } = runtime
+  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, production))
   const existingScripts = getExistingScriptSrcs()
   const existingStyles = getExistingStyleHrefs()
   const existingPreloads = getExistingPreloadLinks()


### PR DESCRIPTION
This PR follows #182 and #183 (which attempted to fix the infinite loop issue when `render-runtime` was unable to get the `component`'s implementation). The current PR aims at solving a few bugs / issues that were tracked during the past week's investigation:
- Update the `this.state` `components` prop properly. Previously, we could 'lose' some of the components during navigation (because the `setState` update did not account for the previous state's `components` prop). This was causing an issue in the `feed` account.
- Do not account for `workspace` when fetching assets from `vteximg` host. The asset is already determined by the app's name and version (this was causing some assets to be loaded twice, because the URL with a querystring implied a 'new' script in the page). This was observed in `gocommerce`'s admin when the workspace was set at `production` mode.