### PR TITLE
Remove invalid property on anchor tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.38.1] - 2018-12-21
 ### Fixed
 - Removed invalid property on anchor tag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed invalid property on anchor tag.
 
 ## [7.38.0] - 2018-12-17
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.38.0",
+  "version": "7.38.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -49,7 +49,7 @@ class Link extends Component<Props & RenderContextProps> {
   }
 
   public render() {
-    const {page, params, to, scrollOptions, runtime: {pages}, ...linkProps} = this.props
+    const {page, params, to, scrollOptions, query, runtime: {pages}, ...linkProps} = this.props
     const href = to || page && pathFromPageName(page, pages, params) || '#'
     return <a href={href} {...linkProps} onClick={this.handleClick} />
   }


### PR DESCRIPTION
AMP validator is complaining that the anchor tag has an invalid attribute `query`.