### PR TITLE
Changing graphql routes to use new route system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.38.0] - 2018-12-17
+
 ## [7.37.3] - 2018-12-14
 ### Fixed
 - Add again the `crossorigin` attribute now that the store service worker cleans old opaque responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [7.38.0] - 2018-12-17
+### Changed
+- Changes graphql routing pattern from `/graphql/public` to `/public/graphql`
 
 ## [7.37.3] - 2018-12-14
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.37.3",
+  "version": "7.38.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -65,7 +65,7 @@ export const createUriSwitchLink = (baseURI: string, workspace: string) =>
       return {
         ...oldContext,
         fetchOptions: {...fetchOptions, method},
-        uri: `${protocol}//${baseURI}/_v/graphql/${scope}/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/${scope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
       }
     })
     return forward ? forward(operation) : null


### PR DESCRIPTION
This PR is related to [this one](https://github.com/vtex/builder-hub/pull/284) and changes the graphql routes to match the new ones `builder-hub` exposes. 