### PR TITLE
Add again the crossorigin attribute to img tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.37.3] - 2018-12-14
 ### Fixed
 - Add again the `crossorigin` attribute now that the store service worker cleans old opaque responses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add again the `crossorigin` attribute now that the store service worker cleans old opaque responses.
 
 ## [7.37.2] - 2018-12-13
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.37.2",
+  "version": "7.37.3",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -116,6 +116,9 @@ function start() {
       }
       if (type === 'img') {
         props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
+        if (props.src && !props.src.startsWith('/')) {
+          props.crossOrigin = props.crossOrigin || 'anonymous'
+        }
       }
       if (props && props.style) {
         props.style = optimizeStyleForVtexImg(vtexImgHost, props.style)


### PR DESCRIPTION
Add again the crossorigin attribute to img tags now that the store service worker cleans old opaque responses (this will solve the "images not loading" bug).