### PR TITLE
Add the crossOrigin attribute to scripts added to the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add the `crossOrigin` attribute to scripts added to the page.
 
 ## [7.38.1] - 2018-12-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.38.2] - 2018-12-21
 ### Fixed
 - Add the `crossOrigin` attribute to scripts added to the page.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.38.1",
+  "version": "7.38.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -34,6 +34,9 @@ export function addScriptToPage(src: string): Promise<void> {
     script.onerror = () => reject()
     script.async = false
     script.src = src
+    if (src && !src.startsWith('/')) {
+      script.crossOrigin = 'anonymous'
+    }
     document.head.appendChild(script)
   })
 }


### PR DESCRIPTION
Without this attribute, the service worker receives two kinds of responses:

1. On SSR, receives the 200 status (cors) response
2. On the client-side, receives the 0 status (opaque) response

This is making our master workspace go wild when refreshing a client-side cached route...