### PR TITLE
Add the crossOrigin attribute only to img tags with src from vteximg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.38.8] - 2019-01-21
 ### Fixed
 - Add the `crossOrigin` attribute **only to img tags with src from vteximg**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add the `crossOrigin` attribute **only to img tags with src from vteximg**.
 
 ## [7.38.7] - 2018-12-26
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.38.7",
+  "version": "7.38.8",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -116,6 +116,9 @@ function start() {
       }
       if (type === 'img') {
         props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
+        if (props.src && props.src.startsWith(vtexImgHost)) {
+          props.crossOrigin = props.crossOrigin || 'anonymous'
+        }
       }
       if (props && props.style) {
         props.style = optimizeStyleForVtexImg(vtexImgHost, props.style)


### PR DESCRIPTION
The problem with the `crossOrigin` attribute was the "real crossorigin" hosts. Our `vteximg` hosts can handle crossorigin requests while some other hosts (clearsale, for example) can't. If we don't know which host can handle crossorigin, we trust only our hosts.

Crossorigin is necessary mostly because of caching. To cache images from other host (like vteximg), we need this. Otherwise, the responses are [opaque with huge size](https://cloudfour.com/thinks/when-7-kb-equals-7-mb/).

[Access the workspace to see it working](https://pwa--boticario.myvtex.com/)

#### Screenshots

![image](https://user-images.githubusercontent.com/15948386/51034431-8522e100-1585-11e9-8c09-722116c08cb4.png)

![image](https://user-images.githubusercontent.com/15948386/51034461-9b30a180-1585-11e9-803b-c414c71b5fe7.png)