### PR TITLE
Remove RC external script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- RC external script.
 
 ## [8.4.0] - 2019-02-06
 ### Added

--- a/public/externals.json
+++ b/public/externals.json
@@ -60,10 +60,6 @@
       },
       {
         "clientOnly": true,
-        "path": "https://io.vtex.com.br/rc/rc.js"
-      },
-      {
-        "clientOnly": true,
         "path": "https://unpkg.com/vtex-render-session@1.0.1/dist/index.js"
       }
     ],
@@ -124,10 +120,6 @@
       },
       {
         "path": "https://unpkg.com/vtex-tachyons@3.0.1/tachyons.min.css"
-      },
-      {
-        "clientOnly": true,
-        "path": "https://io.vtex.com.br/rc/rc.js"
       },
       {
         "clientOnly": true,


### PR DESCRIPTION
The script injection is now handled by the `vtex.request-capture-app`, and there's no need anymore for render to handle this.