### PR TITLE
Automatic translation with IOMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.3.0] - 2019-02-01
+
 ## [8.2.0] - 2019-01-28
 ### Removed
 - `MaybeAuth` component.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/package.json
+++ b/react/package.json
@@ -35,6 +35,7 @@
     "route-parser": "^0.0.5"
   },
   "devDependencies": {
+    "@types/ramda": "^0.25.47",
     "@sentry/browser": "^4.0.6",
     "@types/apollo-upload-client": "^8.1.0",
     "@types/debounce": "^1.0.0",

--- a/react/queries/appMessages.graphql
+++ b/react/queries/appMessages.graphql
@@ -1,3 +1,0 @@
-query AppMessages ($app: String!, $locale: String!) {
-  messages(app: $app, locale: $locale)
-}

--- a/react/queries/messages.graphql
+++ b/react/queries/messages.graphql
@@ -1,5 +1,0 @@
-query Messages ($page: String!, $production: Boolean!, $locale: String!, $renderMajor: Int!) {
-  page(page: $page, production: $production, locale: $locale, renderMajor: $renderMajor) {
-    messagesJSON
-  }
-}

--- a/react/queries/navigationPage.graphql
+++ b/react/queries/navigationPage.graphql
@@ -5,12 +5,10 @@ query NavigationPage (
   $path: String,
   $query: String,
   $renderMajor: Int,
-  $locale: String,
 ) {
   navigationPage(
     routeId: $routeId,
     declarer: $declarer,
-    locale: $locale,
     params: $params,
     path: $path,
     query: $query,

--- a/react/queries/navigationPage.graphql
+++ b/react/queries/navigationPage.graphql
@@ -21,7 +21,10 @@ query NavigationPage (
     cacheHintsJSON
     componentsJSON
     extensionsJSON
-    messagesJSON
+    messages {
+      key
+      message
+    }
     pagesJSON
   }
 }

--- a/react/queries/routePreviews.graphql
+++ b/react/queries/routePreviews.graphql
@@ -1,4 +1,4 @@
-query RoutePreviews($routes: [PreviewRouteInput], $locale: String, $renderMajor: Int) {
+query RoutePreviews($routes: [PreviewRouteInput], $renderMajor: Int) {
   defaultPages: routePreviews (
     routes: $routes,
     renderMajor: $renderMajor,

--- a/react/queries/routePreviews.graphql
+++ b/react/queries/routePreviews.graphql
@@ -1,6 +1,5 @@
 query RoutePreviews($routes: [PreviewRouteInput], $locale: String, $renderMajor: Int) {
   defaultPages: routePreviews (
-    locale: $locale,
     routes: $routes,
     renderMajor: $renderMajor,
   ) {

--- a/react/queries/routePreviews.graphql
+++ b/react/queries/routePreviews.graphql
@@ -6,6 +6,9 @@ query RoutePreviews($routes: [PreviewRouteInput], $locale: String, $renderMajor:
   ) {
     componentsJSON
     extensionsJSON
-    messagesJSON
+    messages {
+      key
+      message
+    }
   }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -231,7 +231,7 @@ interface RenderComponent<P={}, S={}> {
   interface PageQueryResponse {
     componentsJSON: string
     extensionsJSON: string
-    messagesJSON: string
+    messages: [UIMesssage]
     pagesJSON: string
     appsSettingsJSON: string
     appsEtag: string
@@ -241,7 +241,12 @@ interface RenderComponent<P={}, S={}> {
   interface DefaultPagesQueryResponse {
     componentsJSON: string
     extensionsJSON: string
-    messagesJSON: string
+    messages: [UIMessage]
+  }
+
+  interface KeyedString {
+    key: string
+    message: string
   }
 
   interface ParsedPageQueryResponse {
@@ -294,7 +299,7 @@ interface RenderComponent<P={}, S={}> {
     preview: boolean
     production: boolean
     publicEndpoint: string
-    messages: Record<string, string>
+    messages: Locale
     components: Components
     renderMajor: number
     query?: Record<string, string>

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -231,7 +231,7 @@ interface RenderComponent<P={}, S={}> {
   interface PageQueryResponse {
     componentsJSON: string
     extensionsJSON: string
-    messages: [UIMesssage]
+    messages: KeyedString[]
     pagesJSON: string
     appsSettingsJSON: string
     appsEtag: string
@@ -241,7 +241,7 @@ interface RenderComponent<P={}, S={}> {
   interface DefaultPagesQueryResponse {
     componentsJSON: string
     extensionsJSON: string
-    messages: [UIMessage]
+    messages: KeyedString[]
   }
 
   interface KeyedString {

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -1,26 +1,9 @@
-import { NormalizedCacheObject } from 'apollo-cache-inmemory'
-import ApolloClient from 'apollo-client'
 import { pluck, zipObj } from 'ramda'
-import appMessagesQuery from '../queries/appMessages.graphql'
-import pageMessagesQuery from '../queries/messages.graphql'
 
 const YEAR_IN_MS = 12 * 30 * 24 * 60 * 60 * 1000
 
 export const parseMessages = (messages: KeyedString[]) => {
   return zipObj(pluck('key', messages), pluck('message', messages))
-}
-
-export const fetchMessagesForApp = (apolloClient: ApolloClient<NormalizedCacheObject>, app: string, locale: string) =>
-  apolloClient.query<{messages: string}>({query: appMessagesQuery, variables: {app, locale}})
-    .then<RenderRuntime['messages']>(({data, errors}) =>
-      errors ? Promise.reject(errors) : JSON.parse(data.messages)
-    )
-
-export const fetchMessages = (apolloClient: ApolloClient<NormalizedCacheObject>, page: string, production: boolean, locale: string, renderMajor: number, ignoreCache : boolean = false) => {
-  return apolloClient.query<{ page: PageQueryResponse }>({ query: pageMessagesQuery, variables: { page, production, locale, renderMajor }, fetchPolicy: ignoreCache ? 'no-cache' : 'cache-first' })
-    .then<RenderRuntime['messages']>(({data, errors}) =>
-      errors ? Promise.reject(errors) : data.page.messages
-    )
 }
 
 export const createLocaleCookie = (locale: string) => {

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -1,10 +1,14 @@
 import { NormalizedCacheObject } from 'apollo-cache-inmemory'
 import ApolloClient from 'apollo-client'
-import {canUseDOM} from 'exenv'
+import { pluck, zipObj } from 'ramda'
 import appMessagesQuery from '../queries/appMessages.graphql'
 import pageMessagesQuery from '../queries/messages.graphql'
 
 const YEAR_IN_MS = 12 * 30 * 24 * 60 * 60 * 1000
+
+export const parseMessages = (messages: KeyedString[]) => {
+  return zipObj(pluck('key', messages), pluck('message', messages))
+}
 
 export const fetchMessagesForApp = (apolloClient: ApolloClient<NormalizedCacheObject>, app: string, locale: string) =>
   apolloClient.query<{messages: string}>({query: appMessagesQuery, variables: {app, locale}})
@@ -15,7 +19,7 @@ export const fetchMessagesForApp = (apolloClient: ApolloClient<NormalizedCacheOb
 export const fetchMessages = (apolloClient: ApolloClient<NormalizedCacheObject>, page: string, production: boolean, locale: string, renderMajor: number, ignoreCache : boolean = false) => {
   return apolloClient.query<{ page: PageQueryResponse }>({ query: pageMessagesQuery, variables: { page, production, locale, renderMajor }, fetchPolicy: ignoreCache ? 'no-cache' : 'cache-first' })
     .then<RenderRuntime['messages']>(({data, errors}) =>
-      errors ? Promise.reject(errors) : JSON.parse(data.page.messagesJSON)
+      errors ? Promise.reject(errors) : data.page.messages
     )
 }
 

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -2,8 +2,8 @@ import { pluck, zipObj } from 'ramda'
 
 const YEAR_IN_MS = 12 * 30 * 24 * 60 * 60 * 1000
 
-export const parseMessages = (messages: KeyedString[]) => {
-  return zipObj(pluck('key', messages), pluck('message', messages))
+export const parseMessages = (messages: KeyedString[] | null) => {
+  return messages && zipObj(pluck('key', messages), pluck('message', messages))
 }
 
 export const createLocaleCookie = (locale: string) => {

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -1,5 +1,6 @@
 import navigationPageQuery from '../queries/navigationPage.graphql'
 import routePreviews from '../queries/routePreviews.graphql'
+import { parseMessages } from './messages'
 
 const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryResponse => {
   const {
@@ -8,15 +9,14 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     cacheHintsJSON,
     componentsJSON,
     extensionsJSON,
-    messagesJSON,
+    messages,
     pagesJSON,
   } = page
 
-  const [cacheHints, components, extensions, messages, pages, settings] = [
+  const [cacheHints, components, extensions, pages, settings] = [
     cacheHintsJSON,
     componentsJSON,
     extensionsJSON,
-    messagesJSON,
     pagesJSON,
     appsSettingsJSON,
   ].map(json => JSON.parse(json))
@@ -26,7 +26,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     cacheHints,
     components,
     extensions,
-    messages,
+    messages: parseMessages(messages),
     pages,
     settings
   }
@@ -36,19 +36,18 @@ const parseDefaultPagesQueryResponse = (defaultPages: DefaultPagesQueryResponse)
   const {
     componentsJSON,
     extensionsJSON,
-    messagesJSON,
+    messages,
   } = defaultPages
 
-  const [components, extensions, messages] = [
+  const [components, extensions] = [
     componentsJSON,
     extensionsJSON,
-    messagesJSON,
   ].map(json => JSON.parse(json))
 
   return {
     components,
     extensions,
-    messages,
+    messages: parseMessages(messages),
   }
 }
 

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -85,14 +85,13 @@ const getRoutesParam = (routeIds: string[], pages: Pages) => {
 
 export const fetchDefaultPages = ({
   apolloClient,
-  locale,
   pages,
   routeIds,
   renderMajor,
 }: FetchDefaultPages) => {
   return apolloClient.query<{defaultPages: DefaultPagesQueryResponse}>({
     query: routePreviews,
-    variables: {locale, renderMajor, routes: getRoutesParam(routeIds, pages)}
+    variables: { renderMajor, routes: getRoutesParam(routeIds, pages)}
   }).then<ParsedDefaultPagesQueryResponse>(
     ({data: {defaultPages}, errors}: DefaultPagesQueryResult) => {
       return errors ? Promise.reject(errors) : parseDefaultPagesQueryResponse(defaultPages)

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -53,7 +53,6 @@ const parseDefaultPagesQueryResponse = (defaultPages: DefaultPagesQueryResponse)
 
 export const fetchNavigationPage = ({
   apolloClient,
-  locale,
   routeId,
   declarer,
   production,
@@ -64,7 +63,6 @@ export const fetchNavigationPage = ({
   query: navigationPageQuery,
   variables: {
     declarer,
-    locale,
     params: paramsJSON,
     production,
     renderMajor,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR depends on the following  PRs: 
1. [messages](https://github.com/vtex/messages-graphql/pull/1), 
2. [builder-hub](https://github.com/vtex/builder-hub/pull/330)
3. [graphql-server](https://github.com/vtex/graphql-server/pull/137)
4. [pages-graphql](https://github.com/vtex/pages-graphql/pull/105)

Its purpose is to use the IOMessage type to translate automatically data.

#### What problem is this solving?
This PR adapts render-server to the new pages-graphql that uses IOMessage for automatic translation.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

