### PR TITLE
Allow using history's replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.6.1] - 2019-02-06
 ### Added
 - `replace` option to use `history`'s replace instead of `push`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `replace` option to use `history`'s replace instead of `push`.
 
 ## [8.6.0] - 2019-02-06
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -87,7 +87,7 @@ export function getRouteFromPath(path: string, pages: Pages) : Route | null {
 }
 
 export function navigate(history: History | null, pages: Pages, options: NavigateOptions) {
-  const {page, params, query, to, scrollOptions, fallbackToWindowLocation = true} = options
+  const {page, params, query, to, scrollOptions, fallbackToWindowLocation = true, replace} = options
 
   if (!page && !to) {
     console.error(`Invalid navigation options. You should use 'page' or 'to' parameters`)
@@ -105,7 +105,8 @@ export function navigate(history: History | null, pages: Pages, options: Navigat
 
   if (history) {
     const location = createLocationDescriptor(route, {query, scrollOptions})
-    window.setTimeout(() => history.push(location), 0)
+    const method = replace ? 'replace' : 'push'
+    window.setTimeout(() => history[method](location), 0)
     return true
   }
 
@@ -187,4 +188,5 @@ export interface NavigateOptions {
   to?: string
   scrollOptions?: RenderScrollOptions
   fallbackToWindowLocation?: boolean
+  replace?: boolean
 }


### PR DESCRIPTION
You (or anyone, really) can now pass a `replace` flag in the options for the `navigate` function that the runtime will use `history.replace` instead of `history.push` for navigation.  `push` will use as a default.

Used it [here](https://github.com/vtex-apps/store-components/pull/282)