### PR TITLE
Check if props.style is writable before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.6.3] - 2019-02-13
+
 ### Fixed
 - Check if `props.style` is `writable` before assigning 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check if `props.style` is `writable` before assigning 
+
 ## [8.6.2] - 2019-2-7
 ### Changed
 - `LayoutContainer` now gets elements to be rendered from `blocks` directly.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -32,7 +32,7 @@ import { getBaseURI } from '../utils/host'
 import { addLocaleData } from '../utils/locales'
 import { withSession } from '../utils/session'
 import { TreePathContext } from '../utils/treePath'
-import { optimizeSrcForVtexImg, optimizeStyleForVtexImg } from '../utils/vteximg'
+import { optimizeSrcForVtexImg, optimizeStyleForVtexImg, isStyleWritable } from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
 
 if (window.IntlPolyfill) {
@@ -127,7 +127,7 @@ function start() {
           props.crossOrigin = props.crossOrigin || 'anonymous'
         }
       }
-      if (props && props.style) {
+      if (props && props.style && isStyleWritable(props)) {
         props.style = optimizeStyleForVtexImg(vtexImgHost, props.style)
       }
       return ReactCreateElement.apply<typeof React, any, any>(React, arguments)

--- a/react/utils/vteximg.ts
+++ b/react/utils/vteximg.ts
@@ -36,3 +36,8 @@ export function optimizeStyleForVtexImg (vtexImgHost: string, style?: any) {
     return style
   }
 }
+
+export function isStyleWritable(props: any): boolean {
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(props, 'style')
+  return (propertyDescriptor && propertyDescriptor.writable) || false
+}


### PR DESCRIPTION
Fixes the following situation: Using helmet from render-runtime to add an inline style (example below) won't work because `props.style` is `read-only` in some moment.
```
<Helmet>
  <style>{'p { background-color: #000; }'}</style>
</Helmet>
```