### PR TITLE
Check if props.style is writable before assignment - 7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.38.10] - 2019-02-13
+
 ### Fixed
 - Check if `props.style` is `writable` before assigning 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check if `props.style` is `writable` before assigning 
+
 ## [7.38.9] - 2019-01-24
 
 ## [7.38.8] - 2019-01-21

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.38.9",
+  "version": "7.38.10",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -23,7 +23,7 @@ import { getBaseURI } from '../utils/host'
 import { addLocaleData } from '../utils/locales'
 import { withSession } from '../utils/session'
 import { TreePathContext } from '../utils/treePath'
-import { optimizeSrcForVtexImg, optimizeStyleForVtexImg } from '../utils/vteximg'
+import { optimizeSrcForVtexImg, optimizeStyleForVtexImg, isStyleWritable } from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
 
 if (window.IntlPolyfill) {
@@ -120,7 +120,7 @@ function start() {
           props.crossOrigin = props.crossOrigin || 'anonymous'
         }
       }
-      if (props && props.style) {
+      if (props && props.style && isStyleWritable(props)) {
         props.style = optimizeStyleForVtexImg(vtexImgHost, props.style)
       }
       return ReactCreateElement.apply<typeof React, any, any>(React, arguments)

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -75,7 +75,7 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
   )
 
   return canUseDOM
-    ? (disableSSR || created ? renderDOM(root, elem) : hydrate(root, elem)) as Element
+    ? (disableSSR || created ? renderDOM<HTMLDivElement>(root, elem) : hydrate(root, elem)) as Element
     : renderToStringWithData(root).then(({ markup, renderTimeMetric }) => ({
       markups: getMarkups(name, markup),
       maxAge: cacheControl!.maxAge,

--- a/react/utils/vteximg.ts
+++ b/react/utils/vteximg.ts
@@ -36,3 +36,8 @@ export function optimizeStyleForVtexImg (vtexImgHost: string, style?: any) {
     return style
   }
 }
+
+export function isStyleWritable(props: any): boolean {
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(props, 'style')
+  return (propertyDescriptor && propertyDescriptor.writable) || false
+}


### PR DESCRIPTION
Fixes the following situation: Using helmet from render-runtime to add an inline style (example below) won't work because `props.style` is `read-only` in some moment.
```
<Helmet>
  <style>{'p { background-color: #000; }'}</style>
</Helmet>
```