### PR TITLE
Add query to context (7.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.38.12] - 2019-02-27
+
 ### Added
 - query to Render Runtime Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- query to Render Runtime Context
+
 ## [7.38.11] - 2019-02-21
 
 ## [7.38.11-beta] - 2019-02-20

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "7.38.11",
+  "version": "7.38.12",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -111,6 +111,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     production: PropTypes.bool,
     publicEndpoint: PropTypes.string,
     route: PropTypes.object,
+    query: PropTypes.object,
     setDevice: PropTypes.func,
     updateComponentAssets: PropTypes.func,
     updateExtension: PropTypes.func,
@@ -217,7 +218,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public getChildContext() {
     const { history, runtime } = this.props
-    const { components, extensions, page, pages, preview, culture, device, route, defaultExtensions } = this.state
+    const { components, extensions, page, pages, preview, culture, device, route, query, defaultExtensions } = this.state
     const { account, emitter, hints, production, publicEndpoint, workspace } = runtime
 
     return {
@@ -244,6 +245,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       production,
       publicEndpoint,
       route,
+      query,
       setDevice: this.handleSetDevice,
       updateComponentAssets: this.updateComponentAssets,
       updateExtension: this.updateExtension,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -146,7 +146,8 @@ declare global {
     updateExtension: (name: string, extension: Extension) => void,
     updateRuntime: (options?: PageContextOptions) => Subscription,
     workspace: RenderRuntime['workspace'],
-    route: RenderRuntime['route']
+    route: RenderRuntime['route'],
+    query: RenderRuntime['query'],
     defaultExtensions: RenderRuntime['defaultExtensions']
   }
 


### PR DESCRIPTION
Add a property that is present inside `__RUNTIME__` but not inside context.

This property is useful to get query string parameters.