### PR TITLE
Add renderExtension function to __RENDER_8_RUNTIME__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add `renderExtension` function to render runtime
+
 ## [8.6.4] - 2019-02-15
 ### Fixed
 - Escaping string that is used to make dynamic Regex in `isDirectChild`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.7.0] - 2019-02-19
+
 - Add `renderExtension` function to render runtime
 
 ## [8.6.4] - 2019-02-15

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.6.4",
+  "version": "8.7.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ExtensionManager.tsx
+++ b/react/components/ExtensionManager.tsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types'
+import * as R from 'ramda'
+import React, { Component } from 'react'
+
+import ExtensionPortal from './ExtensionPortal'
+
+interface Props {
+  runtime: RenderRuntime,
+}
+
+interface State {
+  extensions: SimplifiedExtension[]
+}
+
+const addOrUpdate = (extensions: SimplifiedExtension[], extension: SimplifiedExtension): SimplifiedExtension[] => {
+  const exists = R.reduce((acc, el: SimplifiedExtension) => {
+    return acc || el.extension === extension.extension
+  }, false, extensions)
+  const newExtensions = exists ? R.map((el: SimplifiedExtension) => el.extension === extension.extension ? extension : el, extensions) : R.append(extension, extensions)
+  return newExtensions
+}
+
+class ExtensionManager extends Component<Props, State> {
+
+  public static propTypes = {
+    runtime: PropTypes.object,
+  }
+
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      extensions: []
+    }
+  }
+
+  public componentDidMount() {
+    const { runtime: { emitter } } = this.props
+    emitter.addListener('renderExtensionLoader.addOrUpdateExtension', this.updateExtensions)
+  }
+
+  public componentWillUnmount() {
+    const { runtime: { emitter } } = this.props
+    emitter.removeListener('renderExtensionLoader.addOrUpdateExtension', this.updateExtensions)
+  }
+
+  public updateExtensions = (extension: SimplifiedExtension) => {
+    console.log('------------ Event ------------')
+    console.log(extension)
+    console.log('-------------------------------')
+    this.setState({
+      extensions: addOrUpdate(this.state.extensions, extension)
+    })
+  }
+
+  public render() {
+    return this.state.extensions.map((el) => {
+      return <ExtensionPortal key={el.extension} extension={el}/>
+    })
+  }
+}
+
+export default ExtensionManager
+

--- a/react/components/ExtensionManager.tsx
+++ b/react/components/ExtensionManager.tsx
@@ -18,16 +18,6 @@ interface State {
   extensionsToRender: PortalRenderingRequest[]
 }
 
-const addOrUpdate = (extensionsList: PortalRenderingRequest[], newExtension: PortalRenderingRequest): PortalRenderingRequest[] => {
-  const exists = R.any((el: PortalRenderingRequest) => {
-    return el.extensionName === newExtension.extensionName
-  })(extensionsList)
-  const newExtensionsList = exists ? R.map((el: PortalRenderingRequest) => {
-    return el.extensionName === newExtension.extensionName ? newExtension : el
-  }, extensionsList) : R.append(newExtension, extensionsList)
-  return newExtensionsList
-}
-
 class ExtensionManager extends Component<Props, State> {
 
   public static propTypes = {
@@ -53,7 +43,7 @@ class ExtensionManager extends Component<Props, State> {
 
   public updateExtensions = (extension: PortalRenderingRequest) => {
     this.setState({
-      extensionsToRender: addOrUpdate(this.state.extensionsToRender, extension)
+      extensionsToRender: this.addOrUpdateExtension(this.state.extensionsToRender, extension)
     })
   }
 
@@ -61,6 +51,16 @@ class ExtensionManager extends Component<Props, State> {
     return this.state.extensionsToRender.map((el) => {
       return <ExtensionPortal key={el.extensionName} extension={el}/>
     })
+  }
+
+  private addOrUpdateExtension = (extensionsList: PortalRenderingRequest[], newExtension: PortalRenderingRequest): PortalRenderingRequest[] => {
+    const exists = R.any((el: PortalRenderingRequest) => {
+      return el.extensionName === newExtension.extensionName
+    })(extensionsList)
+    const newExtensionsList = exists ? R.map((el: PortalRenderingRequest) => {
+      return el.extensionName === newExtension.extensionName ? newExtension : el
+    }, extensionsList) : R.append(newExtension, extensionsList)
+    return newExtensionsList
   }
 }
 

--- a/react/components/ExtensionManager.tsx
+++ b/react/components/ExtensionManager.tsx
@@ -4,20 +4,28 @@ import React, { Component } from 'react'
 
 import ExtensionPortal from './ExtensionPortal'
 
+export interface PortalRenderingRequest {
+  extensionName: string,
+  destination: HTMLElement,
+  props: any
+}
+
 interface Props {
   runtime: RenderRuntime,
 }
 
 interface State {
-  extensions: SimplifiedExtension[]
+  extensionsToRender: PortalRenderingRequest[]
 }
 
-const addOrUpdate = (extensions: SimplifiedExtension[], extension: SimplifiedExtension): SimplifiedExtension[] => {
-  const exists = R.reduce((acc, el: SimplifiedExtension) => {
-    return acc || el.extension === extension.extension
-  }, false, extensions)
-  const newExtensions = exists ? R.map((el: SimplifiedExtension) => el.extension === extension.extension ? extension : el, extensions) : R.append(extension, extensions)
-  return newExtensions
+const addOrUpdate = (extensionsList: PortalRenderingRequest[], newExtension: PortalRenderingRequest): PortalRenderingRequest[] => {
+  const exists = R.any((el: PortalRenderingRequest) => {
+    return el.extensionName === newExtension.extensionName
+  })(extensionsList)
+  const newExtensionsList = exists ? R.map((el: PortalRenderingRequest) => {
+    return el.extensionName === newExtension.extensionName ? newExtension : el
+  }, extensionsList) : R.append(newExtension, extensionsList)
+  return newExtensionsList
 }
 
 class ExtensionManager extends Component<Props, State> {
@@ -29,7 +37,7 @@ class ExtensionManager extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      extensions: []
+      extensionsToRender: []
     }
   }
 
@@ -43,21 +51,17 @@ class ExtensionManager extends Component<Props, State> {
     emitter.removeListener('renderExtensionLoader.addOrUpdateExtension', this.updateExtensions)
   }
 
-  public updateExtensions = (extension: SimplifiedExtension) => {
-    console.log('------------ Event ------------')
-    console.log(extension)
-    console.log('-------------------------------')
+  public updateExtensions = (extension: PortalRenderingRequest) => {
     this.setState({
-      extensions: addOrUpdate(this.state.extensions, extension)
+      extensionsToRender: addOrUpdate(this.state.extensionsToRender, extension)
     })
   }
 
   public render() {
-    return this.state.extensions.map((el) => {
-      return <ExtensionPortal key={el.extension} extension={el}/>
+    return this.state.extensionsToRender.map((el) => {
+      return <ExtensionPortal key={el.extensionName} extension={el}/>
     })
   }
 }
 
 export default ExtensionManager
-

--- a/react/components/ExtensionPortal.tsx
+++ b/react/components/ExtensionPortal.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import {createPortal as reactCreatePortal} from 'react-dom'
+import { createPortal } from 'react-dom'
 
 import { PortalRenderingRequest } from './ExtensionManager'
 import ExtensionPoint from './ExtensionPoint'
@@ -21,7 +21,7 @@ class ExtensionPortal extends Component<Props> {
 
   public render() {
     const { extensionName, destination, props } = this.props.extension
-    return reactCreatePortal(<ExtensionPoint id={extensionName} {...props} />, destination)
+    return createPortal(<ExtensionPoint id={extensionName} {...props} />, destination)
   }
 }
 

--- a/react/components/ExtensionPortal.tsx
+++ b/react/components/ExtensionPortal.tsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import {createPortal as reactCreatePortal} from 'react-dom'
 
+import { PortalRenderingRequest } from './ExtensionManager'
 import ExtensionPoint from './ExtensionPoint'
 
 interface Props {
-  extension: SimplifiedExtension,
+  extension: PortalRenderingRequest,
 }
 
 class ExtensionPortal extends Component<Props> {
@@ -19,9 +20,8 @@ class ExtensionPortal extends Component<Props> {
   }
 
   public render() {
-    const { extension, element, props } = this.props.extension
-    console.log('ESTOU NO PORTAL', this.props)
-    return reactCreatePortal(<ExtensionPoint id={extension} {...props} />, element)
+    const { extensionName, destination, props } = this.props.extension
+    return reactCreatePortal(<ExtensionPoint id={extensionName} {...props} />, destination)
   }
 }
 

--- a/react/components/ExtensionPortal.tsx
+++ b/react/components/ExtensionPortal.tsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import {createPortal as reactCreatePortal} from 'react-dom'
+
+import ExtensionPoint from './ExtensionPoint'
+
+interface Props {
+  extension: SimplifiedExtension,
+}
+
+class ExtensionPortal extends Component<Props> {
+
+  public static propTypes = {
+    extension: PropTypes.object,
+  }
+
+  constructor(props: Props) {
+    super(props)
+  }
+
+  public render() {
+    const { extension, element, props } = this.props.extension
+    console.log('ESTOU NO PORTAL', this.props)
+    return reactCreatePortal(<ExtensionPoint id={extension} {...props} />, element)
+  }
+}
+
+export default ExtensionPortal
+

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -22,6 +22,7 @@ import { createLocaleCookie } from '../utils/messages'
 import { getRouteFromPath, goBack as pageGoBack, navigate as pageNavigate, NavigateOptions, scrollTo as pageScrollTo } from '../utils/pages'
 import { fetchDefaultPages, fetchNavigationPage } from '../utils/routes'
 import { TreePathContext } from '../utils/treePath'
+import ExtensionManager from './ExtensionManager'
 import ExtensionPoint from './ExtensionPoint'
 
 import BuildStatus from './BuildStatus'
@@ -631,6 +632,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           <ApolloProvider client={this.apolloClient}>
             <IntlProvider locale={locale} messages={mergedMessages}>
               <Fragment>
+                <ExtensionManager runtime={this.props.runtime}/>
                 {!production && !isStorefrontIframe && <BuildStatus />}
                 {component}
                 {isStorefrontIframe ? <ExtensionPoint id="store/__overlay" /> : null}

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -55,7 +55,7 @@ const renderExtension = (extension: string, element: HTMLElement, props = {}) =>
       props
     })
   } else {
-    throw new Error(`Extension point can't be rendered before RenderProvider`)
+    throw new Error(`ExtensionPortal can't be rendered before RenderProvider`)
   }
 }
 

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -17,6 +17,7 @@ import NoSSR from 'react-no-ssr'
 import Loading from '../components/Loading'
 
 import ExtensionContainer from '../components/ExtensionContainer'
+import { PortalRenderingRequest } from '../components/ExtensionManager'
 import ExtensionPoint from '../components/ExtensionPoint'
 import LayoutContainer from '../components/LayoutContainer'
 import LegacyExtensionContainer from '../components/LegacyExtensionContainer'
@@ -33,7 +34,7 @@ import { getBaseURI } from '../utils/host'
 import { addLocaleData } from '../utils/locales'
 import { withSession } from '../utils/session'
 import { TreePathContext } from '../utils/treePath'
-import { optimizeSrcForVtexImg, optimizeStyleForVtexImg, isStyleWritable } from '../utils/vteximg'
+import { isStyleWritable, optimizeSrcForVtexImg, optimizeStyleForVtexImg } from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
 
 let emitter: EventEmitter | null = null
@@ -47,13 +48,13 @@ if (window.IntlPolyfill) {
   }
 }
 
-const renderExtension = (extension: string, element: HTMLElement, props = {}) => {
+const renderExtension = (extensionName: string, destination: HTMLElement, props = {}) => {
   if(emitter) {
     emitter.emit('renderExtensionLoader.addOrUpdateExtension', {
-      element,
-      extension,
+      destination,
+      extensionName,
       props
-    })
+    } as PortalRenderingRequest)
   } else {
     throw new Error(`ExtensionPortal can't be rendered before RenderProvider`)
   }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -5,6 +5,7 @@ import 'apollo-link-persisted-queries'
 import 'apollo-upload-client'
 import 'apollo-utilities'
 import 'classnames'
+import * as EventEmitter from 'eventemitter3'
 import {canUseDOM} from 'exenv'
 import 'graphql'
 import createHistory from 'history/createBrowserHistory'
@@ -35,12 +36,26 @@ import { TreePathContext } from '../utils/treePath'
 import { optimizeSrcForVtexImg, optimizeStyleForVtexImg, isStyleWritable } from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
 
+let emitter: EventEmitter | null = null
+
 if (window.IntlPolyfill) {
   if (!window.Intl) {
     window.Intl = window.IntlPolyfill
   } else if (!canUseDOM) {
     window.Intl.NumberFormat = window.IntlPolyfill.NumberFormat
     window.Intl.DateTimeFormat = window.IntlPolyfill.DateTimeFormat
+  }
+}
+
+const renderExtension = (extension: string, element: HTMLElement, props = {}) => {
+  if(emitter) {
+    emitter.emit('renderExtensionLoader.addOrUpdateExtension', {
+      element,
+      extension,
+      props
+    })
+  } else {
+    throw new Error(`Extension point can't be rendered before RenderProvider`)
   }
 }
 
@@ -69,6 +84,7 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
   const cacheControl = canUseDOM ? undefined : new PageCacheControl()
   const baseURI = getBaseURI(runtime)
   registerEmitter(runtime, baseURI)
+  emitter = runtime.emitter
   addLocaleData(locale)
 
   const isPage = !!pages[name] && !!pages[name].path && !!extensions[name].component
@@ -179,6 +195,7 @@ export {
   useRuntime,
   withSession,
   Loading,
-  buildCacheLocator
+  buildCacheLocator,
+  renderExtension
 }
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -66,6 +66,12 @@ declare global {
     [name: string]: Extension
   }
 
+  interface SimplifiedExtension {
+    extension: string,
+    element: HTMLElement,
+    props: any
+  }
+
   interface LogEvent {
     name: string
     data?: any

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -66,12 +66,6 @@ declare global {
     [name: string]: Extension
   }
 
-  interface SimplifiedExtension {
-    extension: string,
-    element: HTMLElement,
-    props: any
-  }
-
   interface LogEvent {
     name: string
     data?: any


### PR DESCRIPTION
- `renderExtension`: Given an `HTMLElement` and an `ExtensionName` the extension will be rendered using React Portals on the given `HTMLElement`. This feature will replace `RenderExtensionLoader`.