### PR TITLE
Remove unnecessary object on setState

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -471,9 +471,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     }))
 
     this.setState(({components, messages}) => ({
-      components: {...defaultComponents, ...this.state.components, ...components},
+      components: {...defaultComponents, ...components},
       defaultExtensions,
-      messages: {...defaultMessages, ...this.state.messages, ...messages}
+      messages: {...defaultMessages, ...messages}
     }))
   }
 


### PR DESCRIPTION
According to [React documentation](https://reactjs.org/docs/react-component.html#setstate), when `setState` receives a function, the first argument on that function call will be the object state in the moment that updater function was called.
