### PR TITLE
Add layoutMode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added support for `layoutMode`.
+- Added support for `unstable__layoutMode`.
 
 ## [8.14.0] - 2019-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.15.0] - 2019-03-21
 ### Added
 - Added support for `unstable__layoutMode`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for `layoutMode`.
 
 ## [8.14.0] - 2019-03-21
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -106,6 +106,16 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       )
     }
 
+    const isDynamicLayout = extension && extension.layoutMode === LayoutMode.dynamic
+
+    const componentChildren = (extension.blocks && isDynamicLayout) ?
+      extension.blocks.map((block, i) =>
+        <ExtensionPoint
+          id={block.extensionPointId}
+          treePath={newTreePath}
+        />
+      ) : children
+
     return component
       ? this.withOuterExtensions(
           after,
@@ -118,7 +128,9 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
               events={track}
               id={id}>
               <TreePathContext.Provider value={{ treePath: newTreePath }}>
-                <ExtensionPointComponent component={component} props={props} runtime={runtime} treePath={newTreePath}>{children}</ExtensionPointComponent>
+                <ExtensionPointComponent component={component} props={props} runtime={runtime} treePath={newTreePath}>
+                  {componentChildren}
+                </ExtensionPointComponent>
               </TreePathContext.Provider>
             </TrackEventsWrapper>
           )

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -102,13 +102,13 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
         before,
         newTreePath,
         props,
-        <Loading />,
+        <Loading />
       )
     }
 
     const isDynamicLayout = extension && extension.layoutMode === 'dynamic'
 
-    const componentChildren = (extension.blocks && isDynamicLayout) ?
+    const componentChildren = (isDynamicLayout && extension.blocks) ?
       extension.blocks.map((block, i) =>
         <ExtensionPoint
           key={i}

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -111,6 +111,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     const componentChildren = (extension.blocks && isDynamicLayout) ?
       extension.blocks.map((block, i) =>
         <ExtensionPoint
+          key={i}
           id={block.extensionPointId}
           treePath={newTreePath}
         />

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -106,7 +106,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       )
     }
 
-    const isDynamicLayout = extension && extension.layoutMode === 'dynamic'
+    const isDynamicLayout = extension && extension.unstable__layoutMode === 'dynamic'
 
     const componentChildren = (isDynamicLayout && extension.blocks) ?
       extension.blocks.map((block, i) =>

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -106,7 +106,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       )
     }
 
-    const isDynamicLayout = extension && extension.layoutMode === LayoutMode.dynamic
+    const isDynamicLayout = extension && extension.layoutMode === 'dynamic'
 
     const componentChildren = (extension.blocks && isDynamicLayout) ?
       extension.blocks.map((block, i) =>

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -41,6 +41,11 @@ declare global {
     height: number
   }
 
+  enum LayoutMode {
+    static = 'static',
+    dynamic = 'dynamic',
+  }
+
   interface BlockInsertion {
     extensionPointId: string
     blockId: string
@@ -62,6 +67,7 @@ declare global {
     content?: Record<string, any>
     shouldRender?: boolean
     preview?: Preview
+    layoutMode: LayoutMode
   }
 
   interface Extensions {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -67,7 +67,7 @@ declare global {
     content?: Record<string, any>
     shouldRender?: boolean
     preview?: Preview
-    layoutMode?: LayoutMode
+    unstable__layoutMode?: LayoutMode
   }
 
   interface Extensions {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -67,7 +67,7 @@ declare global {
     content?: Record<string, any>
     shouldRender?: boolean
     preview?: Preview
-    layoutMode: LayoutMode
+    layoutMode?: LayoutMode
   }
 
   interface Extensions {


### PR DESCRIPTION
Adds support for `layoutMode` (i.e. any component can be a `LayoutContainer` if it wants to)

Works in tandem with https://github.com/vtex/builder-hub/pull/443 and https://github.com/vtex/pages-graphql/pull/148