### PR TITLE
Fix query are setted with older info after page change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix query are setted with older info after page change.
 
 ## [8.16.1] - 2019-03-25
 

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -440,7 +440,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         page,
         pages,
         preview: false,
-        query,
         route: updatedRoute,
         settings,
       }, () => this.sendInfoFromIframe())


### PR DESCRIPTION
#### What is the purpose of this pull request?
the problem is on `onPageChanged` this use set state with old query info in async function.

#### What problem is this solving?
When navigating consecutively between routes with different queries the `RenderProvider` set the `query` in the state with the info of the first URL query, after this, set the `query` in the state with the second URL query and after this `RenderProvider` set `query` again with the info of the first URL to finally set to second. You can check this behavior [here](https://storecomponents.myvtex.com/)

#### How should this be manually tested?
[Access this workspace](https://blurredimage--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
