### PR TITLE
Adding replace option for setQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.17.1] - 2019-04-02
 ### Added
 - Support for `replace` option in setQuery for using that method in navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `replace` option in setQuery for using that method in navigation.
 
 ## [8.17.0] - 2019-03-29
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.17.0",
+  "version": "8.17.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -209,7 +209,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       window.browserHistory = global.browserHistory = history
     }
 
-this.lastNavigatedRouteId = route.id
+    this.lastNavigatedRouteId = route.id
     // todo: reload window if client-side created a segment different from server-side
     this.sessionPromise = canUseDOM
       ? window.__RENDER_8_SESSION__.sessionPromise
@@ -387,7 +387,7 @@ this.lastNavigatedRouteId = route.id
 
   public setQuery = (
     query: Record<string, any> = {},
-    merge: boolean = true
+    { merge = true, replace = false }: SetQueryOptions = {}
   ): boolean => {
     const { history } = this.props
     const {
@@ -402,12 +402,13 @@ this.lastNavigatedRouteId = route.id
       location: { search },
     } = history
     const current = queryStringToMap(search)
-    const nextQuery = mapToQueryString({ ...current, ...query })
+    const nextQuery = mapToQueryString(merge ? { ...current, ...query } : query)
     return pageNavigate(history, pages, {
       fetchPage: false,
       page,
       params,
       query: nextQuery,
+      replace,
     })
   }
 
@@ -490,7 +491,7 @@ this.lastNavigatedRouteId = route.id
     } = pagesState
     const shouldSkipFetchNavigationData =
       (!allowConditions && loadedPages.has(page)) || !fetchPage
-    const query = queryStringToMap(location.search) as RenderRuntime['query'] 
+    const query = queryStringToMap(location.search) as RenderRuntime['query']
 
     if (shouldSkipFetchNavigationData) {
       return this.setState(

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -107,6 +107,11 @@ declare global {
     id: string
   }
 
+  interface SetQueryOptions {
+    merge?: boolean
+    replace?: boolean
+  }
+
   interface Route {
     blockId: string
     canonical?: string


### PR DESCRIPTION
This is useful for selecting variations on ProductPage and, when the user comes back, doesn't make him/her go all the way through the previously selected sku's.

Test it [here](https://ribeiraopreto--delivery.myvtex.com/). I've set `replace` to true.