### PR TITLE
Feature/child props and ChildBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Export ChildBlock and useChildBlock APIs, without unstable flag.
+- ChildBlock now returns the props of the block, inserted via the blocks.json file.
+- Send props inserted via the blocks.json file to the props each child when the block has composition: children.
+- Export Block component, which is an alias of the ExtensionPoint component, and is now the preferred nomenclature.
+
+### Deprecated
+- Unstable__ChildBlock and useChildBlock__unstable.
+- ExtensionPoint component--prefer using the Block component, which has exactly the same API and functionality.
 
 ## [8.17.4] - 2019-04-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.18.0] - 2019-04-10
 ### Added
 - Export ChildBlock and useChildBlock APIs, without unstable flag.
 - ChildBlock now returns the props of the block, inserted via the `blocks.json` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Export ChildBlock and useChildBlock APIs, without unstable flag.
-- ChildBlock now returns the props of the block, inserted via the blocks.json file.
-- Send props inserted via the blocks.json file to the props each child when the block has composition: children.
+- ChildBlock now returns the props of the block, inserted via the `blocks.json` file.
+- Send props inserted via the `blocks.json` file to the `props` object of each child (when `composition` is set to `children`).
 - Export Block component, which is an alias of the ExtensionPoint component, and is now the preferred nomenclature.
 
 ### Deprecated

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.17.4",
+  "version": "8.18.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/ChildBlock.tsx
+++ b/react/components/ChildBlock.tsx
@@ -20,8 +20,11 @@ export function useChildBlock(childBlock: ChildBlock) : Block | null {
   const block = runtime.extensions && runtime.extensions[childPath]
 
   // We are explicitly not exposing the private API here
-  /** Placeholder for possible block data in the future  */
-  return block ? {} : null
+  return block
+    ? {
+      props: block.props,
+    }
+    : null
 }
 
 export function ChildBlock({ id, children }: ChildBlockProps) {

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -108,8 +108,17 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     this.component = component
 
     const props = reduce(mergeDeepRight, {}, [
+      /** Extra props passed to the ExtensionPoint component,
+       * e.g. <ExtensionPoint foo="bar" />
+       */
       parentProps,
+      /** Props that are read from runtime.extensions, that come from
+       * the blocks files
+       */
       extensionProps,
+      /** Props from the blockProps prop, sent this way to 
+       * prevent overriding the native ExtensionPoint props
+       */
       blockProps,
       content,
       { params, query },

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -166,7 +166,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       const childExtension = runtime.extensions && runtime.extensions[childTreePath]
       const childProps = childExtension ? childExtension.props : {}
 
-      /* This ChildExtensionPoint thing is done so the user can read
+      /* This ExtensionPointWrapper thing is done so the user can read
         * the props that were passed through the blocks.json file to
         * its children in a standard, React-ish way; that is:
         * `React.Children.map(children, child => child.props)`
@@ -178,20 +178,20 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
         * (or vice versa, which would cause wrong values being read by
         * the user component). 
       */
-      const ChildExtensionPoint = (blockProps: object) => (
+      const ExtensionPointWrapper = (blockProps: object) => (
         <ExtensionPoint
           id={child.extensionPointId}
           treePath={treePath}
           blockProps={blockProps}
         />
       )
+
       return (
-        <ChildExtensionPoint
+        <ExtensionPointWrapper
           key={i}
           {...childProps}
         />
       )
-
     })
   }
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -154,7 +154,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       : loading
   }
 
-  private getChildExtensions = (runtime: RenderContext, treePath: string) => {
+  private getChildExtensions(runtime: RenderContext, treePath: string) {
     const extension = runtime.extensions && runtime.extensions[treePath]
 
     if (!extension || !extension.blocks) {

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -113,16 +113,15 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     this.component = component
 
     const props = reduce(mergeDeepRight, {}, [
-      /** Extra props passed to the ExtensionPoint component,
+      /** Extra props passed to the ExtensionPoint component
        * e.g. <ExtensionPoint foo="bar" />
        */
       parentProps,
-      /** Props that are read from runtime.extensions, that come from
-       * the blocks files
+      /** Props that are read from runtime.extensions, that come from the blocks files
        */
       extensionProps,
-      /** Props from the blockProps prop, sent this way to 
-       * prevent overriding the native ExtensionPoint props
+      /** Props from the blockProps prop, used when the user wants to prevent overriding
+       * the native ExtensionPoint props (such as `id`)
        */
       blockProps,
       content,

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -12,9 +12,10 @@ import { RenderContext } from './RenderContext'
 import TrackEventsWrapper from './TrackEventsWrapper'
 
 interface Props {
-  id: string,
-  params?: any,
-  query?: any,
+  id: string
+  params?: any
+  query?: any
+  treePath?: string
 }
 
 type ExtendedProps = Props & TreePathProps
@@ -26,9 +27,10 @@ interface State {
 class ExtensionPoint extends Component<ExtendedProps, State> {
   public static propTypes = {
     children: PropTypes.node,
+    id: PropTypes.string,
     params: PropTypes.object,
     query: PropTypes.object,
-    treePath: PropTypes.string.isRequired,
+    treePath: PropTypes.string,
   }
 
   public static childContextTypes = {

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -27,11 +27,16 @@ interface State {
 
 class ExtensionPoint extends Component<ExtendedProps, State> {
   public static propTypes = {
+    blockProps: PropTypes.object,
     children: PropTypes.node,
     id: PropTypes.string,
     params: PropTypes.object,
     query: PropTypes.object,
     treePath: PropTypes.string,
+  }
+
+  public static defaultProps = {
+    blockProps: {},
   }
 
   public static childContextTypes = {
@@ -90,7 +95,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       query,
       id,
       treePath,
-      blockProps = {},
+      blockProps,
       ...parentProps
     } = this.props
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -116,13 +116,15 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
         const childExtension = runtime.extensions && runtime.extensions[childTreePath]
         const childProps = childExtension ? childExtension.props : {}
 
-        /* This ChildExtensionPoint thing is done so the user can read the
-         * props that were passed through blocks.json to its children
-         * in a native react-ish way
-         * (i.e. `React.Children.map(children, child => child.props)`).
-         * The problem was if the user passed a prop that conflicted with
-         * ExtensionPoint props (most notabily, `id`), so just destructuring
-         * the `childProps` over ExtensionPoint would override those props
+        /* This ChildExtensionPoint thing is done so the user can read
+         * the props that were passed through the blocks.json file to
+         * its children in a standard, React-ish way; that is:
+         * `React.Children.map(children, child => child.props)`
+         * 
+         * The problem was, if the user passed a prop that conflicted with
+         * ExtensionPoint props (most notabily, `id`), just destructuring
+         * the `childProps` over ExtensionPoint would override the 
+         * ExtensionPoint props, which would break the rendering.
          * (or vice versa, which would cause wrong values being read by
          * the user component). 
         */

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -127,10 +127,10 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
          * the user component). 
         */
         const ChildExtensionPoint = () => (
-        <ExtensionPoint
-          id={child.extensionPointId}
-          treePath={newTreePath}
-        />
+          <ExtensionPoint
+            id={child.extensionPointId}
+            treePath={newTreePath}
+          />
         )
         return (
           <ChildExtensionPoint

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -130,7 +130,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     const isCompositionChildren = extension && extension.composition === 'children'
 
     const componentChildren = (isCompositionChildren && extension.blocks) ?
-      this.getChildExtensions(runtime, treePath) : children
+      this.getChildExtensions(runtime, newTreePath) : children
 
     return component
       ? this.withOuterExtensions(

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -181,6 +181,10 @@ const TreePathContextConsumer = TreePathContext.Consumer
 
 export {
   ExtensionContainer,
+  /** Block is the preferred nomenclature now, ExtensionPoint is kept for
+   * backwards compatibility
+   */
+  ExtensionPoint as Block,
   ExtensionPoint,
   LayoutContainer,
   LegacyExtensionContainer,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -200,7 +200,7 @@ export {
   withRuntimeContext,
   ChildBlock,
   useChildBlock,
-  // These unstable apis should be deprecated shortly
+  // These unstable APIs should be deprecated shortly
   ChildBlock as Unstable__ChildBlock,
   useChildBlock as useChildBlock__unstable,
   useRuntime,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -194,6 +194,9 @@ export {
   start,
   withHMR,
   withRuntimeContext,
+  ChildBlock,
+  useChildBlock,
+  // These unstable apis should be deprecated shortly
   ChildBlock as Unstable__ChildBlock,
   useChildBlock as useChildBlock__unstable,
   useRuntime,


### PR DESCRIPTION
- Exports ChildBlock and useChildBlock APIs without the `unstable` flag.
- Makes ChildBlock the props of the block, inserted via the `blocks.json` file.
- Sends props inserted via the `blocks.json` file to the `props` object of each child (when the composition is set to `children`)
- Exports `Block` component, which is an alias of the `ExtensionPoint` component.

- Deprecates `Unstable__ChildBlock` and `useChildBlock__unstable`, in favor of the proper names.
- Deprecates the name `ExtensionPoint` in favor of `Block`.
