### PR TITLE
Removing check for the back navigate and add scrollOptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Support for `scrollOptions` on `setQuery`.
+
+### Changed
 - Removing `navigationRoute` check for the back button functionality.
 
 ## [8.18.1] - 2019-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.18.2] - 2019-04-12
 ### Added
 - Support for `scrollOptions` on `setQuery`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `scrollOptions` on `setQuery`.
+- Removing `navigationRoute` check for the back button functionality.
 
 ## [8.18.1] - 2019-04-11
 ### Changed

--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ setQuery(query, options)
 | :------------- |:-------------| :-----|:-----|
 | merge     | `boolean`  | `true` | Set if the passed queries will be merged into the current ones.
 | replace  | `boolean`  | `false` | If `true`, it uses _history_'s replace method instead of push.
+| scrollOptions  | `RenderScrollOptions`  | `false` | After the navigation, if the page should be scrolled to a specific position, or should stay still (use `false`) 

--- a/lint.sh
+++ b/lint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-yarn --cwd react && yarn --cwd react lint
+cd react && yarn && yarn lint

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.18.1",
+  "version": "8.18.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -387,7 +387,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public setQuery = (
     query: Record<string, any> = {},
-    { merge = true, replace = false }: SetQueryOptions = {}
+    { merge = true, replace = false, scrollOptions = false}: SetQueryOptions = {}
   ): boolean => {
     const { history } = this.props
     const {
@@ -409,6 +409,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       params,
       query: nextQuery,
       replace,
+      scrollOptions,
     })
   }
 
@@ -475,11 +476,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     // Make sure this is our navigation
     if (!state || !state.renderRouting) {
-      return
-    }
-
-    // temporary canonical fix
-    if (!state.navigationRoute) {
       return
     }
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -110,6 +110,7 @@ declare global {
   interface SetQueryOptions {
     merge?: boolean
     replace?: boolean
+    scrollOptions?: RenderScrollOptions 
   }
 
   interface Route {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -735,7 +735,6 @@
 "@types/eventemitter3@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/eventemitter3/-/eventemitter3-2.0.2.tgz#94b57c2568c4f09479d64812f625317b12a6edd0"
-  integrity sha1-lLV8JWjE8JR51kgS9iUxexKm7dA=
   dependencies:
     eventemitter3 "*"
 
@@ -2233,7 +2232,6 @@ esutils@^2.0.0, esutils@^2.0.2:
 eventemitter3@*:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
 eventemitter3@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Related PR that should be released firstly: [store](https://github.com/vtex-apps/store/pull/211)

Test [here](https://cafedovento--storecomponents.myvtex.com/) using our search, changing the sort option, and going back. It didn't work before.

This is part of the mecanism to make possible the user navigate to `/shoes`, _shoes_ being a category, and get that page relative to a _category_. When someone accesses `/shoes/c` for the first time we save that registry and `/shoes` is now a category path, and we redirect now a user that tries to navigate to `/shoes/c`.

But that means that we would have to have two navigations for a simple transition, and with every navigation we fetch some heavy data on `pages-graphql`. To avoid fetching the same data again unnecessarily, there was the `if (!state.navigationRoute)` in the `RenderProvider`'s `onPageChanged` that would do that. But, in some cases when going back in the search-result flow (like trying to go to the last applied filter), the lack of the `navigationRoute` caused by that _canonical replace_ would make the `onPageChanged` return and not really change anything on page.

A couple of weeks ago I've added a `fetchPage` option to avoid fetching navigation data on some occasions. What I've done here is use that option instead of not passing `navigationRoute`

**FEAT.**
For the _runtime_, I took advantage and also have added the `scrollOptions` to `setQuery`.