### PR TITLE
Switches to post when max querystring is exceeded

### DIFF
--- a/react/utils/client/links/base64Link.ts
+++ b/react/utils/client/links/base64Link.ts
@@ -1,6 +1,10 @@
 import { ApolloLink, NextLink, Operation } from 'apollo-link'
 import { Base64 } from 'js-base64'
 
+import { OperationContext } from './uriSwitchLink'
+
+const MAX_QUERYSTRING_SIZE = 4096
+
 export const toBase64Link = new ApolloLink((operation: Operation, forward?: NextLink) => {
   const {extensions, variables} = operation
   if (variables && Object.keys(variables).length > 0) {
@@ -8,6 +12,15 @@ export const toBase64Link = new ApolloLink((operation: Operation, forward?: Next
     operation.extensions = {
       ...extensions,
       variables: Base64.encode(JSON.stringify(variables))
+    }
+    if (JSON.stringify(operation.extensions).length > MAX_QUERYSTRING_SIZE) {
+      operation.setContext((oldContext: OperationContext) => {
+        const { fetchOptions = {}} = oldContext
+        return {
+          ...oldContext,
+          fetchOptions: {...fetchOptions, method: 'POST'},
+        }
+      })
     }
   }
   return forward ? forward(operation) : null


### PR DESCRIPTION
Currently, when the querystring is HUGE (>4096) characters, our http infrastructure bugs. To prevent this problem, when the payload size is HUGE we send the request as a POST