### PR TITLE
Feature - Update messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.26.0] - 2019-05-09
+
 ## [8.25.1] - 2019-05-09
 ### Fixed
 - Checks for invalid params in route and throws a warning.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.25.1",
+  "version": "8.26.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -66,15 +66,11 @@ export interface RenderProviderState {
 }
 
 const SEND_INFO_DEBOUNCE_MS = 100
-let isStorefrontIframe: (
-  runtime: RenderContext | null,
-  messages?: Record<string, string>,
-  shouldUpdateRuntime?: boolean
-) => void | undefined
+let isStorefrontIframe: boolean
 
 try {
   if (canUseDOM && window.top !== window.self && window.top.__provideRuntime) {
-    isStorefrontIframe = window.top.__provideRuntime
+    isStorefrontIframe = !!window.top.__provideRuntime
   }
 } catch (e) {
   console.error(e)

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -6,7 +6,6 @@ import debounce from 'debounce'
 import { canUseDOM } from 'exenv'
 import { History, UnregisterCallback } from 'history'
 import PropTypes from 'prop-types'
-import { parse, stringify } from 'query-string'
 import React, { Component, Fragment, ReactElement } from 'react'
 import { ApolloProvider } from 'react-apollo'
 import { Helmet } from 'react-helmet'
@@ -21,7 +20,6 @@ import {
   ROUTE_CLASS_PREFIX,
   routeClass,
 } from '../utils/dom'
-import { loadLocaleData } from '../utils/locales'
 import {
   getRouteFromPath,
   goBack as pageGoBack,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -152,16 +152,21 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     runtime: PropTypes.object,
   }
 
-  public sendInfoFromIframe = debounce((shouldUpdateRuntime?: boolean) => {
-    if (isStorefrontIframe) {
-      const { messages } = this.state
-      window.top.__provideRuntime(
-        this.getChildContext(),
-        messages,
-        shouldUpdateRuntime
-      )
-    }
-  }, SEND_INFO_DEBOUNCE_MS)
+  public sendInfoFromIframe = debounce(
+    (shouldUpdateRuntime: boolean = false) => {
+      if (isStorefrontIframe) {
+        const { messages } = this.state
+
+        window.top.__provideRuntime(
+          this.getChildContext(),
+          messages,
+          shouldUpdateRuntime,
+          this.updateMessages,
+        )
+      }
+    },
+    SEND_INFO_DEBOUNCE_MS,
+  )
 
   private rendered!: boolean
   private sessionPromise: Promise<void>
@@ -848,6 +853,18 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           </ApolloProvider>
         </TreePathContext.Provider>
       </RenderContext.Provider>
+    )
+  }
+
+  private updateMessages = (newMessages: RenderProviderState['messages']) => {
+    this.setState(
+      prevState => ({
+        ...prevState,
+        messages: { ...prevState.messages, ...newMessages },
+      }),
+      () => {
+        this.sendInfoFromIframe()
+      },
     )
   }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -423,7 +423,12 @@ interface RenderComponent<P={}, S={}> {
     __REQUEST_ID__: string
     __APP_ID__: string
     __hasPortals__: boolean
-    __provideRuntime: (runtime: RenderContext | null, messages?: Record<string, string>, shouldUpdateRuntime?: boolean) => void
+    __provideRuntime: (
+      runtime: RenderContext | null,
+      messages: Record<string, string>,
+      shouldUpdateRuntime: boolean,
+      setMessages: (messages: RenderRuntime['messages']) => void,
+    ) => void
     browserHistory: History
     ReactIntlLocaleData: any
     IntlPolyfill: any


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Add setter to `sendInfoFromIframe` and fix typings;
- Fix `isStorefrontIframe` definition;
- Remove unused imports.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Lack of a way to update the Storefront iframe messages from the outer Runtime.
(Related: https://github.com/vtex-apps/admin-pages/pull/191)

#### How should this be manually tested?
Workspace: https://i18n--storecomponents.myvtex.com/admin/cms/storefront.

#### Types of changes
- New feature (a non-breaking change which adds functionality)
