### PR TITLE
Fix/remove extension replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Removed replaceExtensionsWithDefault on page change.
+
 ## [8.32.2] - 2019-05-27
 ### Fixed
 - Error when img `src` attribute isn't a string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.32.3] - 2019-05-27
+
 ### Changed
 - Removed replaceExtensionsWithDefault on page change.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.32.2",
+  "version": "8.32.3",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -77,7 +77,6 @@ try {
 
 const noop = () => {}
 
-
 class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
     account: PropTypes.string,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -77,31 +77,6 @@ try {
 
 const noop = () => {}
 
-const unionKeys = (record1: any, record2: any) => [
-  ...new Set([...Object.keys(record1), ...Object.keys(record2)]),
-]
-
-const isChildOrSelf = (child: string, parent: string) =>
-  child === parent ||
-  (child.startsWith(`${parent}/`) && !child.startsWith(`${parent}/$`))
-
-const replaceExtensionsWithDefault = (
-  extensions: Extensions,
-  page: string,
-  defaultExtensions: Extensions
-) =>
-  unionKeys(extensions, defaultExtensions).reduce<Extensions>((acc, key) => {
-    const maybeExtension = isChildOrSelf(key, page)
-      ? defaultExtensions[key] || {
-          ...extensions[key],
-          component: null,
-        }
-      : extensions[key]
-    if (maybeExtension) {
-      acc[key] = maybeExtension
-    }
-    return acc
-  }, {})
 
 class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
@@ -480,7 +455,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       culture: { locale },
       pages: pagesState,
       production,
-      defaultExtensions,
       route,
       loadedPages,
     } = this.state
@@ -514,11 +488,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     this.setState(
       {
-        extensions: replaceExtensionsWithDefault(
-          this.state.extensions,
-          page,
-          defaultExtensions
-        ),
         page,
         preview: true,
         query,


### PR DESCRIPTION
Refrain from replacing extensions with the default ones on page change, making it faster to switch between types of pages which have been visited previously on the same session.

Switch between home and a category here a couple of times to see the effect: https://lbebber4--storecomponents.myvtex.com/