### PR TITLE
Fix route receiving invalid params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Checks for invalid params in route and throws a warning.
 
 ## [8.25.0] - 2019-05-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.25.1] - 2019-05-09
 ### Fixed
 - Checks for invalid params in route and throws a warning.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -193,7 +193,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const { history, baseURI, cacheControl } = props
     const path = canUseDOM ? window.location.pathname : window.__pathname__
     const route = props.runtime.route || getRouteFromPath(path, pages)
-
+    
     if (history) {
       const renderLocation: RenderHistoryLocation = {
         ...history.location,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -193,7 +193,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     const { history, baseURI, cacheControl } = props
     const path = canUseDOM ? window.location.pathname : window.__pathname__
     const route = props.runtime.route || getRouteFromPath(path, pages)
-    
+
     if (history) {
       const renderLocation: RenderHistoryLocation = {
         ...history.location,

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -68,7 +68,7 @@ function getValidTemplate(page: string, pages: Pages) {
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
   const validTemplate = getValidTemplate(page, pages)
-  if(!validTemplate) return null;
+  if (!validTemplate) return null
   return new RouteParser(validTemplate).reverse(params) || null
 }
 
@@ -108,7 +108,7 @@ function getValidParams(id: string, pages: Pages, path: string, params: any) {
   const validParams = getParams(template, path) as Record<string, any>
   const invalidParams = difference(keys(params), keys(validParams))
 
-  if(!isEmpty(invalidParams)){
+  if (!isEmpty(invalidParams)) {
     console.warn(`The following params are invalid:\n${invalidParams.join('\n')}\n`)
   }
   return validParams
@@ -121,7 +121,7 @@ function getRouteFromPageName(
 ): NavigationRoute | null {
   const path = pathFromPageName(id, pages, params) || ''
   const validParams = getValidParams(id, pages, path, params)
-  return path ? { id, path, params: validParams} : null
+  return path ? { id, path, params: validParams } : null
 }
 
 export function getRouteFromPath(

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,31 +1,43 @@
+<<<<<<< HEAD
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
 import * as RouteParser from 'route-parser'
+=======
+import { canUseDOM } from "exenv";
+import { History, LocationDescriptorObject } from "history";
+import queryString from "query-string";
+import * as RouteParser from "route-parser";
+import { keys, difference, isEmpty } from "ramda";
+>>>>>>> Improve params display of warning and refactor getValidParams method
 
-const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
+const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {};
 
 function getScore(path: string) {
-  const catchAll = (path.match(/\*/g) || []).length
-  const catchOne = (path.match(/:/g) || []).length
-  const fixed = (path.match(/\/[\w_-]+/g) || []).length
+  const catchAll = (path.match(/\*/g) || []).length;
+  const catchOne = (path.match(/:/g) || []).length;
+  const fixed = (path.match(/\/[\w_-]+/g) || []).length;
   // tslint:disable-next-line:no-bitwise
-  return ~((catchAll << 12) + (catchOne << 6) + ((1 << 6) - fixed - 1))
+  return ~((catchAll << 12) + (catchOne << 6) + ((1 << 6) - fixed - 1));
 }
 
 function isHost(hostname: string) {
   return (
     hostname === (canUseDOM ? window.location.hostname : window.__hostname__)
-  )
+  );
 }
 
 function trimEndingSlash(token: string) {
-  return token.replace(/\/$/, '') || '/'
+  return token.replace(/\/$/, "") || "/";
 }
 
 function createLocationDescriptor(
   navigationRoute: NavigationRoute,
-  { query, scrollOptions, fetchPage }: Pick<NavigateOptions, 'query' | 'scrollOptions' | 'fetchPage'>
+  {
+    query,
+    scrollOptions,
+    fetchPage
+  }: Pick<NavigateOptions, "query" | "scrollOptions" | "fetchPage">
 ): LocationDescriptorObject {
   return {
     pathname: navigationRoute.path!,
@@ -33,74 +45,84 @@ function createLocationDescriptor(
       fetchPage,
       navigationRoute,
       renderRouting: true,
-      scrollOptions,
+      scrollOptions
     },
-    ...(query && { search: query }),
-  }
+    ...(query && { search: query })
+  };
 }
 
 function adjustTemplate(template: string) {
   // make last splat capture optional
-  return trimEndingSlash(template).replace(/(\/\*\w+)$/, '($1)')
+  return trimEndingSlash(template).replace(/(\/\*\w+)$/, "($1)");
 }
 
 function adjustPath(path: string) {
-  const [pathname] = path.split('#')
-  return trimEndingSlash(pathname)
+  const [pathname] = path.split("#");
+  return trimEndingSlash(pathname);
 }
 
 function getValidTemplate(page: string, pages: Pages) {
-  const pageDescriptor = pages[page]
+  const pageDescriptor = pages[page];
 
   if (!pageDescriptor) {
-    console.error(`Page ${page} was not found`)
-    return null
+    console.error(`Page ${page} was not found`);
+    return null;
   }
 
-  const { path: template } = pageDescriptor
+  const { path: template } = pageDescriptor;
   if (!template) {
-    console.error(`Page ${page} has no path`)
-    return null
+    console.error(`Page ${page} has no path`);
+    return null;
   }
-
-  return adjustTemplate(template)
+  return adjustTemplate(template);
 }
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
-  const properTemplate = getValidTemplate(page, pages)
-  if (!properTemplate) return null
-  return new RouteParser(properTemplate).reverse(params) || null
+  const validTemplate = getValidTemplate(page, pages);
+  if (!validTemplate) return null;
+  return new RouteParser(validTemplate).reverse(params) || null;
 }
 
 export function queryStringToMap(query: string): Record<string, any> {
   if (!query) {
-    return {}
+    return {};
   }
-  return queryString.parse(query)
+  return queryString.parse(query);
 }
 
- export function mapToQueryString(query: Record<string, any> = {}): string {
-  return queryString.stringify(query)
+export function mapToQueryString(query: Record<string, any> = {}): string {
+  return queryString.stringify(query);
 }
 
 export function getPageParams(name: string, path: string, pages: Pages) {
-  const pagePath = getPagePath(name, pages)
+  const pagePath = getPagePath(name, pages);
   const pagePathWithRest =
     pagePath && /\*\w+$/.test(pagePath)
       ? pagePath
-      : pagePath.replace(/\/?$/, '*_rest')
-  return (pagePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT
+      : pagePath.replace(/\/?$/, "*_rest");
+  return (pagePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT;
 }
 
 function getParams(template: string, target: string) {
-  const properTemplate = adjustTemplate(template)
-  const properTarget = adjustPath(target)
-  return new RouteParser(properTemplate).match(properTarget)
+  const properTemplate = adjustTemplate(template);
+  const properTarget = adjustPath(target);
+  return new RouteParser(properTemplate).match(properTarget);
 }
 
 function getPagePath(name: string, pages: Pages) {
-  const { path: pagePath, cname } = pages[name]
-  return cname && isHost(cname) ? '/' : pagePath
+  const { path: pagePath, cname } = pages[name];
+  return cname && isHost(cname) ? "/" : pagePath;
+}
+
+function getValidParams(id: string, pages: Pages, path: string, params: any) {
+  const template = getValidTemplate(id, pages) || "";
+  const validParams = getParams(template, path) as Record<string, any>;
+  const invalidParams = difference(keys(params), keys(validParams));
+
+  if (!isEmpty(invalidParams)) {
+    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}\n`);
+  }
+  return validParams;
 }
 
 function getRouteFromPageName(
@@ -108,35 +130,44 @@ function getRouteFromPageName(
   pages: Pages,
   params: any
 ): NavigationRoute | null {
+<<<<<<< HEAD
   const path = pathFromPageName(id, pages, params) || ''
   const template = getValidTemplate(id, pages) || ''
   const validParams = getParams(template, path)
 
   params = validParams
   return path ? { id, path, params} : null
+=======
+  const path = pathFromPageName(id, pages, params) || "";
+  const validParams = getValidParams(id, pages, path, params);
+  return path ? { id, path, params: validParams } : null;
+>>>>>>> Improve params display of warning and refactor getValidParams method
 }
 
 export function getRouteFromPath(
-  path: string, 
+  path: string,
   pages: Pages
 ): NavigationRoute | null {
-  const id = routeIdFromPath(path, pages)
-  return id ? { id, path, params: getPageParams(id, path, pages) } : null
+  const id = routeIdFromPath(path, pages);
+  return id ? { id, path, params: getPageParams(id, path, pages) } : null;
 }
 
 const mergePersistingQueries = (currentQuery: string, query: string) => {
-  const KEYS = ['disableUserLand']
-  const current = queryStringToMap(currentQuery)
-  const next = queryStringToMap(query)
-  const has = (value?: string) => !!value || value === null
-  const persisting = KEYS.reduce((cur, key) => {
-    if (has(current[key]) && current[key] !== 'false'){
-      cur[key] = current[key]
-    }
-    return cur
-  } , {} as Record<string, any>)
-  return mapToQueryString({...persisting, ...next})
-}
+  const KEYS = ["disableUserLand"];
+  const current = queryStringToMap(currentQuery);
+  const next = queryStringToMap(query);
+  const has = (value?: string) => !!value || value === null;
+  const persisting = KEYS.reduce(
+    (cur, key) => {
+      if (has(current[key]) && current[key] !== "false") {
+        cur[key] = current[key];
+      }
+      return cur;
+    },
+    {} as Record<string, any>
+  );
+  return mapToQueryString({ ...persisting, ...next });
+};
 
 export function navigate(
   history: History | null,
@@ -152,25 +183,25 @@ export function navigate(
     fallbackToWindowLocation = true,
     rootPath,
     replace,
-    fetchPage = true,
-  } = options
+    fetchPage = true
+  } = options;
 
   if (!page && !to) {
     console.error(
       `Invalid navigation options. You should use 'page' or 'to' parameters`
-    )
-    return false
+    );
+    return false;
   }
 
   const navigationRoute = page
     ? getRouteFromPageName(page, pages, params)
-    : getRouteFromPath(to!, pages)
+    : getRouteFromPath(to!, pages);
 
   if (!navigationRoute) {
     console.warn(
       `Unable to find route for ${page ? `page '${page}'` : `path '${to}'`}`
-    )
-    return false
+    );
+    return false;
   }
 
   // Prefix any non-absolute paths (e.g. http:// or https://) with runtime.rootPath
@@ -179,86 +210,86 @@ export function navigate(
   }
 
   if (history) {
-    const nextQuery = mergePersistingQueries(history.location.search, query)
+    const nextQuery = mergePersistingQueries(history.location.search, query);
     const location = createLocationDescriptor(navigationRoute, {
       fetchPage,
       query: nextQuery,
-      scrollOptions,
-    })
-    const method = replace ? 'replace' : 'push'
-    window.setTimeout(() => history[method](location), 0)
-    return true
+      scrollOptions
+    });
+    const method = replace ? "replace" : "push";
+    window.setTimeout(() => history[method](location), 0);
+    return true;
   }
 
   if (fallbackToWindowLocation) {
-    window.location.href = `${navigationRoute.path}${query}`
-    return true
+    window.location.href = `${navigationRoute.path}${query}`;
+    return true;
   }
 
-  return false
+  return false;
 }
 
 export function goBack(history: History | null) {
   if (history) {
-    window.setTimeout(() => history.goBack(), 0)
-    return true
+    window.setTimeout(() => history.goBack(), 0);
+    return true;
   }
 
-  console.warn('Unable to go to previous page')
-  return false
+  console.warn("Unable to go to previous page");
+  return false;
 }
 
 export function scrollTo(options: RelativeScrollToOptions) {
-  const { baseElementId = null } = options || {}
+  const { baseElementId = null } = options || {};
   const scrollAnchor =
-    baseElementId && document.querySelector(`#${baseElementId}`)
+    baseElementId && document.querySelector(`#${baseElementId}`);
 
   if (!scrollAnchor) {
-    return polyfillScrollTo(options)
+    return polyfillScrollTo(options);
   }
 
-  const { top, left } = scrollAnchor.getBoundingClientRect()
+  const { top, left } = scrollAnchor.getBoundingClientRect();
   polyfillScrollTo({
     left: left + window.scrollX + (options.left || 0),
-    top: top + window.scrollY + (options.top || 0),
-  })
+    top: top + window.scrollY + (options.top || 0)
+  });
 }
 
 function polyfillScrollTo(options: ScrollToOptions) {
   try {
-    window.scrollTo(options)
+    window.scrollTo(options);
   } catch (e) {
-    const x = options.left == null ? window.scrollX : options.left
-    const y = options.top == null ? window.scrollY : options.top
-    window.scrollTo(x, y)
+    const x = options.left == null ? window.scrollX : options.left;
+    const y = options.top == null ? window.scrollY : options.top;
+    window.scrollTo(x, y);
   }
 }
 
 function routeIdFromPath(path: string, routes: Pages) {
-  let id: string | undefined
-  let score: number
-  let highScore: number = Number.NEGATIVE_INFINITY
+  let id: string | undefined;
+  let score: number;
+  let highScore: number = Number.NEGATIVE_INFINITY;
 
   // tslint:disable-next-line:forin
   for (const name in routes) {
-    const pagePath = getPagePath(name, routes)
+    const pagePath = getPagePath(name, routes);
     if (pagePath) {
-      const matches = !!getParams(pagePath, path)
+      const matches = !!getParams(pagePath, path);
       if (!matches) {
-        continue
+        continue;
       }
 
-      score = getScore(pagePath)
+      score = getScore(pagePath);
       if (highScore > score) {
-        continue
+        continue;
       }
 
-      highScore = score
-      id = name
+      highScore = score;
+      id = name;
     }
   }
 
-  return id
+  return id;
 }
 
 export interface NavigateOptions {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -67,20 +67,10 @@ function getValidTemplate(page: string, pages: Pages) {
 }
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
-  const pageDescriptor = pages[page]
-  if (!pageDescriptor) {
-    console.error(`Page ${page} was not found`)
-    return null
-  }
 
-  const { path: template } = pageDescriptor
-  if (!template) {
-    console.error(`Page ${page} has no path`)
-    return null
-  }
-
-  const properTemplate = adjustTemplate(template)
-  return new RouteParser(properTemplate).reverse(params) || null
+  const validTemplate = getValidTemplate(page, pages)
+  if(!validTemplate) return null;
+  return new RouteParser(validTemplate).reverse(params) || null
 }
 
 export function queryStringToMap(query: string): Record<string, any> {
@@ -121,12 +111,15 @@ function getRouteFromPageName(
 ): NavigationRoute | null {
   const path = pathFromPageName(id, pages, params) || ''
   const validParams = new RouteParser(getValidTemplate(id, pages) || '').match(path)
-  console.log(validParams === params)
+  if(JSON.stringify(params) !== JSON.stringify(validParams) ){
+    console.warn('invalid params')
+  }
+  params = validParams
   return path ? { id, path, params } : null
 }
 
 export function getRouteFromPath(
-  path: string,
+  path: string, 
   pages: Pages
 ): NavigationRoute | null {
   const id = routeIdFromPath(path, pages)

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,22 +1,8 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Revert some changes
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
 import * as RouteParser from 'route-parser'
-<<<<<<< HEAD
-=======
-import { canUseDOM } from "exenv";
-import { History, LocationDescriptorObject } from "history";
-import queryString from "query-string";
-import * as RouteParser from "route-parser";
-import { keys, difference, isEmpty } from "ramda";
->>>>>>> Improve params display of warning and refactor getValidParams method
-=======
 import { keys, difference, isEmpty } from 'ramda'
->>>>>>> Revert some changes
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
 
@@ -133,24 +119,9 @@ function getRouteFromPageName(
   pages: Pages,
   params: any
 ): NavigationRoute | null {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  const path = pathFromPageName(id, pages, params) || ''
-  const template = getValidTemplate(id, pages) || ''
-  const validParams = getParams(template, path)
-
-  params = validParams
-  return path ? { id, path, params} : null
-=======
-  const path = pathFromPageName(id, pages, params) || "";
-  const validParams = getValidParams(id, pages, path, params);
-  return path ? { id, path, params: validParams } : null;
->>>>>>> Improve params display of warning and refactor getValidParams method
-=======
   const path = pathFromPageName(id, pages, params) || ''
   const validParams = getValidParams(id, pages, path, params)
   return path ? { id, path, params: validParams} : null
->>>>>>> Revert some changes
 }
 
 export function getRouteFromPath(

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -49,6 +49,23 @@ function adjustPath(path: string) {
   return trimEndingSlash(pathname)
 }
 
+function getValidTemplate(page: string, pages: Pages) {
+  const pageDescriptor = pages[page]
+
+  if (!pageDescriptor) {
+    console.error(`Page ${page} was not found`)
+    return null
+  }
+
+  const { path: template } = pageDescriptor
+  if (!template) {
+    console.error(`Page ${page} has no path`)
+    return null
+  }
+
+  return adjustTemplate(template)
+}
+
 export function pathFromPageName(page: string, pages: Pages, params: any) {
   const pageDescriptor = pages[page]
   if (!pageDescriptor) {
@@ -102,7 +119,9 @@ function getRouteFromPageName(
   pages: Pages,
   params: any
 ): NavigationRoute | null {
-  const path = pathFromPageName(id, pages, params)
+  const path = pathFromPageName(id, pages, params) || ''
+  const validParams = new RouteParser(getValidTemplate(id, pages) || '').match(path)
+  console.log(validParams === params)
   return path ? { id, path, params } : null
 }
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -67,10 +67,9 @@ function getValidTemplate(page: string, pages: Pages) {
 }
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
-
-  const validTemplate = getValidTemplate(page, pages)
-  if(!validTemplate) return null;
-  return new RouteParser(validTemplate).reverse(params) || null
+  const properTemplate = getValidTemplate(page, pages)
+  if (!properTemplate) return null
+  return new RouteParser(properTemplate).reverse(params) || null
 }
 
 export function queryStringToMap(query: string): Record<string, any> {
@@ -110,12 +109,11 @@ function getRouteFromPageName(
   params: any
 ): NavigationRoute | null {
   const path = pathFromPageName(id, pages, params) || ''
-  const validParams = new RouteParser(getValidTemplate(id, pages) || '').match(path)
-  if(JSON.stringify(params) !== JSON.stringify(validParams) ){
-    console.warn('invalid params')
-  }
+  const template = getValidTemplate(id, pages) || ''
+  const validParams = getParams(template, path)
+
   params = validParams
-  return path ? { id, path, params } : null
+  return path ? { id, path, params} : null
 }
 
 export function getRouteFromPath(

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,8 +1,12 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Revert some changes
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
 import * as RouteParser from 'route-parser'
+<<<<<<< HEAD
 =======
 import { canUseDOM } from "exenv";
 import { History, LocationDescriptorObject } from "history";
@@ -10,34 +14,33 @@ import queryString from "query-string";
 import * as RouteParser from "route-parser";
 import { keys, difference, isEmpty } from "ramda";
 >>>>>>> Improve params display of warning and refactor getValidParams method
+=======
+import { keys, difference, isEmpty } from 'ramda'
+>>>>>>> Revert some changes
 
-const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {};
+const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
 
 function getScore(path: string) {
-  const catchAll = (path.match(/\*/g) || []).length;
-  const catchOne = (path.match(/:/g) || []).length;
-  const fixed = (path.match(/\/[\w_-]+/g) || []).length;
+  const catchAll = (path.match(/\*/g) || []).length
+  const catchOne = (path.match(/:/g) || []).length
+  const fixed = (path.match(/\/[\w_-]+/g) || []).length
   // tslint:disable-next-line:no-bitwise
-  return ~((catchAll << 12) + (catchOne << 6) + ((1 << 6) - fixed - 1));
+  return ~((catchAll << 12) + (catchOne << 6) + ((1 << 6) - fixed - 1))
 }
 
 function isHost(hostname: string) {
   return (
     hostname === (canUseDOM ? window.location.hostname : window.__hostname__)
-  );
+  )
 }
 
 function trimEndingSlash(token: string) {
-  return token.replace(/\/$/, "") || "/";
+  return token.replace(/\/$/, '') || '/'
 }
 
 function createLocationDescriptor(
   navigationRoute: NavigationRoute,
-  {
-    query,
-    scrollOptions,
-    fetchPage
-  }: Pick<NavigateOptions, "query" | "scrollOptions" | "fetchPage">
+  { query, scrollOptions, fetchPage }: Pick<NavigateOptions, 'query' | 'scrollOptions' | 'fetchPage'>
 ): LocationDescriptorObject {
   return {
     pathname: navigationRoute.path!,
@@ -45,84 +48,84 @@ function createLocationDescriptor(
       fetchPage,
       navigationRoute,
       renderRouting: true,
-      scrollOptions
+      scrollOptions,
     },
-    ...(query && { search: query })
-  };
+    ...(query && { search: query }),
+  }
 }
 
 function adjustTemplate(template: string) {
   // make last splat capture optional
-  return trimEndingSlash(template).replace(/(\/\*\w+)$/, "($1)");
+  return trimEndingSlash(template).replace(/(\/\*\w+)$/, '($1)')
 }
 
 function adjustPath(path: string) {
-  const [pathname] = path.split("#");
-  return trimEndingSlash(pathname);
+  const [pathname] = path.split('#')
+  return trimEndingSlash(pathname)
 }
 
 function getValidTemplate(page: string, pages: Pages) {
-  const pageDescriptor = pages[page];
+  const pageDescriptor = pages[page]
 
   if (!pageDescriptor) {
-    console.error(`Page ${page} was not found`);
-    return null;
+    console.error(`Page ${page} was not found`)
+    return null
   }
 
-  const { path: template } = pageDescriptor;
+  const { path: template } = pageDescriptor
   if (!template) {
-    console.error(`Page ${page} has no path`);
-    return null;
+    console.error(`Page ${page} has no path`)
+    return null
   }
-  return adjustTemplate(template);
+  return adjustTemplate(template)
 }
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
-  const validTemplate = getValidTemplate(page, pages);
-  if (!validTemplate) return null;
-  return new RouteParser(validTemplate).reverse(params) || null;
+  const validTemplate = getValidTemplate(page, pages)
+  if(!validTemplate) return null;
+  return new RouteParser(validTemplate).reverse(params) || null
 }
 
 export function queryStringToMap(query: string): Record<string, any> {
   if (!query) {
-    return {};
+    return {}
   }
-  return queryString.parse(query);
+  return queryString.parse(query)
 }
 
-export function mapToQueryString(query: Record<string, any> = {}): string {
-  return queryString.stringify(query);
+ export function mapToQueryString(query: Record<string, any> = {}): string {
+  return queryString.stringify(query)
 }
 
 export function getPageParams(name: string, path: string, pages: Pages) {
-  const pagePath = getPagePath(name, pages);
+  const pagePath = getPagePath(name, pages)
   const pagePathWithRest =
     pagePath && /\*\w+$/.test(pagePath)
       ? pagePath
-      : pagePath.replace(/\/?$/, "*_rest");
-  return (pagePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT;
+      : pagePath.replace(/\/?$/, '*_rest')
+  return (pagePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT
 }
 
 function getParams(template: string, target: string) {
-  const properTemplate = adjustTemplate(template);
-  const properTarget = adjustPath(target);
-  return new RouteParser(properTemplate).match(properTarget);
+  const properTemplate = adjustTemplate(template)
+  const properTarget = adjustPath(target)
+  return new RouteParser(properTemplate).match(properTarget)
 }
 
 function getPagePath(name: string, pages: Pages) {
-  const { path: pagePath, cname } = pages[name];
-  return cname && isHost(cname) ? "/" : pagePath;
+  const { path: pagePath, cname } = pages[name]
+  return cname && isHost(cname) ? '/' : pagePath
 }
 
 function getValidParams(id: string, pages: Pages, path: string, params: any) {
-  const template = getValidTemplate(id, pages) || "";
-  const validParams = getParams(template, path) as Record<string, any>;
-  const invalidParams = difference(keys(params), keys(validParams));
+  const template = getValidTemplate(id, pages) || ''
+  const validParams = getParams(template, path) as Record<string, any>
+  const invalidParams = difference(keys(params), keys(validParams))
 
-  if (!isEmpty(invalidParams)) {
-    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}\n`);
+  if(!isEmpty(invalidParams)){
+    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}\n`)
   }
-  return validParams;
+  return validParams
 }
 
 function getRouteFromPageName(
@@ -130,6 +133,7 @@ function getRouteFromPageName(
   pages: Pages,
   params: any
 ): NavigationRoute | null {
+<<<<<<< HEAD
 <<<<<<< HEAD
   const path = pathFromPageName(id, pages, params) || ''
   const template = getValidTemplate(id, pages) || ''
@@ -142,32 +146,34 @@ function getRouteFromPageName(
   const validParams = getValidParams(id, pages, path, params);
   return path ? { id, path, params: validParams } : null;
 >>>>>>> Improve params display of warning and refactor getValidParams method
+=======
+  const path = pathFromPageName(id, pages, params) || ''
+  const validParams = getValidParams(id, pages, path, params)
+  return path ? { id, path, params: validParams} : null
+>>>>>>> Revert some changes
 }
 
 export function getRouteFromPath(
-  path: string,
+  path: string, 
   pages: Pages
 ): NavigationRoute | null {
-  const id = routeIdFromPath(path, pages);
-  return id ? { id, path, params: getPageParams(id, path, pages) } : null;
+  const id = routeIdFromPath(path, pages)
+  return id ? { id, path, params: getPageParams(id, path, pages) } : null
 }
 
 const mergePersistingQueries = (currentQuery: string, query: string) => {
-  const KEYS = ["disableUserLand"];
-  const current = queryStringToMap(currentQuery);
-  const next = queryStringToMap(query);
-  const has = (value?: string) => !!value || value === null;
-  const persisting = KEYS.reduce(
-    (cur, key) => {
-      if (has(current[key]) && current[key] !== "false") {
-        cur[key] = current[key];
-      }
-      return cur;
-    },
-    {} as Record<string, any>
-  );
-  return mapToQueryString({ ...persisting, ...next });
-};
+  const KEYS = ['disableUserLand']
+  const current = queryStringToMap(currentQuery)
+  const next = queryStringToMap(query)
+  const has = (value?: string) => !!value || value === null
+  const persisting = KEYS.reduce((cur, key) => {
+    if (has(current[key]) && current[key] !== 'false'){
+      cur[key] = current[key]
+    }
+    return cur
+  } , {} as Record<string, any>)
+  return mapToQueryString({...persisting, ...next})
+}
 
 export function navigate(
   history: History | null,
@@ -183,25 +189,25 @@ export function navigate(
     fallbackToWindowLocation = true,
     rootPath,
     replace,
-    fetchPage = true
-  } = options;
+    fetchPage = true,
+  } = options
 
   if (!page && !to) {
     console.error(
       `Invalid navigation options. You should use 'page' or 'to' parameters`
-    );
-    return false;
+    )
+    return false
   }
 
   const navigationRoute = page
     ? getRouteFromPageName(page, pages, params)
-    : getRouteFromPath(to!, pages);
+    : getRouteFromPath(to!, pages)
 
   if (!navigationRoute) {
     console.warn(
       `Unable to find route for ${page ? `page '${page}'` : `path '${to}'`}`
-    );
-    return false;
+    )
+    return false
   }
 
   // Prefix any non-absolute paths (e.g. http:// or https://) with runtime.rootPath
@@ -210,86 +216,86 @@ export function navigate(
   }
 
   if (history) {
-    const nextQuery = mergePersistingQueries(history.location.search, query);
+    const nextQuery = mergePersistingQueries(history.location.search, query)
     const location = createLocationDescriptor(navigationRoute, {
       fetchPage,
       query: nextQuery,
-      scrollOptions
-    });
-    const method = replace ? "replace" : "push";
-    window.setTimeout(() => history[method](location), 0);
-    return true;
+      scrollOptions,
+    })
+    const method = replace ? 'replace' : 'push'
+    window.setTimeout(() => history[method](location), 0)
+    return true
   }
 
   if (fallbackToWindowLocation) {
-    window.location.href = `${navigationRoute.path}${query}`;
-    return true;
+    window.location.href = `${navigationRoute.path}${query}`
+    return true
   }
 
-  return false;
+  return false
 }
 
 export function goBack(history: History | null) {
   if (history) {
-    window.setTimeout(() => history.goBack(), 0);
-    return true;
+    window.setTimeout(() => history.goBack(), 0)
+    return true
   }
 
-  console.warn("Unable to go to previous page");
-  return false;
+  console.warn('Unable to go to previous page')
+  return false
 }
 
 export function scrollTo(options: RelativeScrollToOptions) {
-  const { baseElementId = null } = options || {};
+  const { baseElementId = null } = options || {}
   const scrollAnchor =
-    baseElementId && document.querySelector(`#${baseElementId}`);
+    baseElementId && document.querySelector(`#${baseElementId}`)
 
   if (!scrollAnchor) {
-    return polyfillScrollTo(options);
+    return polyfillScrollTo(options)
   }
 
-  const { top, left } = scrollAnchor.getBoundingClientRect();
+  const { top, left } = scrollAnchor.getBoundingClientRect()
   polyfillScrollTo({
     left: left + window.scrollX + (options.left || 0),
-    top: top + window.scrollY + (options.top || 0)
-  });
+    top: top + window.scrollY + (options.top || 0),
+  })
 }
 
 function polyfillScrollTo(options: ScrollToOptions) {
   try {
-    window.scrollTo(options);
+    window.scrollTo(options)
   } catch (e) {
-    const x = options.left == null ? window.scrollX : options.left;
-    const y = options.top == null ? window.scrollY : options.top;
-    window.scrollTo(x, y);
+    const x = options.left == null ? window.scrollX : options.left
+    const y = options.top == null ? window.scrollY : options.top
+    window.scrollTo(x, y)
   }
 }
 
 function routeIdFromPath(path: string, routes: Pages) {
-  let id: string | undefined;
-  let score: number;
-  let highScore: number = Number.NEGATIVE_INFINITY;
+  let id: string | undefined
+  let score: number
+  let highScore: number = Number.NEGATIVE_INFINITY
 
   // tslint:disable-next-line:forin
   for (const name in routes) {
-    const pagePath = getPagePath(name, routes);
+    const pagePath = getPagePath(name, routes)
     if (pagePath) {
-      const matches = !!getParams(pagePath, path);
+      const matches = !!getParams(pagePath, path)
       if (!matches) {
-        continue;
+        continue
       }
 
-      score = getScore(pagePath);
+      score = getScore(pagePath)
       if (highScore > score) {
-        continue;
+        continue
       }
 
-      highScore = score;
-      id = name;
+      highScore = score
+      id = name
     }
   }
 
-  return id;
+  return id
 }
 
 export interface NavigateOptions {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -109,7 +109,7 @@ function getValidParams(id: string, pages: Pages, path: string, params: any) {
   const invalidParams = difference(keys(params), keys(validParams))
 
   if (!isEmpty(invalidParams)) {
-    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}`)
+    console.warn(`The following params are invalid: ${invalidParams.join(', ')}`)
   }
   return validParams
 }

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -154,7 +154,7 @@ function getRouteFromPageName(
 }
 
 export function getRouteFromPath(
-  path: string, 
+  path: string,
   pages: Pages
 ): NavigationRoute | null {
   const id = routeIdFromPath(path, pages)

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -109,7 +109,7 @@ function getValidParams(id: string, pages: Pages, path: string, params: any) {
   const invalidParams = difference(keys(params), keys(validParams))
 
   if (!isEmpty(invalidParams)) {
-    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}\n`)
+    console.warn(`The following params are invalid:\n${invalidParams.join('\n')}`)
   }
   return validParams
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

as title says.

#### What problem is this solving?
When passing params not specified in [routes template](https://github.com/vtex-apps/store/blob/master/store/routes.json), none of warn is displayed. 

#### How should this be manually tested?
1. [Acess this workspace](https://mariana--storecomponents.myvtex.com)
2. Create a navigate object passing more params then necessary e.g `navigate({page: 'store.product',
  params: { slug: 'traveler-backpack', batata: 'batata', banana: 'banana', a:'a'},})`
3. And check if console throws this warn : 
`pages.ts:116 The following params are invalid:
batata
banana
a`


#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.