### PR TITLE
Fix to param of navigate object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Checks for invalid params in route and throws a warning.
 
 ## [8.26.0] - 2019-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Checks for invalid params in route and throws a warning.
+- Extracted query params from `to` path, for the query object. 
 
 ## [8.26.0] - 2019-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.27.0] - 2019-05-09
 ### Fixed
 - Extracted query params from `to` path, for the query object. 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can pass a handful of configuration props to navigate:
 | fallbackToWindowLocation     | `boolean`   | `false`  |If `true`, sets the href of `window.location` with the future path
 | fetchPage     | `boolean`   | `true`  | If `false`, won't fetch navigation assets in `pages-graphql`
 | page     | `string`  | --  | Name of the page that will be redirected to. Maps to a `blocks.json` block. Example: `'store.product'`
-| to     | `string`    |  --  | Alternatively to `page`, you can pass the URL directly instead of the page name (Useful for the `search-result`). Example: `/:slug/p`
+| to     | `string`    |  --  | Alternatively to `page`, you can pass the whole URL directly instead of the page name (Useful for the `search-result`). Example: `/shirt/p?skuId=1`
 | params | `object`      |   `{}`  | Map of _parameters_ names in the path for the page and the values that should replace them. Example: `{slug: 'shirt'}`
 | query | `string`  | `''`   | String representation of the query params that will be appended to the path. Example: `skuId=231`.
 | scrollOptions | `RenderScrollOptions` | -- | After the navigation, if the page should be scrolled to a specific position, or should stay still (use `false`)
@@ -90,7 +90,7 @@ Link is a custom React component that renders an `a` HTML element that, when cli
 | Name      | Type          | Default  | Description | 
 | :------------- |:-------------| :-----|:-----|
 | page     | `string`  | --  | Name of the page that will be redirect to. Maps to a `blocks.json` block. Example: `'store.product'`
-| to     | `string`    |  --  | Alternatively to `page`, you can pass the URL directly instead of the page name (Useful for the `search-result`). Example: `/:slug/p`
+| to     | `string`    |  --  | Alternatively to `page`, you can pass the whole URL directly instead of the page name (Useful for the `search-result`). Example: `/shirt/p?skuId=1`
 | params | `object`      |   `{}`  | Map of _param_ names in the path for the page and the values that should replace them. Example: `{slug: 'shirt'}`
 | query | `string`  | `''`   | String representation of the query params that will be appended to the path. Example: `skuId=231`.
 | onClick | `function` | -- | Callback that will be fired when the user click on the Component. Example: `() => alert('Salut')`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.26.0",
+  "version": "8.27.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -2,7 +2,7 @@ import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
 import * as RouteParser from 'route-parser'
-import { keys, difference, isEmpty } from 'ramda'
+import { difference, is, isEmpty, keys } from 'ramda'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
 
@@ -26,7 +26,11 @@ function trimEndingSlash(token: string) {
 
 function createLocationDescriptor(
   navigationRoute: NavigationRoute,
-  { query, scrollOptions, fetchPage }: Pick<NavigateOptions, 'query' | 'scrollOptions' | 'fetchPage'>
+  {
+    query,
+    scrollOptions,
+    fetchPage,
+  }: Pick<NavigateOptions, 'query' | 'scrollOptions' | 'fetchPage'>
 ): LocationDescriptorObject {
   return {
     pathname: navigationRoute.path!,
@@ -68,7 +72,9 @@ function getValidTemplate(page: string, pages: Pages) {
 
 export function pathFromPageName(page: string, pages: Pages, params: any) {
   const validTemplate = getValidTemplate(page, pages)
-  if (!validTemplate) return null
+  if (!validTemplate) {
+    return null
+  }
   return new RouteParser(validTemplate).reverse(params) || null
 }
 
@@ -79,7 +85,7 @@ export function queryStringToMap(query: string): Record<string, any> {
   return queryString.parse(query)
 }
 
- export function mapToQueryString(query: Record<string, any> = {}): string {
+export function mapToQueryString(query: Record<string, any> = {}): string {
   return queryString.stringify(query)
 }
 
@@ -103,15 +109,16 @@ function getPagePath(name: string, pages: Pages) {
   return cname && isHost(cname) ? '/' : pagePath
 }
 
-function getValidParams(id: string, pages: Pages, path: string, params: any) {
+function checkValidParams(id: string, pages: Pages, path: string, params: any) {
   const template = getValidTemplate(id, pages) || ''
   const validParams = getParams(template, path) as Record<string, any>
   const invalidParams = difference(keys(params), keys(validParams))
 
   if (!isEmpty(invalidParams)) {
-    console.warn(`The following params are invalid: ${invalidParams.join(', ')}`)
+    console.warn(
+      `The following params are invalid: ${invalidParams.join(', ')}`
+    )
   }
-  return validParams
 }
 
 function getRouteFromPageName(
@@ -120,8 +127,8 @@ function getRouteFromPageName(
   params: any
 ): NavigationRoute | null {
   const path = pathFromPageName(id, pages, params) || ''
-  const validParams = getValidParams(id, pages, path, params)
-  return path ? { id, path, params: validParams } : null
+  checkValidParams(id, pages, path, params)
+  return path ? { id, path, params } : null
 }
 
 export function getRouteFromPath(
@@ -137,13 +144,16 @@ const mergePersistingQueries = (currentQuery: string, query: string) => {
   const current = queryStringToMap(currentQuery)
   const next = queryStringToMap(query)
   const has = (value?: string) => !!value || value === null
-  const persisting = KEYS.reduce((cur, key) => {
-    if (has(current[key]) && current[key] !== 'false'){
-      cur[key] = current[key]
-    }
-    return cur
-  } , {} as Record<string, any>)
-  return mapToQueryString({...persisting, ...next})
+  const persisting = KEYS.reduce(
+    (cur, key) => {
+      if (has(current[key]) && current[key] !== 'false') {
+        cur[key] = current[key]
+      }
+      return cur
+    },
+    {} as Record<string, any>
+  )
+  return mapToQueryString({ ...persisting, ...next })
 }
 
 export function navigate(
@@ -169,13 +179,15 @@ export function navigate(
     )
     return false
   }
-  
-  const [to, extractedQuery] = inputTo.split('?')
-  const query = inputQuery || extractedQuery
 
   if (inputTo && inputQuery) {
-    console.warn(`You shouldn't pass 'query' in a separate prop when using 'to'`)
+    console.warn(
+      `You shouldn't pass 'query' in a separate prop when using 'to'`
+    )
   }
+
+  const [to, extractedQuery] = (is(String, inputTo) ? inputTo : '').split('?')
+  const query = inputQuery || extractedQuery
 
   const navigationRoute = page
     ? getRouteFromPageName(page, pages, params)
@@ -183,7 +195,9 @@ export function navigate(
 
   if (!navigationRoute) {
     console.warn(
-      `Unable to find route for ${page ? `page '${page}' and the passed parameters` : `path '${to}'`}`
+      `Unable to find route for ${
+        page ? `page '${page}' and the passed parameters` : `path '${to}'`
+      }`
     )
     return false
   }

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -154,8 +154,8 @@ export function navigate(
   const {
     page,
     params,
-    query,
-    to,
+    query: inputQuery,
+    to: inputTo = '',
     scrollOptions,
     fallbackToWindowLocation = true,
     rootPath,
@@ -163,11 +163,18 @@ export function navigate(
     fetchPage = true,
   } = options
 
-  if (!page && !to) {
+  if (!page && !inputTo) {
     console.error(
       `Invalid navigation options. You should use 'page' or 'to' parameters`
     )
     return false
+  }
+  
+  const [to, extractedQuery] = inputTo.split('?')
+  const query = inputQuery || extractedQuery
+
+  if (inputTo && inputQuery) {
+    console.warn(`You shouldn't pass 'query' in a separate prop when using 'to'`)
   }
 
   const navigationRoute = page
@@ -176,7 +183,7 @@ export function navigate(
 
   if (!navigationRoute) {
     console.warn(
-      `Unable to find route for ${page ? `page '${page}'` : `path '${to}'`}`
+      `Unable to find route for ${page ? `page '${page}' and the passed parameters` : `path '${to}'`}`
     )
     return false
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

as title says.

#### What problem is this solving?
When passing query in `to` path, the query object is empty, and search field needs of this values

#### How should this be manually tested?
1. [Acess this workspace](https://fanny--storecomponents.myvtex.com)
2. Create a navigate object passing more params then necessary e.g `navigate({to: '/classic-shoes/p?map=ft'})`
3. And check if `query` object contains `map` field.

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.