### PR TITLE
Fix routing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.29.0] - 2019-05-16
 ### Added
 - Use `?map` to do route matching.
 - Add first class support to canonical routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use `?map` to do route matching.
+- Add first class support to canonical routes.
 
 ## [8.28.0] - 2019-05-10
 ### Added
-- Scope messages. 
+- Scope messages.
 
 ## [8.27.0] - 2019-05-09
 ### Fixed
-- Extracted query params from `to` path, for the query object. 
+- Extracted query params from `to` path, for the query object.
 
 ## [8.26.0] - 2019-05-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.28.0",
+  "version": "8.29.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -21,7 +21,6 @@ import {
   routeClass,
 } from '../utils/dom'
 import {
-  getRouteFromPath,
   goBack as pageGoBack,
   mapToQueryString,
   navigate as pageNavigate,
@@ -187,11 +186,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       page,
       query,
       production,
+      route,
       settings,
     } = props.runtime
     const { history, baseURI, cacheControl } = props
-    const path = canUseDOM ? window.location.pathname : window.__pathname__
-    const route = props.runtime.route || getRouteFromPath(path, pages)
 
     if (history) {
       const renderLocation: RenderHistoryLocation = {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -190,10 +190,14 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       settings,
     } = props.runtime
     const { history, baseURI, cacheControl } = props
+    const ignoreCanonicalReplacement = query && query.map || !route.canonicalPath
 
     if (history) {
       const renderLocation: RenderHistoryLocation = {
         ...history.location,
+        pathname: ignoreCanonicalReplacement
+          ? history.location.pathname
+          : route.canonicalPath!,
         state: {
           navigationRoute: {
             id: route.id,

--- a/react/queries/navigationPage.graphql
+++ b/react/queries/navigationPage.graphql
@@ -25,6 +25,7 @@ query NavigationPage (
     }
     page {
       blockId
+      canonicalPath
       pageContext {
         id
         type

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -128,7 +128,7 @@ declare global {
 
   interface Route {
     blockId: string
-    canonical?: string
+    canonicalPath?: string
     path: string
     params: Record<string, any>
     pageContext: PageDataContext
@@ -282,6 +282,7 @@ interface RenderComponent<P={}, S={}> {
 
   interface MatchingPage {
     blockId: string
+    canonicalPath?: string
     pageContext: PageDataContext
   }
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -100,6 +100,7 @@ declare global {
 
   interface Page {
     allowConditions: boolean
+    canonical?: string
     cname?: string
     path: string
     auth?: boolean

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -110,6 +110,7 @@ declare global {
     name?: string
     title?: string
     conditional?: boolean
+    map?: string[]
   }
 
   interface NavigationRoute {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,8 +1,8 @@
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
+import { difference, is, isEmpty, keys, startsWith } from 'ramda'
 import * as RouteParser from 'route-parser'
-import { difference, is, isEmpty, keys } from 'ramda'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
 
@@ -89,13 +89,12 @@ export function mapToQueryString(query: Record<string, any> = {}): string {
   return queryString.stringify(query)
 }
 
-export function getPageParams(name: string, path: string, pages: Pages) {
-  const pagePath = getPagePath(name, pages)
+export function getPageParams(path: string, routePath: string) {
   const pagePathWithRest =
-    pagePath && /\*\w+$/.test(pagePath)
-      ? pagePath
-      : pagePath.replace(/\/?$/, '*_rest')
-  return (pagePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT
+    routePath && /\*\w+$/.test(routePath)
+      ? routePath
+      : routePath.replace(/\/?$/, '*_rest')
+  return (routePath && getParams(pagePathWithRest, path)) || EMPTY_OBJECT
 }
 
 function getParams(template: string, target: string) {
@@ -133,10 +132,20 @@ function getRouteFromPageName(
 
 export function getRouteFromPath(
   path: string,
-  pages: Pages
+  pages: Pages,
+  query?: string
 ): NavigationRoute | null {
-  const id = routeIdFromPath(path, pages)
-  return id ? { id, path, params: getPageParams(id, path, pages) } : null
+  const queryMap = query ?  queryStringToMap(query) : {}
+  const routeMatch = routeIdFromPathAndQuery(path, queryMap, pages)
+  if (!routeMatch) {
+    return null
+  }
+
+  return {
+    id: routeMatch.id,
+    params: getPageParams(path, routeMatch.path),
+    path,
+  }
 }
 
 const mergePersistingQueries = (currentQuery: string, query: string) => {
@@ -191,7 +200,7 @@ export function navigate(
 
   const navigationRoute = page
     ? getRouteFromPageName(page, pages, params)
-    : getRouteFromPath(to!, pages)
+    : getRouteFromPath(to!, pages, query)
 
   if (!navigationRoute) {
     console.warn(
@@ -263,7 +272,43 @@ function polyfillScrollTo(options: ScrollToOptions) {
   }
 }
 
-function routeIdFromPath(path: string, routes: Pages) {
+function routeMatchForMappedURL(mappedSegments: string[], routes: Pages) {
+  let id: string | undefined
+  let score: number
+  let highScore: number = Number.NEGATIVE_INFINITY
+
+  // tslint:disable-next-line:forin
+  for (const name in routes) {
+    const {map = [], path: routePath} = routes[name]
+    if (!routePath || map.length === 0 || !startsWith(map, mappedSegments)) {
+      continue
+    }
+
+    score = map.length
+    if (highScore > score) {
+      continue
+    }
+
+    highScore = score
+    id = name
+  }
+
+  if (!id) {
+    return null
+  }
+
+  const {path} = routes[id]
+  const pathSegments = path.split('/')
+  const slicedPathSegments = pathSegments.slice(0, highScore + 1)
+  const newPath = slicedPathSegments.join('/')
+
+  return {
+    id,
+    path: newPath
+  }
+}
+
+function routeMatchFromPath(path: string, routes: Pages) {
   let id: string | undefined
   let score: number
   let highScore: number = Number.NEGATIVE_INFINITY
@@ -271,23 +316,47 @@ function routeIdFromPath(path: string, routes: Pages) {
   // tslint:disable-next-line:forin
   for (const name in routes) {
     const pagePath = getPagePath(name, routes)
-    if (pagePath) {
-      const matches = !!getParams(pagePath, path)
-      if (!matches) {
-        continue
-      }
-
-      score = getScore(pagePath)
-      if (highScore > score) {
-        continue
-      }
-
-      highScore = score
-      id = name
+    if (!pagePath) {
+      continue
     }
+
+    const matches = !!getParams(pagePath, path)
+    if (!matches) {
+      continue
+    }
+
+    score = getScore(pagePath)
+    if (highScore > score) {
+      continue
+    }
+
+    highScore = score
+    id = name
   }
 
-  return id
+  if (!id) {
+    return null
+  }
+
+  return {
+    id,
+    path: getPagePath(id, routes)
+  }
+}
+
+function routeIdFromPathAndQuery(path: string, query: Record<string, string>, routes: Pages) {
+  const mappedSegments = query.map ? query.map.split(',') : []
+  let routeMatch: {id: string, path: string} | null = null
+
+  if (mappedSegments.length > 0) {
+    routeMatch = routeMatchForMappedURL(mappedSegments, routes)
+  }
+
+  if (!routeMatch) {
+    routeMatch = routeMatchFromPath(path, routes)
+  }
+
+  return routeMatch
 }
 
 export interface NavigateOptions {

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -13,6 +13,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     pagesJSON,
     page: {
       blockId,
+      canonicalPath,
       pageContext: {
         id,
         type,
@@ -35,6 +36,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     extensions,
     matchingPage: {
       blockId,
+      canonicalPath,
       pageContext: {id, type}
     },
     messages: parseMessages(messages),


### PR DESCRIPTION
This PR has two features.

It was created originally to fix route matching with `?map` query string. For instance, `/smartphones/White?map=c,specification_filter10` should be identified as a _department_ page, but is being identified as a _category_ page because we only use path segments to decide which route matches. The first commit handles it.

Then this fix brought us another issue with canonical paths. The department path is `/:department/d` and has a canonical `/:department`, but if I browse `/smartphones/White?map=c,specification_filter10` I should not be redirected to `/smartphones?map=c,specification_filter10`, and `vtex.store` was doing that.

Now render-runtime will handle canonical path replacements with the benefit of doing a single history push, instead of going to `/:department/d` and then `/:department`.

Depends on https://github.com/vtex/render-server/pull/352 and https://github.com/vtex/pages-graphql/pull/191