### PR TITLE
Update lint configuration to use eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ docs/_book/
 npm-debug.log
 .build/
 lib
-.eslintrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "eslintIntegration": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.29.2] - 2019-05-20
 ### Fixed
 - Linting errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Linting errors.
 
 ## [8.29.1] - 2019-05-17
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.29.1",
+  "version": "8.29.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/.eslintrc.json
+++ b/react/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": "vtex-react",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  },
+  "rules": {
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "no-console": "off"
+  },
+  "globals": {
+    "global": "writable"
+  }
+}

--- a/react/ErrorPage.tsx
+++ b/react/ErrorPage.tsx
@@ -36,7 +36,7 @@ export default class ErrorPage extends Component {
           <div className="f2 c-on-base">Something went wrong</div>
           <div className="f5 pt5 c-on-base lh-copy">
             <div>There was a technical problem loading this page.</div>
-            <div> Try refreshing the page or come back in 5 minutes.</div>
+            <div>Try refreshing the page or come back in 5 minutes.</div>
           </div>
           <div className="f6 pt5 c-muted-2" style={{fontFamily: 'courier, code'}}>
             <div>ID: {window.__REQUEST_ID__}</div>
@@ -47,7 +47,8 @@ export default class ErrorPage extends Component {
           </div>
         </div>
         <div>
-          <img src={ErrorImg} onClick={this.handleImageClick} className={`${style.imgHeight} pb6 pb0-ns`}></img>
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+          <img src={ErrorImg} onKeyDown={e => e.key === 'Enter' && this.handleImageClick()} onClick={this.handleImageClick} className={`${style.imgHeight} pb6 pb0-ns`} alt=""></img>
         </div>
       </div>
     )

--- a/react/ErrorPage.tsx
+++ b/react/ErrorPage.tsx
@@ -13,7 +13,9 @@ export default class ErrorPage extends Component {
   private splunk = 0
 
   public componentDidMount() {
-    window.setTimeout(()=>{this.setState({enabled: true})} , 5000)
+    window.setTimeout(() => {
+      this.setState({ enabled: true })
+    }, 5000)
   }
 
   public render() {
@@ -38,17 +40,39 @@ export default class ErrorPage extends Component {
             <div>There was a technical problem loading this page.</div>
             <div>Try refreshing the page or come back in 5 minutes.</div>
           </div>
-          <div className="f6 pt5 c-muted-2" style={{fontFamily: 'courier, code'}}>
+          <div
+            className="f6 pt5 c-muted-2"
+            style={{ fontFamily: 'courier, code' }}
+          >
             <div>ID: {window.__REQUEST_ID__}</div>
             <div className="f6 c-muted-2 lh-copy fw7">{date.toUTCString()}</div>
           </div>
           <div className="pt7">
-            <button className={'bw1 ba fw5 ttu br2 fw4 v-mid relative pv4 ph6 f5 ' + (this.state.enabled ? 'bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer' : 'bg-disabled b--disabled c-on-disabled')} disabled={!this.state.enabled} onClick={ ()=>{window.location.reload()}}>Refresh</button>
+            <button
+              className={
+                'bw1 ba fw5 ttu br2 fw4 v-mid relative pv4 ph6 f5 ' +
+                (this.state.enabled
+                  ? 'bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer'
+                  : 'bg-disabled b--disabled c-on-disabled')
+              }
+              disabled={!this.state.enabled}
+              onClick={() => {
+                window.location.reload()
+              }}
+            >
+              Refresh
+            </button>
           </div>
         </div>
         <div>
           {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-          <img src={ErrorImg} onKeyDown={e => e.key === 'Enter' && this.handleImageClick()} onClick={this.handleImageClick} className={`${style.imgHeight} pb6 pb0-ns`} alt=""></img>
+          <img
+            src={ErrorImg}
+            onKeyDown={e => e.key === 'Enter' && this.handleImageClick()}
+            onClick={this.handleImageClick}
+            className={`${style.imgHeight} pb6 pb0-ns`}
+            alt=""
+          />
         </div>
       </div>
     )
@@ -57,12 +81,25 @@ export default class ErrorPage extends Component {
   private renderErrorDetails = (error: any) => {
     return (
       <div>
-        <div className={`${style.errorStack} bg-danger--faded pa7 mt4 br3 t-body lh-copy`}>
+        <div
+          className={`${
+            style.errorStack
+          } bg-danger--faded pa7 mt4 br3 t-body lh-copy`}
+        >
           {error.stack.split('\n').map((item: string, key: number) => {
-            return <Fragment key={key}>{item}<br/></Fragment>
+            return (
+              <Fragment key={key}>
+                {item}
+                <br />
+              </Fragment>
+            )
           })}
         </div>
-        <div className={`${style.errorDetails} bg-warning--faded pa7 mt4 br3 lh-copy`}>
+        <div
+          className={`${
+            style.errorDetails
+          } bg-warning--faded pa7 mt4 br3 lh-copy`}
+        >
           <ReactJson src={error.details} />
         </div>
       </div>

--- a/react/ExtensionContainer.tsx
+++ b/react/ExtensionContainer.tsx
@@ -1,3 +1,3 @@
-import {ExtensionContainer} from 'vtex.render-runtime'
+import { ExtensionContainer } from 'vtex.render-runtime'
 
 export default ExtensionContainer

--- a/react/ExtensionPoint.tsx
+++ b/react/ExtensionPoint.tsx
@@ -1,3 +1,3 @@
-import {ExtensionPoint} from 'vtex.render-runtime'
+import { ExtensionPoint } from 'vtex.render-runtime'
 
 export default ExtensionPoint

--- a/react/LayoutContainer.tsx
+++ b/react/LayoutContainer.tsx
@@ -1,3 +1,3 @@
-import {LayoutContainer} from 'vtex.render-runtime'
+import { LayoutContainer } from 'vtex.render-runtime'
 
 export default LayoutContainer

--- a/react/LegacyExtensionContainer.tsx
+++ b/react/LegacyExtensionContainer.tsx
@@ -1,3 +1,3 @@
-import {LegacyExtensionContainer} from 'vtex.render-runtime'
+import { LegacyExtensionContainer } from 'vtex.render-runtime'
 
 export default LegacyExtensionContainer

--- a/react/components/BuildStatus.tsx
+++ b/react/components/BuildStatus.tsx
@@ -20,7 +20,7 @@ class BuildStatus extends Component<RenderContextProps, State> {
   private animateOutHandle!: number
   private hideHandle!: number
 
-  constructor(props: RenderContextProps) {
+  public constructor(props: RenderContextProps) {
     super(props)
 
     this.state = {
@@ -40,14 +40,10 @@ class BuildStatus extends Component<RenderContextProps, State> {
     this.hideHandle = window.setTimeout(() => this.setState({ status: null, animateOut: false }), delayMillis + 300)
   }
 
-  private toggleAnchor = () => {
+  private handleMouseOver = () => {
     this.setState(state => ({
       anchor: state.anchor === 'left' ? 'right' : 'left'
     }))
-  }
-
-  private handleMouseOver = () => {
-    this.toggleAnchor()
   }
 
   public updateStatus = (status: string) => {
@@ -104,10 +100,13 @@ class BuildStatus extends Component<RenderContextProps, State> {
     )
 
     return (
+      // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
       <div
+        aria-hidden
         className={className}
         style={{ top: '12px', [anchor]: '12px', animationDuration: '0.2s', opacity: 0.8 }}
-        onMouseOver={this.toggleAnchor}>
+        onMouseOver={this.handleMouseOver}
+      >
         {status === 'fail'
           ? fail
           : status === 'reload'

--- a/react/components/BuildStatus.tsx
+++ b/react/components/BuildStatus.tsx
@@ -1,5 +1,5 @@
-import React, {Component} from 'react'
-import {RenderContextProps, withRuntimeContext} from './RenderContext'
+import React, { Component } from 'react'
+import { RenderContextProps, withRuntimeContext } from './RenderContext'
 
 interface State {
   animateOut: boolean
@@ -8,10 +8,42 @@ interface State {
 }
 
 const buildStatusLoading = (
-  <svg width="26px" height="26px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
-    <circle cx="50" opacity="0.2" cy="50" fill="none" stroke="#F71963" strokeWidth="14" r="40"></circle>
-    <circle cx="50" cy="50" fill="none" stroke="#F71963" strokeWidth="12" r="40" strokeDasharray="60 900" strokeLinecap="round" transform="rotate(96 50 50)">
-      <animateTransform attributeName="transform" type="rotate" calcMode="linear" values="0 50 50;360 50 50" keyTimes="0;1" dur="0.7s" begin="0s" repeatCount="indefinite"></animateTransform>
+  <svg
+    width="26px"
+    height="26px"
+    viewBox="0 0 100 100"
+    preserveAspectRatio="xMidYMid"
+  >
+    <circle
+      cx="50"
+      opacity="0.2"
+      cy="50"
+      fill="none"
+      stroke="#F71963"
+      strokeWidth="14"
+      r="40"
+    />
+    <circle
+      cx="50"
+      cy="50"
+      fill="none"
+      stroke="#F71963"
+      strokeWidth="12"
+      r="40"
+      strokeDasharray="60 900"
+      strokeLinecap="round"
+      transform="rotate(96 50 50)"
+    >
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        calcMode="linear"
+        values="0 50 50;360 50 50"
+        keyTimes="0;1"
+        dur="0.7s"
+        begin="0s"
+        repeatCount="indefinite"
+      />
     </circle>
   </svg>
 )
@@ -36,13 +68,19 @@ class BuildStatus extends Component<RenderContextProps, State> {
   }
 
   public hideWithDelay = (delayMillis: number) => {
-    this.animateOutHandle = window.setTimeout(() => this.setState({ animateOut: true }), delayMillis)
-    this.hideHandle = window.setTimeout(() => this.setState({ status: null, animateOut: false }), delayMillis + 300)
+    this.animateOutHandle = window.setTimeout(
+      () => this.setState({ animateOut: true }),
+      delayMillis
+    )
+    this.hideHandle = window.setTimeout(
+      () => this.setState({ status: null, animateOut: false }),
+      delayMillis + 300
+    )
   }
 
   private handleMouseOver = () => {
     this.setState(state => ({
-      anchor: state.anchor === 'left' ? 'right' : 'left'
+      anchor: state.anchor === 'left' ? 'right' : 'left',
     }))
   }
 
@@ -52,7 +90,7 @@ class BuildStatus extends Component<RenderContextProps, State> {
       return
     }
 
-    this.setState({status, animateOut: false})
+    this.setState({ status, animateOut: false })
     this.clearTimeouts()
 
     if (status === 'success' || status === 'hmr:success') {
@@ -62,12 +100,12 @@ class BuildStatus extends Component<RenderContextProps, State> {
   }
 
   public subscribeToStatus = () => {
-    const {emitter} = this.props.runtime
+    const { emitter } = this.props.runtime
     emitter.addListener('build.status', this.updateStatus)
   }
 
   public unsubscribeToStatus = () => {
-    const {emitter} = this.props.runtime
+    const { emitter } = this.props.runtime
     emitter.removeListener('build.status', this.updateStatus)
   }
 
@@ -81,7 +119,7 @@ class BuildStatus extends Component<RenderContextProps, State> {
   }
 
   public render() {
-    const {status, animateOut, anchor} = this.state
+    const { status, animateOut, anchor } = this.state
 
     if (status === null) {
       return null
@@ -92,26 +130,31 @@ class BuildStatus extends Component<RenderContextProps, State> {
     }`
 
     const fail = (
-      <p className="ma2">Oops! Build failed. Check your terminal for more information</p>
+      <p className="ma2">
+        Oops! Build failed. Check your terminal for more information
+      </p>
     )
 
-    const reload = (
-      <p className="ma2">Performing full reload</p>
-    )
+    const reload = <p className="ma2">Performing full reload</p>
 
     return (
       // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
       <div
         aria-hidden
         className={className}
-        style={{ top: '12px', [anchor]: '12px', animationDuration: '0.2s', opacity: 0.8 }}
+        style={{
+          top: '12px',
+          [anchor]: '12px',
+          animationDuration: '0.2s',
+          opacity: 0.8,
+        }}
         onMouseOver={this.handleMouseOver}
       >
         {status === 'fail'
           ? fail
           : status === 'reload'
-            ? reload
-            : buildStatusLoading}
+          ? reload
+          : buildStatusLoading}
       </div>
     )
   }

--- a/react/components/ChildBlock.tsx
+++ b/react/components/ChildBlock.tsx
@@ -38,7 +38,7 @@ interface ChildBlock {
 }
 
 /** Placeholder for possible block data in the future */
-/* tslint:disable-next-line no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Block {
 }
 

--- a/react/components/ChildBlock.tsx
+++ b/react/components/ChildBlock.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { useTreePath } from '../utils/treePath'
 import { useRuntime } from './RenderContext'
 
-export function useChildBlock(childBlock: ChildBlock) : Block | null {
+export function useChildBlock(childBlock: ChildBlock): Block | null {
   if (typeof childBlock === 'string') {
-    throw new Error(`You are passing a string as a parameter to useChildBlock ("${childBlock}"). You should pass an object like {id: "${childBlock}"}.`)
+    throw new Error(
+      `You are passing a string as a parameter to useChildBlock ("${childBlock}"). You should pass an object like {id: "${childBlock}"}.`
+    )
   }
 
   const { id } = childBlock
@@ -22,8 +24,8 @@ export function useChildBlock(childBlock: ChildBlock) : Block | null {
   // We are explicitly not exposing the private API here
   return block
     ? {
-      props: block.props,
-    }
+        props: block.props,
+      }
     : null
 }
 
@@ -39,8 +41,7 @@ interface ChildBlock {
 
 /** Placeholder for possible block data in the future */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Block {
-}
+interface Block {}
 
 interface ChildBlockProps extends ChildBlock {
   children(block: Block | null): React.ReactNode

--- a/react/components/ExtensionContainer.tsx
+++ b/react/components/ExtensionContainer.tsx
@@ -1,15 +1,15 @@
 import PropTypes from 'prop-types'
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 
-import {getDirectChildren, TreePathContext} from '../utils/treePath'
+import { getDirectChildren, TreePathContext } from '../utils/treePath'
 import ExtensionPoint from './ExtensionPoint'
-import {RenderContext} from './RenderContext'
+import { RenderContext } from './RenderContext'
 
 const join = (p: string | null, c: string | null): string =>
   [p, c].filter(id => !!id).join('/')
 
 interface Props {
-  id: string | null,
+  id: string | null
 }
 
 class ExtensionContainer extends Component<Props> {
@@ -18,23 +18,30 @@ class ExtensionContainer extends Component<Props> {
   }
 
   public render() {
-    const {id} = this.props
+    const { id } = this.props
 
     return (
       <RenderContext.Consumer>
-        {runtime =>
+        {runtime => (
           <TreePathContext.Consumer>
-            {({treePath}) => {
-                const containerTreePath = join(treePath, id)
-                return getDirectChildren(runtime.extensions, containerTreePath)
-                  .map(cid => {
-                    const childTreePath = join(id, cid)
-                    return <ExtensionPoint {...this.props} key={childTreePath} id={childTreePath} />
-                  })
-              }
-            }
+            {({ treePath }) => {
+              const containerTreePath = join(treePath, id)
+              return getDirectChildren(
+                runtime.extensions,
+                containerTreePath
+              ).map(cid => {
+                const childTreePath = join(id, cid)
+                return (
+                  <ExtensionPoint
+                    {...this.props}
+                    key={childTreePath}
+                    id={childTreePath}
+                  />
+                )
+              })
+            }}
           </TreePathContext.Consumer>
-        }
+        )}
       </RenderContext.Consumer>
     )
   }

--- a/react/components/ExtensionManager.tsx
+++ b/react/components/ExtensionManager.tsx
@@ -24,7 +24,7 @@ class ExtensionManager extends Component<Props, State> {
     runtime: PropTypes.object,
   }
 
-  constructor(props: Props) {
+  public constructor(props: Props) {
     super(props)
     this.state = {
       extensionsToRender: []

--- a/react/components/ExtensionManager.tsx
+++ b/react/components/ExtensionManager.tsx
@@ -5,13 +5,13 @@ import React, { Component } from 'react'
 import ExtensionPortal from './ExtensionPortal'
 
 export interface PortalRenderingRequest {
-  extensionName: string,
-  destination: HTMLElement,
+  extensionName: string
+  destination: HTMLElement
   props: any
 }
 
 interface Props {
-  runtime: RenderRuntime,
+  runtime: RenderRuntime
 }
 
 interface State {
@@ -19,7 +19,6 @@ interface State {
 }
 
 class ExtensionManager extends Component<Props, State> {
-
   public static propTypes = {
     runtime: PropTypes.object,
   }
@@ -27,39 +26,59 @@ class ExtensionManager extends Component<Props, State> {
   public constructor(props: Props) {
     super(props)
     this.state = {
-      extensionsToRender: []
+      extensionsToRender: [],
     }
   }
 
   public componentDidMount() {
-    const { runtime: { emitter } } = this.props
-    emitter.addListener('renderExtensionLoader.addOrUpdateExtension', this.updateExtensions)
+    const {
+      runtime: { emitter },
+    } = this.props
+    emitter.addListener(
+      'renderExtensionLoader.addOrUpdateExtension',
+      this.updateExtensions
+    )
   }
 
   public componentWillUnmount() {
-    const { runtime: { emitter } } = this.props
-    emitter.removeListener('renderExtensionLoader.addOrUpdateExtension', this.updateExtensions)
+    const {
+      runtime: { emitter },
+    } = this.props
+    emitter.removeListener(
+      'renderExtensionLoader.addOrUpdateExtension',
+      this.updateExtensions
+    )
   }
 
   public updateExtensions = (extension: PortalRenderingRequest) => {
     this.setState({
-      extensionsToRender: this.addOrUpdateExtension(this.state.extensionsToRender, extension)
+      extensionsToRender: this.addOrUpdateExtension(
+        this.state.extensionsToRender,
+        extension
+      ),
     })
   }
 
   public render() {
-    return this.state.extensionsToRender.map((el) => {
-      return <ExtensionPortal key={el.extensionName} extension={el}/>
+    return this.state.extensionsToRender.map(el => {
+      return <ExtensionPortal key={el.extensionName} extension={el} />
     })
   }
 
-  private addOrUpdateExtension = (extensionsList: PortalRenderingRequest[], newExtension: PortalRenderingRequest): PortalRenderingRequest[] => {
+  private addOrUpdateExtension = (
+    extensionsList: PortalRenderingRequest[],
+    newExtension: PortalRenderingRequest
+  ): PortalRenderingRequest[] => {
     const exists = R.any((el: PortalRenderingRequest) => {
       return el.extensionName === newExtension.extensionName
     })(extensionsList)
-    const newExtensionsList = exists ? R.map((el: PortalRenderingRequest) => {
-      return el.extensionName === newExtension.extensionName ? newExtension : el
-    }, extensionsList) : R.append(newExtension, extensionsList)
+    const newExtensionsList = exists
+      ? R.map((el: PortalRenderingRequest) => {
+          return el.extensionName === newExtension.extensionName
+            ? newExtension
+            : el
+        }, extensionsList)
+      : R.append(newExtension, extensionsList)
     return newExtensionsList
   }
 }

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -107,7 +107,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       before = [],
       content = {},
       props: extensionProps = {},
-      track = []
+      track = [],
     } = extension || {}
 
     this.component = component
@@ -128,10 +128,13 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       { params, query },
     ])
 
-    const isCompositionChildren = extension && extension.composition === 'children'
+    const isCompositionChildren =
+      extension && extension.composition === 'children'
 
-    const componentChildren = (isCompositionChildren && extension.blocks) ?
-      this.getChildExtensions(runtime, newTreePath) : children
+    const componentChildren =
+      isCompositionChildren && extension.blocks
+        ? this.getChildExtensions(runtime, newTreePath)
+        : children
 
     return this.withOuterExtensions(
       after,
@@ -139,19 +142,22 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       before,
       newTreePath,
       props,
-      (
-        <TrackEventsWrapper
-          events={track}
-          id={id}>
-          <TreePathContext.Provider value={{ treePath: newTreePath }}>
-            {component ? (
-              <ExtensionPointComponent component={component} props={props} runtime={runtime} treePath={newTreePath}>
-                {componentChildren}
-              </ExtensionPointComponent>
-            ) : <Loading />}
-          </TreePathContext.Provider>
-        </TrackEventsWrapper>
-      )
+      <TrackEventsWrapper events={track} id={id}>
+        <TreePathContext.Provider value={{ treePath: newTreePath }}>
+          {component ? (
+            <ExtensionPointComponent
+              component={component}
+              props={props}
+              runtime={runtime}
+              treePath={newTreePath}
+            >
+              {componentChildren}
+            </ExtensionPointComponent>
+          ) : (
+            <Loading />
+          )}
+        </TreePathContext.Provider>
+      </TrackEventsWrapper>
     )
   }
 
@@ -163,22 +169,26 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
     }
 
     return extension.blocks.map((child, i) => {
-      const childTreePath = ExtensionPoint.mountTreePath(child.extensionPointId, treePath)
-      const childExtension = runtime.extensions && runtime.extensions[childTreePath]
+      const childTreePath = ExtensionPoint.mountTreePath(
+        child.extensionPointId,
+        treePath
+      )
+      const childExtension =
+        runtime.extensions && runtime.extensions[childTreePath]
       const childProps = childExtension ? childExtension.props : {}
 
       /* This ExtensionPointWrapper thing is done so the user can read
-        * the props that were passed through the blocks.json file to
-        * its children in a standard, React-ish way; that is:
-        * `React.Children.map(children, child => child.props)`
-        * 
-        * The problem was, if the user passed a prop that conflicted with
-        * ExtensionPoint props (most notabily, `id`), just destructuring
-        * the `childProps` over ExtensionPoint would override the 
-        * ExtensionPoint props, which would break the rendering.
-        * (or vice versa, which would cause wrong values being read by
-        * the user component). 
-      */
+       * the props that were passed through the blocks.json file to
+       * its children in a standard, React-ish way; that is:
+       * `React.Children.map(children, child => child.props)`
+       *
+       * The problem was, if the user passed a prop that conflicted with
+       * ExtensionPoint props (most notabily, `id`), just destructuring
+       * the `childProps` over ExtensionPoint would override the
+       * ExtensionPoint props, which would break the rendering.
+       * (or vice versa, which would cause wrong values being read by
+       * the user component).
+       */
       const ExtensionPointWrapper = (blockProps: object) => (
         <ExtensionPoint
           id={child.extensionPointId}
@@ -187,16 +197,18 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
         />
       )
 
-      return (
-        <ExtensionPointWrapper
-          key={i}
-          {...childProps}
-        />
-      )
+      return <ExtensionPointWrapper key={i} {...childProps} />
     })
   }
 
-  private withOuterExtensions(after: string[], around: string[], before: string[], treePath: string, props: any, element: JSX.Element) {
+  private withOuterExtensions(
+    after: string[],
+    around: string[],
+    before: string[],
+    treePath: string,
+    props: any,
+    element: JSX.Element
+  ) {
     const beforeElements = (
       <Fragment>
         {before.map(beforeId => (
@@ -233,16 +245,22 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       </Fragment>
     )
 
-    return around.reduce((acc, aroundId) => (
-      <ExtensionPoint id={aroundId} treePath={treePath} {...props}>
-        {acc}
-      </ExtensionPoint>
-    ), wrapped)
+    return around.reduce(
+      (acc, aroundId) => (
+        <ExtensionPoint id={aroundId} treePath={treePath} {...props}>
+          {acc}
+        </ExtensionPoint>
+      ),
+      wrapped
+    )
   }
 
   private addDataToElementIfEditable = () => {
     const ComponentImpl = this.component && getImplementation(this.component)
-    const isEditable = ComponentImpl && (ComponentImpl.hasOwnProperty('schema') || ComponentImpl.hasOwnProperty('getSchema'))
+    const isEditable =
+      ComponentImpl &&
+      (ComponentImpl.hasOwnProperty('schema') ||
+        ComponentImpl.hasOwnProperty('getSchema'))
 
     if (!isEditable) {
       return

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -55,7 +55,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
 
   private component?: string | null
 
-  constructor(props: ExtendedProps) {
+  public constructor(props: ExtendedProps) {
     super(props)
 
     this.state = {
@@ -248,6 +248,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       return
     }
 
+    // eslint-disable-next-line react/no-find-dom-node
     const element = ReactDOM.findDOMNode(this) as Element
 
     if (element && element.setAttribute) {
@@ -256,6 +257,7 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
   }
 
   private removeDataFromElement = () => {
+    // eslint-disable-next-line react/no-find-dom-node
     const element = ReactDOM.findDOMNode(this) as Element
 
     if (element && element.removeAttribute) {

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -23,7 +23,6 @@ interface State {
 const componentPromiseMap: any = {}
 const componentPromiseResolvedMap: any = {}
 
-
 class ExtensionPointComponent extends PureComponent<
   Props & RenderContextProps,
   State
@@ -72,7 +71,7 @@ class ExtensionPointComponent extends PureComponent<
 
     // Let's fetch the assets and re-render.
     if (component && !Component) {
-      if (!(component in componentPromiseMap)){
+      if (!(component in componentPromiseMap)) {
         componentPromiseMap[component] = fetchComponent(component)
       } else if (componentPromiseResolvedMap[component]) {
         throw new Error(`Unable to fetch component ${component}`)
@@ -100,11 +99,11 @@ class ExtensionPointComponent extends PureComponent<
     const {
       component,
       props,
-      runtime: {production, account, workspace},
+      runtime: { production, account, workspace },
       runtime,
       treePath: path,
     } = this.props
-    const {children, __errorInstance, __clearError, ...componentProps} = props
+    const { children, __errorInstance, __clearError, ...componentProps } = props
 
     console.error('Failed to render extension point', path, component)
     // Only log 10 percent of the errors so we dont exceed our quota

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -36,11 +36,10 @@ class ExtensionPointComponent extends PureComponent<
     treePath: PropTypes.string,
   }
 
-  // tslint:disable-next-line:variable-name
   private _isMounted!: boolean
   private mountedError!: boolean
 
-  constructor(props: Props & RenderContextProps) {
+  public constructor(props: Props & RenderContextProps) {
     super(props)
 
     this.state = {}
@@ -54,11 +53,14 @@ class ExtensionPointComponent extends PureComponent<
 
     this.setState({ error: null, errorInfo: null, lastUpdate: Date.now() })
     const { component: mounted, treePath } = this.props
+
     console.log(
       `[render] Component updated. treePath=${treePath} ${
         mounted !== component ? `mounted=${mounted} ` : ''
       }updated=${component}`
     )
+
+    return true
   }
 
   public fetchAndRerender = () => {
@@ -166,7 +168,7 @@ class ExtensionPointComponent extends PureComponent<
       const errorInstance = (
         <ExtensionPointError
           error={error}
-          errorInfo={errorInfo!}
+          errorInfo={errorInfo}
           treePath={treePath}
         />
       )

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {ErrorInfo, PureComponent} from 'react'
+import React, { ErrorInfo, PureComponent } from 'react'
 
 interface Props {
   treePath: string
@@ -30,26 +30,30 @@ class ExtensionPointError extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {treePath, error, errorInfo} = this.props
-    const {errorDetails} = this.state
+    const { treePath, error, errorInfo } = this.props
+    const { errorDetails } = this.state
     const componentStack = errorInfo && errorInfo.componentStack
 
     return (
       <div className="bg-washed-red pa6 f5 serious-black br3 pre">
-        <span>Error rendering extension point <strong>{treePath}</strong></span>
-        <button type="button" className="red ph0 ma0 mh3 bg-transparent bn pointer link" onClick={this.handleToggleErrorDetails}>({errorDetails ? 'hide' : 'show'} details)</button>
+        <span>
+          Error rendering extension point <strong>{treePath}</strong>
+        </span>
+        <button
+          type="button"
+          className="red ph0 ma0 mh3 bg-transparent bn pointer link"
+          onClick={this.handleToggleErrorDetails}
+        >
+          ({errorDetails ? 'hide' : 'show'} details)
+        </button>
         {errorDetails && error && (
           <pre>
-            <code className="f6">
-              {error.stack}
-            </code>
+            <code className="f6">{error.stack}</code>
           </pre>
         )}
         {errorDetails && componentStack && (
           <pre>
-            <code className="f6">
-              {componentStack}
-            </code>
+            <code className="f6">{componentStack}</code>
           </pre>
         )}
       </div>

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -4,7 +4,7 @@ import React, {ErrorInfo, PureComponent} from 'react'
 interface Props {
   treePath: string
   error?: Error
-  errorInfo?: ErrorInfo
+  errorInfo?: ErrorInfo | null
 }
 
 interface State {
@@ -18,7 +18,7 @@ class ExtensionPointError extends PureComponent<Props, State> {
     treePath: PropTypes.string,
   }
 
-  constructor(props: any) {
+  public constructor(props: any) {
     super(props)
     this.state = {}
   }
@@ -38,10 +38,10 @@ class ExtensionPointError extends PureComponent<Props, State> {
       <div className="bg-washed-red pa6 f5 serious-black br3 pre">
         <span>Error rendering extension point <strong>{treePath}</strong></span>
         <button type="button" className="red ph0 ma0 mh3 bg-transparent bn pointer link" onClick={this.handleToggleErrorDetails}>({errorDetails ? 'hide' : 'show'} details)</button>
-        {errorDetails && (
+        {errorDetails && error && (
           <pre>
             <code className="f6">
-              {error!.stack}
+              {error.stack}
             </code>
           </pre>
         )}

--- a/react/components/ExtensionPortal.tsx
+++ b/react/components/ExtensionPortal.tsx
@@ -15,7 +15,7 @@ class ExtensionPortal extends Component<Props> {
     extension: PropTypes.object,
   }
 
-  constructor(props: Props) {
+  public constructor(props: Props) {
     super(props)
   }
 

--- a/react/components/ExtensionPortal.tsx
+++ b/react/components/ExtensionPortal.tsx
@@ -6,11 +6,10 @@ import { PortalRenderingRequest } from './ExtensionManager'
 import ExtensionPoint from './ExtensionPoint'
 
 interface Props {
-  extension: PortalRenderingRequest,
+  extension: PortalRenderingRequest
 }
 
 class ExtensionPortal extends Component<Props> {
-
   public static propTypes = {
     extension: PropTypes.object,
   }
@@ -21,9 +20,11 @@ class ExtensionPortal extends Component<Props> {
 
   public render() {
     const { extensionName, destination, props } = this.props.extension
-    return createPortal(<ExtensionPoint id={extensionName} {...props} />, destination) as ReactPortal
+    return createPortal(
+      <ExtensionPoint id={extensionName} {...props} />,
+      destination
+    ) as ReactPortal
   }
 }
 
 export default ExtensionPortal
-

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -20,7 +20,8 @@ interface ContainerProps {
   preview?: boolean
 }
 
-const elementPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired
+const elementPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+  .isRequired
 
 class Container extends Component<ContainerProps> {
   public static propTypes = {
@@ -33,7 +34,9 @@ class Container extends Component<ContainerProps> {
   public render() {
     const { isRow, elements, children, ...props } = this.props
 
-    const className = `flex flex-grow-1 w-100 ${isRow ? 'flex-row' : 'flex-column'}`
+    const className = `flex flex-grow-1 w-100 ${
+      isRow ? 'flex-row' : 'flex-column'
+    }`
     if (typeof elements === 'string') {
       if (elements === '__children__') {
         return children
@@ -50,30 +53,39 @@ class Container extends Component<ContainerProps> {
       elementsToRender = this.props.aboveTheFold
     }
 
-    const returnValue: JSX.Element[] = elements.slice(0, elementsToRender).map((element: Element) => {
-      return (
-        <Container key={element.toString()} elements={element} isRow={!isRow} {...props}>
-          {children}
-        </Container>
-      )
-    })
+    const returnValue: JSX.Element[] = elements
+      .slice(0, elementsToRender)
+      .map((element: Element) => {
+        return (
+          <Container
+            key={element.toString()}
+            elements={element}
+            isRow={!isRow}
+            {...props}
+          >
+            {children}
+          </Container>
+        )
+      })
 
-    return (
-      <div className={className}>
-        {returnValue}
-      </div>
-    )
+    return <div className={className}>{returnValue}</div>
   }
 }
 
 // tslint:disable-next-line
-const LayoutContainer: React.FunctionComponent<LayoutContainerProps> = (props) => {
-  const {extensions, preview} = useRuntime()
-  const {treePath} = useTreePath()
+const LayoutContainer: React.FunctionComponent<
+  LayoutContainerProps
+> = props => {
+  const { extensions, preview } = useRuntime()
+  const { treePath } = useTreePath()
 
   const extension = extensions[treePath]
-  const elements = extension && extension.blocks && extension.blocks.map(insertion => insertion.extensionPointId) || []
-  const containerProps = {...props, elements}
+  const elements =
+    (extension &&
+      extension.blocks &&
+      extension.blocks.map(insertion => insertion.extensionPointId)) ||
+    []
+  const containerProps = { ...props, elements }
 
   return <Container {...containerProps} preview={preview} isRow={false} />
 }

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -5,6 +5,7 @@ import ExtensionPoint from './ExtensionPoint'
 import { useRuntime } from './RenderContext'
 
 type Element = string | ElementArray
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface ElementArray extends Array<Element> {}
 
 interface LayoutContainerProps {

--- a/react/components/LegacyExtensionContainer.tsx
+++ b/react/components/LegacyExtensionContainer.tsx
@@ -6,31 +6,37 @@ import ExtensionPoint from './ExtensionPoint'
 import { RenderContext } from './RenderContext'
 
 interface Props {
-  query: any,
+  query: any
   params: any
 }
 
-class LegacyExtensionContainer extends Component<Props, {hydrate: boolean}> {
+class LegacyExtensionContainer extends Component<Props, { hydrate: boolean }> {
   public state = {
-    hydrate: false
+    hydrate: false,
   }
 
   public componentDidMount() {
-    this.setState({hydrate: true})
+    this.setState({ hydrate: true })
   }
 
   public render() {
-    const {params, query} = this.props
+    const { params, query } = this.props
     return (
       <RenderContext.Consumer>
-        {runtime =>
+        {runtime => (
           <TreePathContext.Consumer>
-            {({treePath}) =>
-              getDirectChildren(runtime.extensions, treePath)
-                .map(id => createPortal(<ExtensionPoint id={id} query={query} params={params} />, `${treePath}/${id}`, this.state.hydrate) as ReactPortal)
+            {({ treePath }) =>
+              getDirectChildren(runtime.extensions, treePath).map(
+                id =>
+                  createPortal(
+                    <ExtensionPoint id={id} query={query} params={params} />,
+                    `${treePath}/${id}`,
+                    this.state.hydrate
+                  ) as ReactPortal
+              )
             }
           </TreePathContext.Consumer>
-        }
+        )}
       </RenderContext.Consumer>
     )
   }

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -74,7 +74,11 @@ const Link: React.FunctionComponent<Props> = ({
     return '#'
   }
 
-  return <a href={getHref()} {...linkProps} onClick={handleClick}>{children}</a>
+  return (
+    <a href={getHref()} {...linkProps} onClick={handleClick}>
+      {children}
+    </a>
+  )
 }
 
 export default Link

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import React, { MouseEvent, useCallback } from 'react'
 import { NavigateOptions, pathFromPageName } from '../utils/pages'
 import { useRuntime } from './RenderContext'
@@ -14,16 +13,17 @@ const absoluteRegex = /^https?:\/\/|^\/\//i
 const isAbsoluteUrl = (url: string) => absoluteRegex.test(url)
 
 interface Props extends NavigateOptions {
-  onClick: (event: any) => void
+  onClick: (event: React.MouseEvent) => void
 }
 
 const Link: React.FunctionComponent<Props> = ({
   page,
-  onClick,
+  onClick = () => {},
   params,
   to,
   scrollOptions,
   query,
+  children,
   ...linkProps
 }) => {
   const { pages, navigate, rootPath = '' } = useRuntime()
@@ -53,7 +53,7 @@ const Link: React.FunctionComponent<Props> = ({
         event.preventDefault()
       }
     },
-    [page, params, query, to, scrollOptions, navigate]
+    [to, onClick, page, params, query, rootPath, scrollOptions, navigate]
   )
 
   const getHref = () => {
@@ -74,21 +74,7 @@ const Link: React.FunctionComponent<Props> = ({
     return '#'
   }
 
-  return <a href={getHref()} {...linkProps} onClick={handleClick} />
-}
-
-Link.defaultProps = {
-  onClick: () => {
-    return
-  },
-}
-
-Link.propTypes = {
-  onClick: PropTypes.func,
-  page: PropTypes.string,
-  params: PropTypes.object,
-  query: PropTypes.string,
-  to: PropTypes.string,
+  return <a href={getHref()} {...linkProps} onClick={handleClick}>{children}</a>
 }
 
 export default Link

--- a/react/components/Loading.tsx
+++ b/react/components/Loading.tsx
@@ -17,9 +17,7 @@ const Loading = () => {
     return null
   }
 
-  return (
-    <Preview extension={extension} />
-  )
+  return <Preview extension={extension} />
 }
 
 export default Loading

--- a/react/components/MaybeContext.tsx
+++ b/react/components/MaybeContext.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react'
+import React, { PureComponent } from 'react'
 import ExtensionPointComponent from '../components/ExtensionPointComponent'
 import { RenderContextProps } from './RenderContext'
 
@@ -8,28 +8,39 @@ interface Props {
   query?: any
 }
 
-export default class MaybeContext extends PureComponent<Props & RenderContextProps> {
+export default class MaybeContext extends PureComponent<
+  Props & RenderContextProps
+> {
   public render() {
-    const {children, runtime, nestedPage, query, params} = this.props
-    const {context, props: pageProps} = runtime.extensions[nestedPage]
+    const { children, runtime, nestedPage, query, params } = this.props
+    const { context, props: pageProps } = runtime.extensions[nestedPage]
     const pageContextProps = pageProps && pageProps.context
 
     let contextComponent
     let props
 
     if (context) {
-      contextComponent  = context.component
+      contextComponent = context.component
       props = {
         ...pageContextProps,
         nextTreePath: nestedPage,
         params,
         query,
-        ...context.props
+        ...context.props,
       }
     }
 
-    return contextComponent
-      ? <ExtensionPointComponent component={contextComponent} props={props} runtime={runtime} treePath={nestedPage}>{children}</ExtensionPointComponent>
-      : children
+    return contextComponent ? (
+      <ExtensionPointComponent
+        component={contextComponent}
+        props={props}
+        runtime={runtime}
+        treePath={nestedPage}
+      >
+        {children}
+      </ExtensionPointComponent>
+    ) : (
+      children
+    )
   }
 }

--- a/react/components/MaybeContext.tsx
+++ b/react/components/MaybeContext.tsx
@@ -12,15 +12,20 @@ export default class MaybeContext extends PureComponent<Props & RenderContextPro
   public render() {
     const {children, runtime, nestedPage, query, params} = this.props
     const {context, props: pageProps} = runtime.extensions[nestedPage]
-    const contextComponent = context && context.component
     const pageContextProps = pageProps && pageProps.context
 
-    const props = contextComponent && {
-      ...pageContextProps,
-      nextTreePath: nestedPage,
-      params,
-      query,
-      ...context!.props
+    let contextComponent
+    let props
+
+    if (context) {
+      contextComponent  = context.component
+      props = {
+        ...pageContextProps,
+        nextTreePath: nestedPage,
+        params,
+        query,
+        ...context.props
+      }
     }
 
     return contextComponent

--- a/react/components/Preview/Box.tsx
+++ b/react/components/Preview/Box.tsx
@@ -6,16 +6,9 @@ interface Props {
   height: number
 }
 
-const Box = ({width, height}: Props) => (
+const Box = ({ width, height }: Props) => (
   <ContentLoader width={width} height={height}>
-    <rect
-      x="0"
-      y="0"
-      rx="5"
-      ry="5"
-      width={width}
-      height={height}
-    />
+    <rect x="0" y="0" rx="5" ry="5" width={width} height={height} />
   </ContentLoader>
 )
 

--- a/react/components/Preview/Circle.tsx
+++ b/react/components/Preview/Circle.tsx
@@ -6,16 +6,13 @@ interface Props {
   height: number
 }
 
-const Circle = ({width, height}: Props) => (
-  <ContentLoader width={width} height={height} preserveAspectRatio="xMidYMid meet">
-    <rect
-      x="0"
-      y="0"
-      rx={width}
-      ry={height}
-      width={width}
-      height={height}
-    />
+const Circle = ({ width, height }: Props) => (
+  <ContentLoader
+    width={width}
+    height={height}
+    preserveAspectRatio="xMidYMid meet"
+  >
+    <rect x="0" y="0" rx={width} ry={height} width={width} height={height} />
   </ContentLoader>
 )
 

--- a/react/components/Preview/ContentLoader.tsx
+++ b/react/components/Preview/ContentLoader.tsx
@@ -3,29 +3,30 @@ import React, { FunctionComponent } from 'react'
 import ReactContentLoader, { IContentLoaderProps } from 'react-content-loader'
 
 interface Props {
-  width: number,
-  height: number,
-  preserveAspectRatio?: string,
+  width: number
+  height: number
+  preserveAspectRatio?: string
 }
 
 const ContentLoader: FunctionComponent<Props> = ({
   children,
   width,
   height,
-  preserveAspectRatio='none',
+  preserveAspectRatio = 'none',
 }) => (
   <ReactContentLoader
     width={width}
     height={height}
-
     /** TODO: get these colors from the store theme */
     primaryColor="#fafafa"
     secondaryColor="#efefef"
-    preserveAspectRatio={preserveAspectRatio as IContentLoaderProps['preserveAspectRatio']}
+    preserveAspectRatio={
+      preserveAspectRatio as IContentLoaderProps['preserveAspectRatio']
+    }
     style={{
       height,
       maxWidth: width,
-      width: '100%'
+      width: '100%',
     }}
   >
     {children}

--- a/react/components/Preview/Grid.tsx
+++ b/react/components/Preview/Grid.tsx
@@ -6,7 +6,7 @@ interface Props {
   height: number
 }
 
-const Grid = ({width, height}: Props) => {
+const Grid = ({ width, height }: Props) => {
   // TODO: make these values configurable
   const itemWidth = 250
   const itemHeight = 400
@@ -15,8 +15,10 @@ const Grid = ({width, height}: Props) => {
   const itemsNumX = Math.floor(width / (itemWidth + minSpacingX))
   const itemsNumY = Math.floor(height / (itemHeight + minSpacingY))
   // distributes the remaining available space between each item of the grid
-  const spacingX = (width - (itemsNumX * itemWidth)) / (itemsNumX > 1 ? itemsNumX - 1 : 2) 
-  const spacingY = (height - (itemsNumY * itemHeight)) / (itemsNumY > 1 ? itemsNumY - 1 : 2)
+  const spacingX =
+    (width - itemsNumX * itemWidth) / (itemsNumX > 1 ? itemsNumX - 1 : 2)
+  const spacingY =
+    (height - itemsNumY * itemHeight) / (itemsNumY > 1 ? itemsNumY - 1 : 2)
 
   return (
     <ContentLoader width={width} height={height}>

--- a/react/components/Preview/Spinner.tsx
+++ b/react/components/Preview/Spinner.tsx
@@ -5,11 +5,16 @@ interface Props {
   height: number
 }
 
-const Spinner = ({width, height}: Props) => (
+const Spinner = ({ width, height }: Props) => (
   <div className="flex items-center justify-center" style={{ width, height }}>
-    <svg width="26px" height="26px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink">
+    <svg
+      width="26px"
+      height="26px"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
       <use xlinkHref="#sti-loading" />
     </svg>
   </div>

--- a/react/components/Preview/Text.tsx
+++ b/react/components/Preview/Text.tsx
@@ -6,7 +6,7 @@ interface Props {
   height: number
 }
 
-const Text = ({width, height}: Props) => {
+const Text = ({ width, height }: Props) => {
   // TODO: make the line height configurable
   const lineHeight = 16
   const lineSize = lineHeight * 1.5
@@ -20,8 +20,7 @@ const Text = ({width, height}: Props) => {
       {Array.from({ length: lines }).map((_, i) => {
         const isLast = i === lines - 1
         const widthMultiplier = isLast ? 0.7 : 1
-        const lineWidth =
-          width * widthMultiplier - horizontalMargin * 2
+        const lineWidth = width * widthMultiplier - horizontalMargin * 2
         return (
           <rect
             key={i}

--- a/react/components/Preview/index.tsx
+++ b/react/components/Preview/index.tsx
@@ -19,7 +19,7 @@ export default class Preview extends React.PureComponent<
 > {
   private container: RefObject<HTMLDivElement>
 
-  constructor(props: Props) {
+  public constructor(props: Props) {
     super(props)
 
     this.container = React.createRef()
@@ -36,6 +36,7 @@ export default class Preview extends React.PureComponent<
     switch (type) {
       case 'box':
       /** TODO: deprecate block in favor of box */
+      // eslint-disable-next-line no-fallthrough
       case 'block':
         return <Box width={width} height={height} />
       case 'text': 
@@ -54,7 +55,7 @@ export default class Preview extends React.PureComponent<
     }
   }
 
-  componentDidMount() { // tslint:disable-line member-access member-ordering
+  public componentDidMount() {
     /** Fixes a bug on react-content-loader related to limiting
      * the width of the component
      */
@@ -111,7 +112,7 @@ export default class Preview extends React.PureComponent<
     }
   }
 
-  render() { // tslint:disable-line member-access member-ordering
+  public render() {
     const { extension } = this.props
 
     if (!extension.preview) {

--- a/react/components/Preview/index.tsx
+++ b/react/components/Preview/index.tsx
@@ -13,10 +13,7 @@ interface State {
   containerWidth?: number | null
 }
 
-export default class Preview extends React.PureComponent<
-  Props,
-  State
-> {
+export default class Preview extends React.PureComponent<Props, State> {
   private container: RefObject<HTMLDivElement>
 
   public constructor(props: Props) {
@@ -28,7 +25,11 @@ export default class Preview extends React.PureComponent<
     }
   }
 
-  private renderPreviewGraphic = (width: number, height: number, type: string): ReactElement<any> | null => {
+  private renderPreviewGraphic = (
+    width: number,
+    height: number,
+    type: string
+  ): ReactElement<any> | null => {
     if (!type || type === 'none') {
       return null
     }
@@ -39,10 +40,10 @@ export default class Preview extends React.PureComponent<
       // eslint-disable-next-line no-fallthrough
       case 'block':
         return <Box width={width} height={height} />
-      case 'text': 
+      case 'text':
         return <Text width={width} height={height} />
       /** TODO: add support for Grid preview */
-      case 'grid': 
+      case 'grid':
         return <Grid width={width} height={height} />
       case 'circle':
         return <Circle width={width} height={height} />
@@ -88,7 +89,8 @@ export default class Preview extends React.PureComponent<
 
     const { defaultValue } = dimensionObject
 
-    const valueFromProp = dimensionObject.fromProp && extension.props[dimensionObject.fromProp]
+    const valueFromProp =
+      dimensionObject.fromProp && extension.props[dimensionObject.fromProp]
 
     if (typeof valueFromProp === 'number') {
       return valueFromProp
@@ -119,22 +121,21 @@ export default class Preview extends React.PureComponent<
       return null
     }
 
-    const {
-      type,
-      fullWidth,
-    } = extension.preview
+    const { type, fullWidth } = extension.preview
 
-    const {
-      width: initialWidth,
-      height: initialHeight,
-    } = this.getDimensions()
+    const { width: initialWidth, height: initialHeight } = this.getDimensions()
 
     const { containerWidth } = this.state
 
-    const maxWidth = containerWidth || (window && window.innerWidth) || initialWidth || 0
+    const maxWidth =
+      containerWidth || (window && window.innerWidth) || initialWidth || 0
 
     const padding = 20
-    const width = (typeof initialWidth === 'number' ? Math.min(maxWidth, initialWidth) : maxWidth) - padding * 2
+    const width =
+      (typeof initialWidth === 'number'
+        ? Math.min(maxWidth, initialWidth)
+        : maxWidth) -
+      padding * 2
     const height = initialHeight ? initialHeight - padding * 2 : 0
 
     return (
@@ -145,10 +146,10 @@ export default class Preview extends React.PureComponent<
       <div
         ref={this.container}
         className={fullWidth ? '' : 'mw9 center'}
-        style={{ padding }}>
+        style={{ padding }}
+      >
         {this.renderPreviewGraphic(width, height, type)}
       </div>
     )
   }
 }
-

--- a/react/components/RenderContext.tsx
+++ b/react/components/RenderContext.tsx
@@ -1,5 +1,5 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import React, {ComponentType, useContext} from 'react'
+import React, { ComponentType, useContext } from 'react'
 
 export interface RenderContextProps {
   runtime: RenderContext
@@ -15,22 +15,44 @@ export const useRuntime = () => {
   return useContext(RenderContext)
 }
 
-export const withRuntimeContext = <TOriginalProps extends {} = {}>(Component: ComponentType<TOriginalProps & RenderContextProps>): ComponentType<TOriginalProps> => {
-  const ExtendedComponent = (props: TOriginalProps) => <RenderContext.Consumer>{runtime => <Component {...props} runtime={runtime} />}</RenderContext.Consumer>
-  ExtendedComponent.displayName = `ExtendedComponent(${Component.displayName || Component.name || 'Component'})`
-  return hoistNonReactStatics<TOriginalProps, RenderContextProps>(ExtendedComponent, Component)
+export const withRuntimeContext = <TOriginalProps extends {} = {}>(
+  Component: ComponentType<TOriginalProps & RenderContextProps>
+): ComponentType<TOriginalProps> => {
+  const ExtendedComponent = (props: TOriginalProps) => (
+    <RenderContext.Consumer>
+      {runtime => <Component {...props} runtime={runtime} />}
+    </RenderContext.Consumer>
+  )
+  ExtendedComponent.displayName = `ExtendedComponent(${Component.displayName ||
+    Component.name ||
+    'Component'})`
+  return hoistNonReactStatics<TOriginalProps, RenderContextProps>(
+    ExtendedComponent,
+    Component
+  )
 }
 
-export const withEmitter = <TOriginalProps extends {} = {}>(Component: ComponentType<TOriginalProps & EmitterProps>): ComponentType<TOriginalProps> => {
+export const withEmitter = <TOriginalProps extends {} = {}>(
+  Component: ComponentType<TOriginalProps & EmitterProps>
+): ComponentType<TOriginalProps> => {
   class WithEmitter extends React.Component<TOriginalProps> {
     public static get displayName(): string {
-      return `WithEmitter(${Component.displayName || Component.name || 'Component'})`
+      return `WithEmitter(${Component.displayName ||
+        Component.name ||
+        'Component'})`
     }
 
     public render() {
-      return <RenderContext.Consumer>{runtime => <Component {...this.props} __emitter={runtime.emitter} />}</RenderContext.Consumer>
+      return (
+        <RenderContext.Consumer>
+          {runtime => <Component {...this.props} __emitter={runtime.emitter} />}
+        </RenderContext.Consumer>
+      )
     }
   }
 
-  return hoistNonReactStatics<TOriginalProps, EmitterProps>(WithEmitter, Component)
+  return hoistNonReactStatics<TOriginalProps, EmitterProps>(
+    WithEmitter,
+    Component
+  )
 }

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -4,7 +4,7 @@ import MaybeContext from './MaybeContext'
 import { RenderContext } from './RenderContext'
 
 interface Props {
-  page: string,
+  page: string
   query?: Record<string, string>
 }
 
@@ -12,12 +12,18 @@ export default class RenderPage extends PureComponent<Props> {
   public render() {
     return (
       <RenderContext.Consumer>
-      {
-        runtime => {
-          const {route: {params}} = runtime
-          const {page, query} = this.props
+        {runtime => {
+          const {
+            route: { params },
+          } = runtime
+          const { page, query } = this.props
           return (
-            <MaybeContext nestedPage={page} query={query} params={params} runtime={runtime}>
+            <MaybeContext
+              nestedPage={page}
+              query={query}
+              params={params}
+              runtime={runtime}
+            >
               <ExtensionPoint
                 id={page}
                 query={query}
@@ -26,8 +32,7 @@ export default class RenderPage extends PureComponent<Props> {
               />
             </MaybeContext>
           )
-        }
-      }
+        }}
       </RenderContext.Consumer>
     )
   }

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -91,7 +91,7 @@ const replaceExtensionsWithDefault = (
   page: string,
   defaultExtensions: Extensions
 ) =>
-  unionKeys(extensions, defaultExtensions).reduce(
+  unionKeys(extensions, defaultExtensions).reduce<Extensions>(
     (acc, key) => {
       const maybeExtension = isChildOrSelf(key, page)
         ? defaultExtensions[key] || {
@@ -104,7 +104,7 @@ const replaceExtensionsWithDefault = (
       }
       return acc
     },
-    {} as Extensions
+    {}
   )
 
 class RenderProvider extends Component<Props, RenderProviderState> {
@@ -171,9 +171,8 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   private sessionPromise: Promise<void>
   private unlisten!: UnregisterCallback | null
   private apolloClient: ApolloClient<NormalizedCacheObject>
-  private lastNavigatedRouteId: string
 
-  constructor(props: Props) {
+  public constructor(props: Props) {
     super(props)
     const {
       appsEtag,
@@ -190,14 +189,14 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       settings,
     } = props.runtime
     const { history, baseURI, cacheControl } = props
-    const ignoreCanonicalReplacement = query && query.map || !route.canonicalPath
+    const ignoreCanonicalReplacement = query && query.map
 
     if (history) {
       const renderLocation: RenderHistoryLocation = {
         ...history.location,
-        pathname: ignoreCanonicalReplacement
+        pathname: ignoreCanonicalReplacement || !route.canonicalPath
           ? history.location.pathname
-          : route.canonicalPath!,
+          : route.canonicalPath,
         state: {
           navigationRoute: {
             id: route.id,
@@ -212,7 +211,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       window.browserHistory = global.browserHistory = history
     }
 
-    this.lastNavigatedRouteId = route.id
     // todo: reload window if client-side created a segment different from server-side
     this.sessionPromise = canUseDOM
       ? window.__RENDER_8_SESSION__.sessionPromise

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -91,21 +91,18 @@ const replaceExtensionsWithDefault = (
   page: string,
   defaultExtensions: Extensions
 ) =>
-  unionKeys(extensions, defaultExtensions).reduce<Extensions>(
-    (acc, key) => {
-      const maybeExtension = isChildOrSelf(key, page)
-        ? defaultExtensions[key] || {
-            ...extensions[key],
-            component: null,
-          }
-        : extensions[key]
-      if (maybeExtension) {
-        acc[key] = maybeExtension
-      }
-      return acc
-    },
-    {}
-  )
+  unionKeys(extensions, defaultExtensions).reduce<Extensions>((acc, key) => {
+    const maybeExtension = isChildOrSelf(key, page)
+      ? defaultExtensions[key] || {
+          ...extensions[key],
+          component: null,
+        }
+      : extensions[key]
+    if (maybeExtension) {
+      acc[key] = maybeExtension
+    }
+    return acc
+  }, {})
 
 class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
@@ -160,11 +157,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           this.getChildContext(),
           messages,
           shouldUpdateRuntime,
-          this.updateMessages,
+          this.updateMessages
         )
       }
     },
-    SEND_INFO_DEBOUNCE_MS,
+    SEND_INFO_DEBOUNCE_MS
   )
 
   private rendered!: boolean
@@ -194,9 +191,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     if (history) {
       const renderLocation: RenderHistoryLocation = {
         ...history.location,
-        pathname: ignoreCanonicalReplacement || !route.canonicalPath
-          ? history.location.pathname
-          : route.canonicalPath,
+        pathname:
+          ignoreCanonicalReplacement || !route.canonicalPath
+            ? history.location.pathname
+            : route.canonicalPath,
         state: {
           navigationRoute: {
             id: route.id,
@@ -392,7 +390,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public setQuery = (
     query: Record<string, any> = {},
-    { merge = true, replace = false, scrollOptions = false}: SetQueryOptions = {}
+    {
+      merge = true,
+      replace = false,
+      scrollOptions = false,
+    }: SetQueryOptions = {}
   ): boolean => {
     const { history } = this.props
     const {
@@ -864,7 +866,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       }),
       () => {
         this.sendInfoFromIframe()
-      },
+      }
     )
   }
 }

--- a/react/components/ScopeMessagesHandler.tsx
+++ b/react/components/ScopeMessagesHandler.tsx
@@ -14,19 +14,16 @@ const removeScopeForApp = (appNameAtMajor: string) => (key: string) => {
 }
 
 export const scopeMessages = (app: string, Component: any) => {
-  const ScopeMessagesComponent = ({children, intl, ...props}: any) => {
+  const ScopeMessagesComponent = ({ children, intl, ...props }: any) => {
     const { messages } = intl
     const [appName, version] = app.split('@')
     const [major] = version.split('.')
     const appNameAtMajor = `${appName}@${major}.x`
     const removeScope = removeScopeForApp(appNameAtMajor)
-    forEachObjIndexed(
-      (value, key, obj) => {
-        const renamedKey = removeScope(key as string)
-        obj[renamedKey] = value
-      },
-      messages
-    )
+    forEachObjIndexed((value, key, obj) => {
+      const renamedKey = removeScope(key as string)
+      obj[renamedKey] = value
+    }, messages)
     return (
       <IntlProvider messages={messages}>
         <Component {...props}>{children}</Component>

--- a/react/components/ScopeMessagesHandler.tsx
+++ b/react/components/ScopeMessagesHandler.tsx
@@ -9,31 +9,30 @@ const removeScopeForApp = (appNameAtMajor: string) => (key: string) => {
   if (key.indexOf(appNameAtMajor) === -1) {
     return key
   }
-  const [_, unScopedKey] = key.split(APP_SPACER)
+  const unScopedKey = key.split(APP_SPACER)[1]
   return unScopedKey
 }
 
-const ScopeMessagesComponent = (app: string, Component: any) => ({children, intl, ...props}: any) => {
-  const { messages } = intl
-  const [appName, version] = app.split('@')
-  const [major] = version.split('.')
-  const appNameAtMajor = `${appName}@${major}.x`
-  const removeScope = removeScopeForApp(appNameAtMajor)
-  forEachObjIndexed(
-    (value, key, obj) => {
-      const renamedKey = removeScope(key as string)
-      obj[renamedKey] = value
-    },
-    messages
-  )
-  return (
-    <IntlProvider messages={messages}>
-      <Component {...props}>{children}</Component>
-    </IntlProvider>
-  )
-}
+export const scopeMessages = (app: string, Component: any) => {
+  const ScopeMessagesComponent = ({children, intl, ...props}: any) => {
+    const { messages } = intl
+    const [appName, version] = app.split('@')
+    const [major] = version.split('.')
+    const appNameAtMajor = `${appName}@${major}.x`
+    const removeScope = removeScopeForApp(appNameAtMajor)
+    forEachObjIndexed(
+      (value, key, obj) => {
+        const renamedKey = removeScope(key as string)
+        obj[renamedKey] = value
+      },
+      messages
+    )
+    return (
+      <IntlProvider messages={messages}>
+        <Component {...props}>{children}</Component>
+      </IntlProvider>
+    )
+  }
 
-export const scopeMessages = (app: string, Component: any) => hoistNonReactStatics(
-  injectIntl(ScopeMessagesComponent(app, Component)),
-  Component
-)
+  return hoistNonReactStatics(injectIntl(ScopeMessagesComponent), Component)
+}

--- a/react/components/Session.tsx
+++ b/react/components/Session.tsx
@@ -1,4 +1,4 @@
-import React, {Component, ReactElement} from 'react'
+import React, {Component} from 'react'
 import Loading from './Loading'
 import {RenderContextProps, withRuntimeContext} from './RenderContext'
 

--- a/react/components/Session.tsx
+++ b/react/components/Session.tsx
@@ -1,6 +1,6 @@
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import Loading from './Loading'
-import {RenderContextProps, withRuntimeContext} from './RenderContext'
+import { RenderContextProps, withRuntimeContext } from './RenderContext'
 
 interface State {
   ensured: boolean
@@ -8,7 +8,7 @@ interface State {
 }
 
 class Session extends Component<RenderContextProps, State> {
-  public state = {ensured: false, error: null}
+  public state = { ensured: false, error: null }
 
   public componentDidMount() {
     this.onUpdate()
@@ -19,8 +19,8 @@ class Session extends Component<RenderContextProps, State> {
   }
 
   public render() {
-    const {children} = this.props
-    const {ensured, error} = this.state
+    const { children } = this.props
+    const { ensured, error } = this.state
 
     if (ensured) {
       return children
@@ -31,9 +31,7 @@ class Session extends Component<RenderContextProps, State> {
         <div className="bg-washed-red pa6 f5 serious-black br3 pre">
           <span>Error initializing session</span>
           <pre>
-            <code className="f6">
-              {error}
-            </code>
+            <code className="f6">{error}</code>
           </pre>
         </div>
       )
@@ -43,8 +41,10 @@ class Session extends Component<RenderContextProps, State> {
   }
 
   private onUpdate() {
-    const {runtime: {ensureSession}} = this.props
-    const {ensured, error} = this.state
+    const {
+      runtime: { ensureSession },
+    } = this.props
+    const { ensured, error } = this.state
 
     if (ensured || error) {
       return
@@ -52,10 +52,10 @@ class Session extends Component<RenderContextProps, State> {
 
     ensureSession()
       .then(() => {
-        this.setState({ensured: true})
+        this.setState({ ensured: true })
       })
       .catch((err: any) => {
-        this.setState({error: err})
+        this.setState({ error: err })
       })
   }
 }

--- a/react/components/TrackEventsWrapper.tsx
+++ b/react/components/TrackEventsWrapper.tsx
@@ -24,6 +24,7 @@ class TrackEventsWrapper extends PureComponent<Props> {
   public componentDidMount(){
     const { id, events } = this.props
     if(events && events.length && id){
+      // eslint-disable-next-line react/no-find-dom-node
       const element = ReactDOM.findDOMNode(this)
       if(element && element.addEventListener){
         forEach(
@@ -39,6 +40,7 @@ class TrackEventsWrapper extends PureComponent<Props> {
   public componentWillUnmount(){
     const { id, events } = this.props
     if(events && events.length && id){
+      // eslint-disable-next-line react/no-find-dom-node
       const element = ReactDOM.findDOMNode(this)
       if(element && element.addEventListener){
         forEach(

--- a/react/components/TrackEventsWrapper.tsx
+++ b/react/components/TrackEventsWrapper.tsx
@@ -8,49 +8,51 @@ interface Props {
 }
 
 const sendEvent = (id: string, event: string) => {
-  window.postMessage({
-    pageComponentInteraction : {
-      blockId: id,
-      interactionType: event,
-      namespace: 'renderRuntime',
-    }
-  }, '*')
+  window.postMessage(
+    {
+      pageComponentInteraction: {
+        blockId: id,
+        interactionType: event,
+        namespace: 'renderRuntime',
+      },
+    },
+    '*'
+  )
 }
 
 class TrackEventsWrapper extends PureComponent<Props> {
-
   public eventsHandler: Record<string, () => void> = {}
 
-  public componentDidMount(){
+  public componentDidMount() {
     const { id, events } = this.props
-    if(events && events.length && id){
+    if (events && events.length && id) {
       // eslint-disable-next-line react/no-find-dom-node
       const element = ReactDOM.findDOMNode(this)
-      if(element && element.addEventListener){
-        forEach(
-          event => {
-            this.eventsHandler[event] = () => sendEvent(id, event)
-            element.addEventListener(event, this.eventsHandler[event])
-          }
-        , events)
+      if (element && element.addEventListener) {
+        forEach(event => {
+          this.eventsHandler[event] = () => sendEvent(id, event)
+          element.addEventListener(event, this.eventsHandler[event])
+        }, events)
       }
     }
   }
 
-  public componentWillUnmount(){
+  public componentWillUnmount() {
     const { id, events } = this.props
-    if(events && events.length && id){
+    if (events && events.length && id) {
       // eslint-disable-next-line react/no-find-dom-node
       const element = ReactDOM.findDOMNode(this)
-      if(element && element.addEventListener){
+      if (element && element.addEventListener) {
         forEach(
-          event => element.removeEventListener(event, this.eventsHandler[event])
-        , events)
+          event =>
+            element.removeEventListener(event, this.eventsHandler[event]),
+          events
+        )
       }
     }
   }
 
-  public render(){
+  public render() {
     const { children } = this.props
     return children
   }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -56,7 +56,7 @@ const renderExtension = (extensionName: string, destination: HTMLElement, props 
       destination,
       extensionName,
       props
-    } as PortalRenderingRequest)
+    })
   } else {
     throw new Error(`ExtensionPortal can't be rendered before RenderProvider`)
   }
@@ -92,7 +92,7 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
 
   const isPage = !!pages[name] && !!pages[name].path && !!extensions[name].component
   const created = !element && ensureContainer(page)
-  const elem = element || getContainer(name)
+  const elem = element || getContainer()
   const history = canUseDOM && isPage && !customRouting ? createHistory() : null
   const root = (
     <RenderProvider history={history} cacheControl={cacheControl} baseURI={baseURI} root={name} runtime={runtime}>
@@ -104,6 +104,7 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
     ? (disableSSR || created ? renderDOM<HTMLDivElement>(root, elem) : hydrate(root, elem)) as Element
     : renderToStringWithData(root).then(({ markup, renderTimeMetric }) => ({
       markups: getMarkups(name, markup),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       maxAge: cacheControl!.maxAge,
       page,
       renderTimeMetric
@@ -149,7 +150,7 @@ function start() {
       if (props && props.style && isStyleWritable(props)) {
         props.style = optimizeStyleForVtexImg(vtexImgHost, props.style)
       }
-      return ReactCreateElement.apply<typeof React, any, any>(React, arguments)
+      return ReactCreateElement.apply(React, arguments)
     }
 
     const maybeRenderPromise = render(rootName, runtime)
@@ -157,9 +158,9 @@ function start() {
       // Expose render promise to global context.
       window.rendered = (maybeRenderPromise as Promise<NamedServerRendered>)
         .then(({ markups, maxAge, page, renderTimeMetric }) => ({
-          extensions: markups.reduce(
+          extensions: markups.reduce<RenderedSuccess['extensions']>(
             (acc, { name, markup }) => (acc[name] = markup, acc),
-            {} as RenderedSuccess['extensions'],
+            {},
           ),
           head: Helmet.rewind(),
           maxAge,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -6,13 +6,13 @@ import 'apollo-upload-client'
 import 'apollo-utilities'
 import 'classnames'
 import * as EventEmitter from 'eventemitter3'
-import {canUseDOM} from 'exenv'
+import { canUseDOM } from 'exenv'
 import 'graphql'
 import createHistory from 'history/createBrowserHistory'
-import React, {ReactElement} from 'react'
-import {getDataFromTree} from 'react-apollo'
-import {hydrate, render as renderDOM} from 'react-dom'
-import {Helmet} from 'react-helmet'
+import React, { ReactElement } from 'react'
+import { getDataFromTree } from 'react-apollo'
+import { hydrate, render as renderDOM } from 'react-dom'
+import { Helmet } from 'react-helmet'
 import NoSSR from 'react-no-ssr'
 import Loading from '../components/Loading'
 
@@ -23,7 +23,11 @@ import ExtensionPoint from '../components/ExtensionPoint'
 import LayoutContainer from '../components/LayoutContainer'
 import LegacyExtensionContainer from '../components/LegacyExtensionContainer'
 import Link from '../components/Link'
-import { RenderContext, useRuntime, withRuntimeContext  } from '../components/RenderContext'
+import {
+  RenderContext,
+  useRuntime,
+  withRuntimeContext,
+} from '../components/RenderContext'
 import RenderProvider from '../components/RenderProvider'
 import { getVTEXImgHost } from '../utils/assets'
 import PageCacheControl from '../utils/cacheControl'
@@ -36,7 +40,11 @@ import { addLocaleData } from '../utils/locales'
 import registerComponent from '../utils/registerComponent'
 import { withSession } from '../utils/session'
 import { TreePathContext, useTreePath } from '../utils/treePath'
-import { isStyleWritable, optimizeSrcForVtexImg, optimizeStyleForVtexImg } from '../utils/vteximg'
+import {
+  isStyleWritable,
+  optimizeSrcForVtexImg,
+  optimizeStyleForVtexImg,
+} from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
 
 let emitter: EventEmitter | null = null
@@ -50,19 +58,25 @@ if (window.IntlPolyfill) {
   }
 }
 
-const renderExtension = (extensionName: string, destination: HTMLElement, props = {}) => {
-  if(emitter) {
+const renderExtension = (
+  extensionName: string,
+  destination: HTMLElement,
+  props = {}
+) => {
+  if (emitter) {
     emitter.emit('renderExtensionLoader.addOrUpdateExtension', {
       destination,
       extensionName,
-      props
+      props,
     })
   } else {
     throw new Error(`ExtensionPortal can't be rendered before RenderProvider`)
   }
 }
 
-function renderToStringWithData(component: ReactElement<any>): Promise<ServerRendered> {
+function renderToStringWithData(
+  component: ReactElement<any>
+): Promise<ServerRendered> {
   const startGetDataFromTree = window.hrtime()
   return getDataFromTree(component).then(() => {
     const endGetDataFromTree = window.hrtime(startGetDataFromTree)
@@ -81,8 +95,19 @@ function renderToStringWithData(component: ReactElement<any>): Promise<ServerRen
 }
 
 // Either renders the root component to a DOM element or returns a {name, markup} promise.
-const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Rendered => {
-  const { customRouting, disableSSR, page, pages, extensions, culture: { locale } } = runtime
+const render = (
+  name: string,
+  runtime: RenderRuntime,
+  element?: HTMLElement
+): Rendered => {
+  const {
+    customRouting,
+    disableSSR,
+    page,
+    pages,
+    extensions,
+    culture: { locale },
+  } = runtime
 
   const cacheControl = canUseDOM ? undefined : new PageCacheControl()
   const baseURI = getBaseURI(runtime)
@@ -90,26 +115,34 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
   emitter = runtime.emitter
   addLocaleData(locale)
 
-  const isPage = !!pages[name] && !!pages[name].path && !!extensions[name].component
+  const isPage =
+    !!pages[name] && !!pages[name].path && !!extensions[name].component
   const created = !element && ensureContainer(page)
   const elem = element || getContainer()
   const history = canUseDOM && isPage && !customRouting ? createHistory() : null
   const root = (
-    <RenderProvider history={history} cacheControl={cacheControl} baseURI={baseURI} root={name} runtime={runtime}>
+    <RenderProvider
+      history={history}
+      cacheControl={cacheControl}
+      baseURI={baseURI}
+      root={name}
+      runtime={runtime}
+    >
       {!isPage ? <ExtensionPoint id={name} /> : null}
     </RenderProvider>
   )
 
   return canUseDOM
-    ? (disableSSR || created ? renderDOM<HTMLDivElement>(root, elem) : hydrate(root, elem)) as Element
+    ? ((disableSSR || created
+        ? renderDOM<HTMLDivElement>(root, elem)
+        : hydrate(root, elem)) as Element)
     : renderToStringWithData(root).then(({ markup, renderTimeMetric }) => ({
-      markups: getMarkups(name, markup),
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      maxAge: cacheControl!.maxAge,
-      page,
-      renderTimeMetric
-    })
-    )
+        markups: getMarkups(name, markup),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        maxAge: cacheControl!.maxAge,
+        page,
+        renderTimeMetric,
+      }))
 }
 
 function validateRootComponent(rootName: string, extensions: Extensions) {
@@ -137,7 +170,10 @@ function start() {
         }
         // Follow Google's security recommendations concerning target blank
         // https://developers.google.com/web/tools/lighthouse/audits/noopener
-        if (props.target === '_blank' && !(props.rel === 'noopener' || props.rel === 'noreferrer')) {
+        if (
+          props.target === '_blank' &&
+          !(props.rel === 'noopener' || props.rel === 'noreferrer')
+        ) {
           props.rel = 'noopener'
         }
       }
@@ -156,19 +192,22 @@ function start() {
     const maybeRenderPromise = render(rootName, runtime)
     if (!canUseDOM) {
       // Expose render promise to global context.
-      window.rendered = (maybeRenderPromise as Promise<NamedServerRendered>)
-        .then(({ markups, maxAge, page, renderTimeMetric }) => ({
-          extensions: markups.reduce<RenderedSuccess['extensions']>(
-            (acc, { name, markup }) => (acc[name] = markup, acc),
-            {},
-          ),
-          head: Helmet.rewind(),
-          maxAge,
-          renderMetrics: { [page]: renderTimeMetric },
-          state: getState(runtime),
-        }))
+      window.rendered = (maybeRenderPromise as Promise<
+        NamedServerRendered
+      >).then(({ markups, maxAge, page, renderTimeMetric }) => ({
+        extensions: markups.reduce<RenderedSuccess['extensions']>(
+          (acc, { name, markup }) => ((acc[name] = markup), acc),
+          {}
+        ),
+        head: Helmet.rewind(),
+        maxAge,
+        renderMetrics: { [page]: renderTimeMetric },
+        state: getState(runtime),
+      }))
     } else {
-      console.log('Welcome to Render! Want to look under the hood? https://careers.vtex.com')
+      console.log(
+        'Welcome to Render! Want to look under the hood? https://careers.vtex.com'
+      )
     }
   } catch (error) {
     console.error('Unexpected error rendering:', error)
@@ -211,6 +250,5 @@ export {
   withSession,
   Loading,
   buildCacheLocator,
-  renderExtension
+  renderExtension,
 }
-

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -1,3 +1,4 @@
+/* global module */
 import * as runtimeGlobals from './core/main'
 
 window.__RENDER_8_RUNTIME__ = {...runtimeGlobals}
@@ -26,6 +27,7 @@ start()
 
 if (module.hot) {
   module.hot.accept('./core/main', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hotGlobals = require('./core/main')
     window.__RENDER_8_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
     window.__RENDER_8_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint
@@ -38,7 +40,7 @@ if (module.hot) {
 } else {
   const CLOSED = 2
   let eventSource: any
-  function initSSE () {
+  const initSSE = () => {
     const hasNoSSE = !eventSource || eventSource.readyState === CLOSED
     if (!document.hidden && hasNoSSE) {
       eventSource = window.myvtexSSE(global.__RUNTIME__.account, global.__RUNTIME__.workspace, 'vtex.builder-hub:*:build.status', {verbose: true}, (event: any) => {

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -1,24 +1,27 @@
 /* global module */
 import * as runtimeGlobals from './core/main'
 
-window.__RENDER_8_RUNTIME__ = {...runtimeGlobals}
+window.__RENDER_8_RUNTIME__ = { ...runtimeGlobals }
 
 // compatibility
-window.__RENDER_8_COMPONENTS__ = window.__RENDER_8_COMPONENTS__ || global.__RENDER_8_COMPONENTS__
+window.__RENDER_8_COMPONENTS__ =
+  window.__RENDER_8_COMPONENTS__ || global.__RENDER_8_COMPONENTS__
 window.__RENDER_8_HOT__ = window.__RENDER_8_HOT__ || global.__RENDER_8_HOT__
 global.__RUNTIME__ = window.__RUNTIME__
 
 const ERROR_COMPONENT_REGEX = /vtex.render-runtime@\d+\.\d+\.\d+\/ErrorPage/
 
 const start = () => {
-  const errorComponent = Object.keys(global.__RENDER_8_COMPONENTS__).find((k: string) => ERROR_COMPONENT_REGEX.test(k)) as string
+  const errorComponent = Object.keys(global.__RENDER_8_COMPONENTS__).find(
+    (k: string) => ERROR_COMPONENT_REGEX.test(k)
+  ) as string
   global.__RUNTIME__.extensions = global.__RUNTIME__.extensions || {}
   global.__RUNTIME__.pages = global.__RUNTIME__.pages || {}
   global.__RUNTIME__.components = global.__RUNTIME__.components || {}
   global.__RUNTIME__.disableSSR = true
   global.__RUNTIME__.extensions.error = {
     component: errorComponent,
-    props: {}
+    props: {},
   }
   runtimeGlobals.render('error', global.__RUNTIME__)
 }
@@ -29,7 +32,8 @@ if (module.hot) {
   module.hot.accept('./core/main', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hotGlobals = require('./core/main')
-    window.__RENDER_8_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
+    window.__RENDER_8_RUNTIME__.ExtensionContainer =
+      hotGlobals.ExtensionContainer
     window.__RENDER_8_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint
     window.__RENDER_8_RUNTIME__.LayoutContainer = hotGlobals.LayoutContainer
     window.__RENDER_8_RUNTIME__.Link = hotGlobals.Link
@@ -43,11 +47,17 @@ if (module.hot) {
   const initSSE = () => {
     const hasNoSSE = !eventSource || eventSource.readyState === CLOSED
     if (!document.hidden && hasNoSSE) {
-      eventSource = window.myvtexSSE(global.__RUNTIME__.account, global.__RUNTIME__.workspace, 'vtex.builder-hub:*:build.status', {verbose: true}, (event: any) => {
-        if (event.body && event.body.code === 'success') {
-          window.location.reload()
+      eventSource = window.myvtexSSE(
+        global.__RUNTIME__.account,
+        global.__RUNTIME__.workspace,
+        'vtex.builder-hub:*:build.status',
+        { verbose: true },
+        (event: any) => {
+          if (event.body && event.body.code === 'success') {
+            window.location.reload()
+          }
         }
-      })
+      )
     }
   }
   initSSE()

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,3 +1,4 @@
+/* global module */
 import 'core-js/es6/symbol'
 import 'core-js/fn/symbol/iterator'
 import * as runtimeGlobals from './core/main'
@@ -11,6 +12,7 @@ global.__RUNTIME__ = window.__RUNTIME__
 
 if (module.hot) {
   module.hot.accept('./core/main', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hotGlobals = require('./core/main')
     window.__RENDER_8_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
     window.__RENDER_8_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -3,10 +3,11 @@ import 'core-js/es6/symbol'
 import 'core-js/fn/symbol/iterator'
 import * as runtimeGlobals from './core/main'
 
-window.__RENDER_8_RUNTIME__ = {...runtimeGlobals}
+window.__RENDER_8_RUNTIME__ = { ...runtimeGlobals }
 
 // compatibility
-window.__RENDER_8_COMPONENTS__ = window.__RENDER_8_COMPONENTS__ || global.__RENDER_8_COMPONENTS__
+window.__RENDER_8_COMPONENTS__ =
+  window.__RENDER_8_COMPONENTS__ || global.__RENDER_8_COMPONENTS__
 window.__RENDER_8_HOT__ = window.__RENDER_8_HOT__ || global.__RENDER_8_HOT__
 global.__RUNTIME__ = window.__RUNTIME__
 
@@ -14,7 +15,8 @@ if (module.hot) {
   module.hot.accept('./core/main', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hotGlobals = require('./core/main')
-    window.__RENDER_8_RUNTIME__.ExtensionContainer = hotGlobals.ExtensionContainer
+    window.__RENDER_8_RUNTIME__.ExtensionContainer =
+      hotGlobals.ExtensionContainer
     window.__RENDER_8_RUNTIME__.ExtensionPoint = hotGlobals.ExtensionPoint
     window.__RENDER_8_RUNTIME__.LayoutContainer = hotGlobals.LayoutContainer
     window.__RENDER_8_RUNTIME__.Link = hotGlobals.Link

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": null,
   "license": "UNLICENSED",
   "scripts": {
-    "lint": "tsc --noEmit --pretty && tslint src/**/*.ts",
+    "lint": "tsc --noEmit --pretty && eslint --ext ts,tsx .",
     "test": "jest"
   },
   "dependencies": {
@@ -58,11 +58,14 @@
     "babel-jest": "^24.1.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react-app": "^7.0.1",
+    "eslint": "^5.16.0",
+    "eslint-config-vtex-react": "^4.1.0",
     "eventsource-polyfill": "^0.9.6",
     "history": "^4.7.2",
     "jest": "^24.1.0",
     "jest-dom": "^3.1.1",
     "jest-transform-graphql": "^2.1.0",
+    "prettier": "^1.17.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hot-loader": "^4.3.12",
@@ -70,9 +73,6 @@
     "react-testing-library": "^5.6.0",
     "regenerator-runtime": "^0.13.1",
     "ts-jest": "^23.10.5",
-    "tslint": "^5.2.0",
-    "tslint-config-vtex": "^2.0.0",
-    "tslint-eslint-rules": "^5.1.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.4.5"
   }
 }

--- a/react/start.ts
+++ b/react/start.ts
@@ -1,15 +1,16 @@
 import * as Sentry from '@sentry/browser'
-import {canUseDOM} from 'exenv'
+import { canUseDOM } from 'exenv'
 
 if (canUseDOM && window.__RUNTIME__.production) {
   const { config = null, version = '' } = window.__RUNTIME__.runtimeMeta || {}
   const dsn = config && config.sentryDSN
   Sentry.init({
-    beforeSend: (event: Sentry.SentryEvent) => event.tags && event.tags.component ? event : null,
+    beforeSend: (event: Sentry.SentryEvent) =>
+      event.tags && event.tags.component ? event : null,
     defaultIntegrations: true,
     dsn,
     environment: canUseDOM ? 'browser' : 'ssr',
-    release: version
+    release: version,
   })
 }
 

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,27 +1,31 @@
 {
   "compilerOptions": {
-    "types": [
-      "jest",
-      "node"
-    ],
+    "alwaysStrict": true,
+    "esModuleInterop": true,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "es2018.promise"],
     "module": "es6",
     "moduleResolution": "node",
-    "sourceMap": true,
-    "target": "es2017",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
-    "strict": true
+    "sourceMap": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "target": "es2017",
+    "typeRoots": ["node_modules/@types"],
+    "types": ["node", "jest", "graphql"]
   },
+  "exclude": ["node_modules"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
   "typeAcquisition": {
     "enable": false
-  },
-  "include": [
-    "./**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  }
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -12,7 +12,6 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/react/tsconfig.test.json
+++ b/react/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "esModuleInterop": true
-  }
-}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,19 +1,19 @@
-import {ApolloClient, Subscription} from 'apollo-client'
-import {NormalizedCacheObject} from "apollo-cache-inmemory"
-import {EventEmitter} from 'eventemitter3'
-import {ReactElement, Component} from "react"
-import ExtensionContainer from "../ExtensionContainer"
-import ExtensionPoint from "../ExtensionPoint"
-import Link from "../components/Link"
-import {History, Location} from "history"
-import {HelmetData} from "react-helmet"
-import {TreePathProps} from "../utils/treePath"
+import { ApolloClient, Subscription } from 'apollo-client'
+import { NormalizedCacheObject } from 'apollo-cache-inmemory'
+import { EventEmitter } from 'eventemitter3'
+import { ReactElement, Component } from 'react'
+import ExtensionContainer from '../ExtensionContainer'
+import ExtensionPoint from '../ExtensionPoint'
+import Link from '../components/Link'
+import { History, Location } from 'history'
+import { HelmetData } from 'react-helmet'
+import { TreePathProps } from '../utils/treePath'
 import { LayoutContainer } from '../core/main'
 
 declare global {
   interface RenderMetric {
-    getDataFromTree: [number, number],
-    renderToString: [number, number],
+    getDataFromTree: [number, number]
+    renderToString: [number, number]
   }
 
   interface ServerRendered {
@@ -155,8 +155,8 @@ declare global {
   }
 
   interface RenderedSuccess {
-    state: any,
-    head: HelmetData,
+    state: any
+    head: HelmetData
     maxAge: number
     extensions: {
       [id: string]: string
@@ -179,34 +179,34 @@ declare global {
   }
 
   interface RenderContext {
-    account: RenderRuntime['account'],
-    components: RenderRuntime['components'],
-    culture: RenderRuntime['culture'],
-    device: ConfigurationDevice,
-    emitter: RenderRuntime['emitter'],
-    ensureSession: () => Promise<void>,
-    extensions: RenderRuntime['extensions'],
-    fetchComponent: (component: string) => Promise<void>,
-    getSettings: (app: string) => any,
-    hints: RenderHints,
-    history: History | null,
-    navigate: (options: NavigateOptions) => boolean,
-    onPageChanged: (location: RenderHistoryLocation) => void,
-    page: RenderRuntime['page'],
-    pages: RenderRuntime['pages'],
-    patchSession: (data?: any) => Promise<void>,
-    prefetchPage: (name: string) => void,
-    preview: RenderRuntime['preview'],
-    production: RenderRuntime['production'],
-    publicEndpoint: RenderRuntime['publicEndpoint'],
-    setDevice: (device: ConfigurationDevice) => void,
-    updateComponentAssets: (availableComponents: Components) => void,
-    updateExtension: (name: string, extension: Extension) => void,
-    updateRuntime: (options?: PageContextOptions) => Subscription,
-    workspace: RenderRuntime['workspace'],
-    route: RenderRuntime['route'],
-    query: RenderRuntime['query'],
-    defaultExtensions: RenderRuntime['defaultExtensions'],
+    account: RenderRuntime['account']
+    components: RenderRuntime['components']
+    culture: RenderRuntime['culture']
+    device: ConfigurationDevice
+    emitter: RenderRuntime['emitter']
+    ensureSession: () => Promise<void>
+    extensions: RenderRuntime['extensions']
+    fetchComponent: (component: string) => Promise<void>
+    getSettings: (app: string) => any
+    hints: RenderHints
+    history: History | null
+    navigate: (options: NavigateOptions) => boolean
+    onPageChanged: (location: RenderHistoryLocation) => void
+    page: RenderRuntime['page']
+    pages: RenderRuntime['pages']
+    patchSession: (data?: any) => Promise<void>
+    prefetchPage: (name: string) => void
+    preview: RenderRuntime['preview']
+    production: RenderRuntime['production']
+    publicEndpoint: RenderRuntime['publicEndpoint']
+    setDevice: (device: ConfigurationDevice) => void
+    updateComponentAssets: (availableComponents: Components) => void
+    updateExtension: (name: string, extension: Extension) => void
+    updateRuntime: (options?: PageContextOptions) => Subscription
+    workspace: RenderRuntime['workspace']
+    route: RenderRuntime['route']
+    query: RenderRuntime['query']
+    defaultExtensions: RenderRuntime['defaultExtensions']
     rootPath?: string
   }
 
@@ -218,21 +218,21 @@ declare global {
   }
 
   interface FetchRoutesInput extends PageContextOptions {
-    apolloClient: ApolloClient<NormalizedCacheObject>,
-    locale: string,
-    page: string,
-    paramsJSON?: string,
-    path?: string,
-    production: boolean,
-    renderMajor: number,
+    apolloClient: ApolloClient<NormalizedCacheObject>
+    locale: string
+    page: string
+    paramsJSON?: string
+    path?: string
+    production: boolean
+    renderMajor: number
   }
 
   interface FetchDefaultPages {
-    apolloClient: ApolloClient<NormalizedCacheObject>,
-    locale: string,
-    pages: Pages,
-    routeIds: string[],
-    renderMajor: number,
+    apolloClient: ApolloClient<NormalizedCacheObject>
+    locale: string
+    pages: Pages
+    routeIds: string[]
+    renderMajor: number
   }
 
   interface FetchNavigationDataInput {
@@ -243,15 +243,15 @@ declare global {
     declarer?: string
     paramsJSON?: string
     path?: string
-    renderMajor: number,
+    renderMajor: number
     query: string
   }
 
-interface RenderComponent<P={}, S={}> {
-  getCustomMessages?: (locale: string) => any
-  WrappedComponent?: RenderComponent
-  new(): Component<P,S>
-}
+  interface RenderComponent<P = {}, S = {}> {
+    getCustomMessages?: (locale: string) => any
+    WrappedComponent?: RenderComponent
+    new (): Component<P, S>
+  }
 
   interface ComponentsRegistry {
     [component: string]: RenderComponent<any, any>
@@ -267,12 +267,12 @@ interface RenderComponent<P={}, S={}> {
   }
 
   interface DefaultPagesQueryResult {
-    data: DefaultPagesQueryResultData,
-    errors?: any,
+    data: DefaultPagesQueryResultData
+    errors?: any
   }
 
   interface DefaultPagesQueryResultData {
-    defaultPages: DefaultPagesQueryResponse,
+    defaultPages: DefaultPagesQueryResponse
   }
 
   interface PageDataContext {
@@ -369,7 +369,7 @@ interface RenderComponent<P={}, S={}> {
       config?: any
     }
     settings: {
-      [app: string]: any;
+      [app: string]: any
     }
     cacheHints: CacheHintsMap
     segmentToken: string
@@ -405,7 +405,11 @@ interface RenderComponent<P={}, S={}> {
     buildCacheLocator: any
     useRuntime(): RenderContext
     start(): void
-    render(name: string, runtime: RenderRuntime, element?: HTMLElement): Rendered
+    render(
+      name: string,
+      runtime: RenderRuntime,
+      element?: HTMLElement
+    ): Rendered
   }
 
   interface RenderSession {
@@ -430,7 +434,7 @@ interface RenderComponent<P={}, S={}> {
       runtime: RenderContext | null,
       messages: Record<string, string>,
       shouldUpdateRuntime: boolean,
-      setMessages: (messages: RenderRuntime['messages']) => void,
+      setMessages: (messages: RenderRuntime['messages']) => void
     ) => void
     browserHistory: History
     ReactIntlLocaleData: any

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -388,9 +388,9 @@ interface RenderComponent<P={}, S={}> {
   }
 
   interface RuntimeExports {
-    ExtensionContainer: typeof ExtensionContainer
-    ExtensionPoint: typeof ExtensionPoint
-    Link: typeof Link
+    ExtensionContainer: ExtensionContainer
+    ExtensionPoint: ExtensionPoint
+    Link: Link
     NoSSR: any
     LayoutContainer: any
     LegacyExtensionContainer: any

--- a/react/typings/node.d.ts
+++ b/react/typings/node.d.ts
@@ -7,10 +7,10 @@ declare var global: Window
 declare var module: Module
 
 declare module '*.graphql' {
-  import {DocumentNode} from 'graphql';
+  import { DocumentNode } from 'graphql'
 
-  const value: DocumentNode;
-  export default value;
+  const value: DocumentNode
+  export default value
 }
 
 declare module '*.png' {
@@ -19,8 +19,8 @@ declare module '*.png' {
 }
 
 declare module '*.css' {
-  const content: any;
-  export default content;
+  const content: any
+  export default content
 }
 
 declare var vtex: any

--- a/react/typings/react-no-ssr.d.ts
+++ b/react/typings/react-no-ssr.d.ts
@@ -1,3 +1,1 @@
-declare module 'react-no-ssr' {
-
-}
+declare module 'react-no-ssr' {}

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -136,42 +136,67 @@ function isStyle(path: string) {
   return getExtension(path) === '.css'
 }
 
-export function shouldAddScriptToPage(path: string, scripts: string[] = getExistingScriptSrcs()) {
+export function shouldAddScriptToPage(
+  path: string,
+  scripts: string[] = getExistingScriptSrcs()
+) {
   return isScript(path) && !assetOnList(path, scripts)
 }
 
-function shouldAddStyleToPage(path: string, styles: string[] = getExistingStyleHrefs()) {
+function shouldAddStyleToPage(
+  path: string,
+  styles: string[] = getExistingStyleHrefs()
+) {
   return isStyle(path) && !assetOnList(path, styles)
 }
 
-export function getImplementation<P={}, S={}>(component: string) {
+export function getImplementation<P = {}, S = {}>(component: string) {
   return window.__RENDER_8_COMPONENTS__[component] as RenderComponent<P, S>
 }
 
-export function getExtensionImplementation<P={}, S={}>(extensions: Extensions, name: string) {
+export function getExtensionImplementation<P = {}, S = {}>(
+  extensions: Extensions,
+  name: string
+) {
   const extension = extensions[name]
-  return extension && extension.component ? getImplementation<P, S>(extension.component) : null
+  return extension && extension.component
+    ? getImplementation<P, S>(extension.component)
+    : null
 }
 
 export function fetchAssets(runtime: RenderRuntime, assets: string[]) {
   const { account, production } = runtime
-  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, production))
+  const absoluteAssets = assets.map(url =>
+    getAbsoluteURL(account, url, production)
+  )
   const existingScripts = getExistingScriptSrcs()
   const existingStyles = getExistingStyleHrefs()
-  const scripts = absoluteAssets.filter((a) => shouldAddScriptToPage(a, existingScripts))
-  const styles = absoluteAssets.filter((a) => shouldAddStyleToPage(a, existingStyles))
+  const scripts = absoluteAssets.filter(a =>
+    shouldAddScriptToPage(a, existingScripts)
+  )
+  const styles = absoluteAssets.filter(a =>
+    shouldAddStyleToPage(a, existingStyles)
+  )
   styles.forEach(addStyleToPage)
-  return Promise.all(scripts.map(addScriptToPage)).then(() => { return })
+  return Promise.all(scripts.map(addScriptToPage)).then(() => {
+    return
+  })
 }
 
 export function preloadAssets(runtime: RenderRuntime, assets: string[]) {
   const { account, production } = runtime
-  const absoluteAssets = assets.map(url => getAbsoluteURL(account, url, production))
+  const absoluteAssets = assets.map(url =>
+    getAbsoluteURL(account, url, production)
+  )
   const existingScripts = getExistingScriptSrcs()
   const existingStyles = getExistingStyleHrefs()
   const existingPreloads = getExistingPreloadLinks()
-  const scripts = absoluteAssets.filter((a) => shouldAddScriptToPage(a, [...existingScripts, ...existingPreloads]))
-  const styles = absoluteAssets.filter((a) => shouldAddStyleToPage(a, [...existingStyles, ...existingPreloads]))
+  const scripts = absoluteAssets.filter(a =>
+    shouldAddScriptToPage(a, [...existingScripts, ...existingPreloads])
+  )
+  const styles = absoluteAssets.filter(a =>
+    shouldAddStyleToPage(a, [...existingStyles, ...existingPreloads])
+  )
   scripts.forEach(preloadScript)
   styles.forEach(preloadStyle)
 }

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -19,7 +19,7 @@ const getAbsoluteURL = (account: string, url: string, production: boolean) => {
 }
 
 class ServerSideAssetLoadingError extends Error {
-  constructor() {
+  public constructor() {
     super('Loading assets on server side rendering is not supported')
   }
 }
@@ -90,7 +90,10 @@ function preloadScript(href: string) {
 function getExistingScriptSrcs() {
   const paths: string[] = []
   for (let i = 0; i < document.scripts.length; i++) {
-    paths.push(document.scripts.item(i)!.src)
+    const script = document.scripts.item(i)
+    if (script !== null) {
+      paths.push(script.src)
+    }
   }
   return paths
 }
@@ -98,9 +101,12 @@ function getExistingScriptSrcs() {
 function getExistingStyleHrefs() {
   const hrefs: string[] = []
   for (let i = 0; i < document.styleSheets.length; i++) {
-    const href = document.styleSheets.item(i)!.href
-    if (href) {
-      hrefs.push(href)
+    const stylesheet = document.styleSheets.item(i)
+    if (stylesheet !== null) {
+      const href = stylesheet.href
+      if (href) {
+        hrefs.push(href)
+      }
     }
   }
   return hrefs

--- a/react/utils/cacheControl.ts
+++ b/react/utils/cacheControl.ts
@@ -5,7 +5,7 @@ const STATIC_PAGE_MAX_AGE_S = 7 * 24 * 60 * 60
 const parseCacheControl = (cacheControl: string) => {
   const cacheDirectives = cacheControl.split(',').map(d => d.trim())
   const maxAgeDirective = cacheDirectives.find(d => d.startsWith('max-age'))
-  const [, maxAgeStr] = maxAgeDirective ? maxAgeDirective.split('=') : [, null]
+  const maxAgeStr = maxAgeDirective ? maxAgeDirective.split('=')[1] : null
   const maxAge = maxAgeStr ? parseInt(maxAgeStr, 10) : 0
 
   return {
@@ -32,7 +32,7 @@ const getMaxAge = (response: Response) => {
 export default class PageCacheControl {
   private maxAges: number[] = []
 
-  get maxAge(): number {
+  public get maxAge(): number {
     return this.maxAges.length > 0
       ? Math.min(...this.maxAges)
       : STATIC_PAGE_MAX_AGE_S

--- a/react/utils/cacheControl.ts
+++ b/react/utils/cacheControl.ts
@@ -21,7 +21,7 @@ const getMaxAge = (response: Response) => {
     return DEFAULT_MAX_AGE_S
   }
 
-  const {noCache, noStore, maxAge} = parseCacheControl(cacheControlHeader)
+  const { noCache, noStore, maxAge } = parseCacheControl(cacheControlHeader)
   if (noCache || noStore) {
     return MINIMUM_MAX_AGE_S
   }
@@ -38,7 +38,7 @@ export default class PageCacheControl {
       : STATIC_PAGE_MAX_AGE_S
   }
 
-  public evaluate (innerResponse: Response) {
+  public evaluate(innerResponse: Response) {
     const responseMaxAge = getMaxAge(innerResponse)
     this.maxAges.push(responseMaxAge)
   }

--- a/react/utils/client/generateHash.ts
+++ b/react/utils/client/generateHash.ts
@@ -1,4 +1,10 @@
-import {ArgumentNode, BREAK, DocumentNode, StringValueNode, visit} from 'graphql'
+import {
+  ArgumentNode,
+  BREAK,
+  DocumentNode,
+  StringValueNode,
+  visit,
+} from 'graphql'
 
 interface HashedDocumentNode extends DocumentNode {
   documentId: string
@@ -9,19 +15,18 @@ const isHashedDocumentNode = (arg: any): arg is HashedDocumentNode => {
 }
 
 export const generateHash = (query: HashedDocumentNode | DocumentNode) => {
-
   if (isHashedDocumentNode(query)) {
     return query.documentId
   }
 
-  const asset = {hash: ''}
+  const asset = { hash: '' }
   visit(query, {
     Argument(node: ArgumentNode) {
       if (node.name.value === 'hash') {
         asset.hash = (node.value as StringValueNode).value
         return BREAK
       }
-    }
+    },
   })
   return asset.hash
 }

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -30,6 +30,7 @@ const buildCacheId = (
 const dataIdFromObject = (value: any) => {
   const {cacheId, __typename} = value || {} as any
   if (value && __typename && cacheId) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [vendor, app, major, minor, patch, ...type] = __typename.split('_')
     return buildCacheId(vendor, app, major, type, cacheId)
   }
@@ -37,7 +38,7 @@ const dataIdFromObject = (value: any) => {
 }
 
 export const buildCacheLocator = (app: string, type: string, cacheId: string) => {
-  const [vendor, appAndMajor, x] = app.replace(/-/g, '').split('.')
+  const [vendor, appAndMajor] = app.replace(/-/g, '').split('.')
   const [appName, major] = appAndMajor && appAndMajor.split('@')
   return buildCacheId(vendor, appName, major, type, cacheId)
 }

--- a/react/utils/client/links/base64Link.ts
+++ b/react/utils/client/links/base64Link.ts
@@ -1,14 +1,16 @@
 import { ApolloLink, NextLink, Operation } from 'apollo-link'
 import { Base64 } from 'js-base64'
 
-export const toBase64Link = new ApolloLink((operation: Operation, forward?: NextLink) => {
-  const {extensions, variables} = operation
-  if (variables && Object.keys(variables).length > 0) {
-    operation.variables = {}
-    operation.extensions = {
-      ...extensions,
-      variables: Base64.encode(JSON.stringify(variables))
+export const toBase64Link = new ApolloLink(
+  (operation: Operation, forward?: NextLink) => {
+    const { extensions, variables } = operation
+    if (variables && Object.keys(variables).length > 0) {
+      operation.variables = {}
+      operation.extensions = {
+        ...extensions,
+        variables: Base64.encode(JSON.stringify(variables)),
+      }
     }
+    return forward ? forward(operation) : null
   }
-  return forward ? forward(operation) : null
-})
+)

--- a/react/utils/client/links/cachingLink.ts
+++ b/react/utils/client/links/cachingLink.ts
@@ -1,11 +1,11 @@
-import {ApolloLink, NextLink, Operation} from 'apollo-link'
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
 import PageCacheControl from '../../cacheControl'
 
 export const cachingLink = (cacheControl: PageCacheControl) => {
   return new ApolloLink((operation: Operation, forward?: NextLink) => {
     if (forward) {
       return forward(operation).map(data => {
-        const {response} = operation.getContext()
+        const { response } = operation.getContext()
         cacheControl.evaluate(response)
         return data
       })

--- a/react/utils/client/links/ioFetchLink.ts
+++ b/react/utils/client/links/ioFetchLink.ts
@@ -1,9 +1,10 @@
-import {ApolloLink, NextLink, Operation} from 'apollo-link'
-import {canUseDOM} from 'exenv'
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
+import { canUseDOM } from 'exenv'
 
-const isUploadable = (v: any) => v instanceof File || v instanceof Blob || v instanceof FileList
+const isUploadable = (v: any) =>
+  v instanceof File || v instanceof Blob || v instanceof FileList
 
-const usesUpload = (value : any): boolean => {
+const usesUpload = (value: any): boolean => {
   if (isUploadable(value)) {
     return true
   }
@@ -17,7 +18,7 @@ const usesUpload = (value : any): boolean => {
 }
 
 const useHttpLink = (operation: Operation) => {
-  const {variables} = operation
+  const { variables } = operation
 
   // No file upload is allowed during SSR
   if (!canUseDOM) {
@@ -28,10 +29,10 @@ const useHttpLink = (operation: Operation) => {
   return doUseHttpLink
 }
 
-const passthrough = (operation: Operation, forward?: NextLink) => (forward ? forward(operation) : null)
+const passthrough = (operation: Operation, forward?: NextLink) =>
+  forward ? forward(operation) : null
 
-export const createIOFetchLink = (httpLink: ApolloLink, uploadLink: ApolloLink) => new ApolloLink(passthrough).split(
-  useHttpLink,
-  httpLink,
-  uploadLink,
-)
+export const createIOFetchLink = (
+  httpLink: ApolloLink,
+  uploadLink: ApolloLink
+) => new ApolloLink(passthrough).split(useHttpLink, httpLink, uploadLink)

--- a/react/utils/client/links/omitVariableTypenameLink.ts
+++ b/react/utils/client/links/omitVariableTypenameLink.ts
@@ -1,21 +1,34 @@
-import {ApolloLink, NextLink, Operation} from 'apollo-link'
-import {canUseDOM} from 'exenv'
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
+import { canUseDOM } from 'exenv'
 
-const deepCopyFiles = (src: any, dst: any) => src && typeof src === 'object' && Object.keys(src).forEach((key) => {
-  if (src[key] instanceof File || src[key] instanceof Blob || src[key] instanceof FileList) {
-    dst[key] = src[key]
-  } else {
-    deepCopyFiles(src[key], dst[key])
+const deepCopyFiles = (src: any, dst: any) =>
+  src &&
+  typeof src === 'object' &&
+  Object.keys(src).forEach(key => {
+    if (
+      src[key] instanceof File ||
+      src[key] instanceof Blob ||
+      src[key] instanceof FileList
+    ) {
+      dst[key] = src[key]
+    } else {
+      deepCopyFiles(src[key], dst[key])
+    }
+  })
+
+const omitTypename = (key: string, value: any) =>
+  key === '__typename' ? undefined : value
+
+export const omitTypenameLink = new ApolloLink(
+  (operation: Operation, forward?: NextLink) => {
+    const { variables } = operation
+    if (variables && canUseDOM) {
+      operation.variables = JSON.parse(
+        JSON.stringify(operation.variables),
+        omitTypename
+      )
+      deepCopyFiles(variables, operation.variables)
+    }
+    return forward ? forward(operation) : null
   }
-})
-
-const omitTypename = (key: string, value: any) => (key === '__typename') ? undefined : value
-
-export const omitTypenameLink = new ApolloLink((operation: Operation, forward?:  NextLink) => {
-  const {variables} = operation
-  if (variables && canUseDOM) {
-    operation.variables = JSON.parse(JSON.stringify(operation.variables), omitTypename)
-    deepCopyFiles(variables, operation.variables)
-  }
-  return forward ? forward(operation) : null
-})
+)

--- a/react/utils/client/links/persistedQueryVersionLink.ts
+++ b/react/utils/client/links/persistedQueryVersionLink.ts
@@ -4,20 +4,22 @@ import { ArgumentNode, BREAK, visit } from 'graphql'
 const persistedQueryVersion = (extensions: any) =>
   extensions && extensions.persistedQuery && extensions.persistedQuery.version
 
-export const persistedQueryVersionLink = new ApolloLink((operation: Operation, forward?: NextLink) => {
-  const {extensions, query} = operation
-  const version = persistedQueryVersion(extensions)
-  if (version) {
-    let senderApp
-    visit(query, {
-      Argument(node: ArgumentNode) {
-        if (node.name.value === 'sender') {
-          senderApp = (node.value as any).value
-          return BREAK
-        }
-      }
-    })
-    extensions.persistedQuery.version = senderApp || version
+export const persistedQueryVersionLink = new ApolloLink(
+  (operation: Operation, forward?: NextLink) => {
+    const { extensions, query } = operation
+    const version = persistedQueryVersion(extensions)
+    if (version) {
+      let senderApp
+      visit(query, {
+        Argument(node: ArgumentNode) {
+          if (node.name.value === 'sender') {
+            senderApp = (node.value as any).value
+            return BREAK
+          }
+        },
+      })
+      extensions.persistedQuery.version = senderApp || version
+    }
+    return forward ? forward(operation) : null
   }
-  return forward ? forward(operation) : null
-})
+)

--- a/react/utils/client/links/runtimeContextLink.ts
+++ b/react/utils/client/links/runtimeContextLink.ts
@@ -1,4 +1,4 @@
-import {ApolloLink, NextLink, Operation} from 'apollo-link'
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
 
 export const createRuntimeContextLink = () =>
   new ApolloLink((operation: Operation, forward?: NextLink) => {

--- a/react/utils/client/links/versionSplitterLink.ts
+++ b/react/utils/client/links/versionSplitterLink.ts
@@ -62,6 +62,8 @@ const queryFromNodeCreator = (query: DocumentNode) => (node: Node) => visit(pars
         variableDefinitions: Object.values(node.usedVariables),
       }
     }
+
+    return null
   },
 }) as DocumentNode
 
@@ -110,7 +112,7 @@ const mergeRecursively = (accumulator: any, value: any) => {
 }
 
 const createOperationForQuery = (operation: Operation) => (query: DocumentNode) => {
-  const graphQLRequest = {...operation, query} as GraphQLRequest
+  const graphQLRequest: GraphQLRequest = {...operation, query}
   const op = validateOperation(transformOperation(graphQLRequest))
   return createOperation(operation.getContext(), op)
 }

--- a/react/utils/client/links/versionSplitterLink.ts
+++ b/react/utils/client/links/versionSplitterLink.ts
@@ -1,6 +1,27 @@
-import {ApolloLink, createOperation, GraphQLRequest, NextLink, Observable, Operation} from 'apollo-link'
-import {transformOperation, validateOperation} from 'apollo-link/lib/linkUtils'
-import {BREAK, DirectiveNode, DocumentNode, OperationDefinitionNode, parse, print, SelectionNode, VariableDefinitionNode, VariableNode, visit} from 'graphql'
+import {
+  ApolloLink,
+  createOperation,
+  GraphQLRequest,
+  NextLink,
+  Observable,
+  Operation,
+} from 'apollo-link'
+import {
+  transformOperation,
+  validateOperation,
+} from 'apollo-link/lib/linkUtils'
+import {
+  BREAK,
+  DirectiveNode,
+  DocumentNode,
+  OperationDefinitionNode,
+  parse,
+  print,
+  SelectionNode,
+  VariableDefinitionNode,
+  VariableNode,
+  visit,
+} from 'graphql'
 
 interface Variables {
   [name: string]: VariableDefinitionNode
@@ -14,19 +35,23 @@ interface Node {
 const pickAvailableVariables = (query: DocumentNode) => {
   const availableVariables: Variables = {}
   visit(query, {
-    VariableDefinition (node: VariableDefinitionNode) {
+    VariableDefinition(node: VariableDefinitionNode) {
       availableVariables[node.variable.name.value] = node
     },
   })
   return availableVariables
 }
 
-const isRuntimeMetaDirective = (node: DirectiveNode) => node.name.value === 'runtimeMeta'
+const isRuntimeMetaDirective = (node: DirectiveNode) =>
+  node.name.value === 'runtimeMeta'
 
-const pickUsedVariables = (selection: SelectionNode, availableVariables: Variables) => {
+const pickUsedVariables = (
+  selection: SelectionNode,
+  availableVariables: Variables
+) => {
   const usedVariables: Variables = {}
   visit(selection, {
-    Variable (varNode: VariableNode) {
+    Variable(varNode: VariableNode) {
       usedVariables[varNode.name.value] = availableVariables[varNode.name.value]
     },
   })
@@ -36,8 +61,11 @@ const pickUsedVariables = (selection: SelectionNode, availableVariables: Variabl
 const pickFields = (query: DocumentNode, availableVariables: Variables) => {
   const nodes: Node[] = []
   visit(query, {
-    Field (selection: SelectionNode) {
-      if (selection.directives && selection.directives.find(isRuntimeMetaDirective)) {
+    Field(selection: SelectionNode) {
+      if (
+        selection.directives &&
+        selection.directives.find(isRuntimeMetaDirective)
+      ) {
         nodes.push({
           selection,
           usedVariables: pickUsedVariables(selection, availableVariables),
@@ -50,41 +78,48 @@ const pickFields = (query: DocumentNode, availableVariables: Variables) => {
 
 const operationWhiteList = ['query', 'mutation', 'subscription']
 
-const queryFromNodeCreator = (query: DocumentNode) => (node: Node) => visit(parse(print(query)), {
-  OperationDefinition (opNode: OperationDefinitionNode) {
-    if (operationWhiteList.includes(opNode.operation)) {
-      return {
-        ...opNode,
-        selectionSet: {
-          ...opNode.selectionSet,
-          selections: [node.selection],
-        },
-        variableDefinitions: Object.values(node.usedVariables),
+const queryFromNodeCreator = (query: DocumentNode) => (node: Node) =>
+  visit(parse(print(query)), {
+    OperationDefinition(opNode: OperationDefinitionNode) {
+      if (operationWhiteList.includes(opNode.operation)) {
+        return {
+          ...opNode,
+          selectionSet: {
+            ...opNode.selectionSet,
+            selections: [node.selection],
+          },
+          variableDefinitions: Object.values(node.usedVariables),
+        }
       }
-    }
 
-    return null
-  },
-}) as DocumentNode
+      return null
+    },
+  }) as DocumentNode
 
 const isTypeQuery = (docNode: DocumentNode) => {
-  const asset = {isQuery: false}
+  const asset = { isQuery: false }
   visit(docNode, {
     OperationDefinition(node: OperationDefinitionNode) {
       if (node.operation === 'query') {
         asset.isQuery = true
         return BREAK
       }
-    }
+    },
   })
   return asset.isQuery
 }
 
 const assertSingleOperation = (query: DocumentNode) => {
-  const ops = query.definitions.filter(definition => operationWhiteList.includes((definition as OperationDefinitionNode).operation))
+  const ops = query.definitions.filter(definition =>
+    operationWhiteList.includes(
+      (definition as OperationDefinitionNode).operation
+    )
+  )
 
   if (ops.length > 1) {
-    throw new Error('Only one operation definition is allowed per query. Please split your queries in two different files')
+    throw new Error(
+      'Only one operation definition is allowed per query. Please split your queries in two different files'
+    )
   }
 }
 
@@ -111,8 +146,10 @@ const mergeRecursively = (accumulator: any, value: any) => {
   return accumulator
 }
 
-const createOperationForQuery = (operation: Operation) => (query: DocumentNode) => {
-  const graphQLRequest: GraphQLRequest = {...operation, query}
+const createOperationForQuery = (operation: Operation) => (
+  query: DocumentNode
+) => {
+  const graphQLRequest: GraphQLRequest = { ...operation, query }
   const op = validateOperation(transformOperation(graphQLRequest))
   return createOperation(operation.getContext(), op)
 }
@@ -122,40 +159,44 @@ const operationByRuntimeMetaDirective = (operation: Operation) => {
   return queries.map(createOperationForQuery(operation))
 }
 
-const observableFromOperations = (operations: Operation[], forward: NextLink) => new Observable(observer => {
-  const reduced = {}
-  let togo = 0
+const observableFromOperations = (operations: Operation[], forward: NextLink) =>
+  new Observable(observer => {
+    const reduced = {}
+    let togo = 0
 
-  operations.forEach((op: Operation) => forward(op).subscribe({
-    complete: () => {
-      if (togo === operations.length) {
-        togo++
-        observer.next(reduced)
-        observer.complete()
+    operations.forEach((op: Operation) =>
+      forward(op).subscribe({
+        complete: () => {
+          if (togo === operations.length) {
+            togo++
+            observer.next(reduced)
+            observer.complete()
+          }
+        },
+        error: err => {
+          togo++
+          observer.error(err)
+        },
+        next: data => {
+          togo++
+          mergeRecursively(reduced, data)
+        },
+      })
+    )
+  })
+
+export const versionSplitterLink = new ApolloLink(
+  (operation: Operation, forward?: NextLink) => {
+    if (forward) {
+      const query = operation.query
+      const operations = operationByRuntimeMetaDirective(operation)
+
+      if (operations.length && isTypeQuery(query)) {
+        return observableFromOperations(operations, forward)
+      } else {
+        return forward(operation)
       }
-    },
-    error: (err) => {
-      togo++
-      observer.error(err)
-    },
-    next: (data) => {
-      togo++
-      mergeRecursively(reduced, data)
-    },
-  }))
-})
-
-export const versionSplitterLink = new ApolloLink((operation: Operation, forward?: NextLink) => {
-  if (forward) {
-    const query = operation.query
-    const operations = operationByRuntimeMetaDirective(operation)
-
-    if (operations.length && isTypeQuery(query)) {
-      return observableFromOperations(operations, forward)
     }
-    else {
-      return forward(operation)
-    }
+    return null
   }
-  return null
-})
+)

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -2,18 +2,24 @@ const prependUniq = (arrOne: any[], arrTwo: any[]) => {
   return [...arrOne, ...arrTwo.filter(item => !arrOne.includes(item))]
 }
 
-export const traverseComponent = (components: Components | Record<string, string[]>, component: string): ComponentTraversalResult => {
+export const traverseComponent = (
+  components: Components | Record<string, string[]>,
+  component: string
+): ComponentTraversalResult => {
   const entry = components[component]
   const [app] = component.split('/')
   if (Array.isArray(entry)) {
-    return {apps: [app], assets: entry}
+    return { apps: [app], assets: entry }
   }
 
-  const {dependencies, assets} = entry
+  const { dependencies, assets } = entry
   return dependencies
     .map(dep => traverseComponent(components, dep))
-    .reduce((acc, dependency) => ({
-      apps: prependUniq(dependency.apps, acc.apps),
-      assets: prependUniq(dependency.assets, acc.assets)
-    }), {apps: [app], assets})
+    .reduce(
+      (acc, dependency) => ({
+        apps: prependUniq(dependency.apps, acc.apps),
+        assets: prependUniq(dependency.assets, acc.assets),
+      }),
+      { apps: [app], assets }
+    )
 }

--- a/react/utils/dom.tsx
+++ b/react/utils/dom.tsx
@@ -13,7 +13,8 @@ export const RENDER_CONTAINER_CLASS = 'render-container'
 
 export const ROUTE_CLASS_PREFIX = 'render-route-'
 
-export const routeClass = (name: string) => `${ROUTE_CLASS_PREFIX}${hyphenate(name)}`
+export const routeClass = (name: string) =>
+  `${ROUTE_CLASS_PREFIX}${hyphenate(name)}`
 
 const renderContainer = (name: string, markup: string) =>
   `<div class="${RENDER_CONTAINER_CLASS} ${routeClass(name)}">${markup}</div>`
@@ -21,13 +22,21 @@ const renderContainer = (name: string, markup: string) =>
 const portalWrapper = (name: string, markup: string) =>
   `<span id="${portalWrapperId(name)}">${markup}</span>`
 
-export const createPortal = (children: ReactElement<any>, name: string, hydrate: boolean) => {
+export const createPortal = (
+  children: ReactElement<any>,
+  name: string,
+  hydrate: boolean
+) => {
   window.__hasPortals__ = true
 
   if (!hydrate) {
-    return canUseDOM
-      ? null
-      : <Fragment>{`START_SERVER_PORTAL_${name}!`}{children}{`END_SERVER_PORTAL_${name}!`}</Fragment>
+    return canUseDOM ? null : (
+      <Fragment>
+        {`START_SERVER_PORTAL_${name}!`}
+        {children}
+        {`END_SERVER_PORTAL_${name}!`}
+      </Fragment>
+    )
   }
 
   const ssrPortalContainer = document.getElementById(portalWrapperId(name))
@@ -44,7 +53,10 @@ export const createPortal = (children: ReactElement<any>, name: string, hydrate:
   return reactCreatePortal(children, container) as ReactPortal
 }
 
-export const getMarkups = (pageName: string, pageMarkup: string): NamedMarkup[] => {
+export const getMarkups = (
+  pageName: string,
+  pageMarkup: string
+): NamedMarkup[] => {
   const markups: NamedMarkup[] = []
 
   let matches = window.__hasPortals__ && portalPattern.exec(pageMarkup)
@@ -54,7 +66,7 @@ export const getMarkups = (pageName: string, pageMarkup: string): NamedMarkup[] 
     strippedMarkup = strippedMarkup.replace(matched, '')
     markups.push({
       markup: renderContainer(name, portalWrapper(name, markup)),
-      name
+      name,
     })
     matches = portalPattern.exec(pageMarkup)
   }
@@ -67,9 +79,10 @@ export const getMarkups = (pageName: string, pageMarkup: string): NamedMarkup[] 
   return markups
 }
 
-
 export const getContainer = () => {
-  return canUseDOM ? document.getElementsByClassName(RENDER_CONTAINER_CLASS)[0] : null
+  return canUseDOM
+    ? document.getElementsByClassName(RENDER_CONTAINER_CLASS)[0]
+    : null
 }
 
 export const ensureContainer = (name: string) => {
@@ -77,7 +90,9 @@ export const ensureContainer = (name: string) => {
     return false
   }
 
-  const existingContainer = document.getElementsByClassName(RENDER_CONTAINER_CLASS)[0]
+  const existingContainer = document.getElementsByClassName(
+    RENDER_CONTAINER_CLASS
+  )[0]
   if (existingContainer) {
     return false
   }

--- a/react/utils/dom.tsx
+++ b/react/utils/dom.tsx
@@ -68,7 +68,7 @@ export const getMarkups = (pageName: string, pageMarkup: string): NamedMarkup[] 
 }
 
 
-export const getContainer = (name: string) => {
+export const getContainer = () => {
   return canUseDOM ? document.getElementsByClassName(RENDER_CONTAINER_CLASS)[0] : null
 }
 

--- a/react/utils/events.ts
+++ b/react/utils/events.ts
@@ -30,6 +30,7 @@ const initSSE = (account: string, workspace: string, baseURI: string) => {
   }
 
   require('eventsource-polyfill')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const myvtexSSE = require('myvtex-sse')
   const path = `vtex.builder-hub:*:react2,pages0,build.status?workspace=${workspace}`
   const source: EventSource = myvtexSSE(account, workspace, path, {verbose: false, host: baseURI})

--- a/react/utils/events.ts
+++ b/react/utils/events.ts
@@ -1,14 +1,14 @@
 import EventEmitter from 'eventemitter3'
-import {canUseDOM} from 'exenv'
+import { canUseDOM } from 'exenv'
 
 interface IOEvent {
   key: string
   body: {
-    code: string,
-    type: string,
-    hash: string,
-    locales: any,
-    subject: string,
+    code: string
+    type: string
+    hash: string
+    locales: any
+    subject: string
   }
 }
 
@@ -33,25 +33,37 @@ const initSSE = (account: string, workspace: string, baseURI: string) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const myvtexSSE = require('myvtex-sse')
   const path = `vtex.builder-hub:*:react2,pages0,build.status?workspace=${workspace}`
-  const source: EventSource = myvtexSSE(account, workspace, path, {verbose: false, host: baseURI})
+  const source: EventSource = myvtexSSE(account, workspace, path, {
+    verbose: false,
+    host: baseURI,
+  })
 
-  const handler = ({data}: MessageEvent) => {
+  const handler = ({ data }: MessageEvent) => {
     const event = JSON.parse(data) as IOEvent
-    const {key, body: {code, type, hash, locales, subject}} = event
+    const {
+      key,
+      body: { code, type, hash, locales, subject },
+    } = event
 
     if (key === 'build.status') {
       switch (code) {
         case 'start':
           console.log(`[build] Build started. app=${subject}`)
-          emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('build.status', code))
+          emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+            e.emit('build.status', code)
+          )
           break
         case 'success':
           console.log(`[build] Build success. app=${subject}`)
-          emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('build.status', code))
+          emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+            e.emit('build.status', code)
+          )
           break
         case 'fail':
           console.log(`[build] Build failed. app=${subject}`)
-          emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('build.status', code))
+          emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+            e.emit('build.status', code)
+          )
           break
       }
       return
@@ -66,23 +78,33 @@ const initSSE = (account: string, workspace: string, baseURI: string) => {
         break
       case 'reload':
         console.log(`[react2] Received reload. app=${subject}`)
-        emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('build.status', 'reload'))
+        emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+          e.emit('build.status', 'reload')
+        )
         location.reload(true)
         break
       case 'locales':
-        console.log(`[react2] Received locale update. appId=${subject} locales=${locales}`)
-        emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('localesUpdated', locales))
+        console.log(
+          `[react2] Received locale update. appId=${subject} locales=${locales}`
+        )
+        emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+          e.emit('localesUpdated', locales)
+        )
         break
       case 'changed':
         console.log('[pages0] Extensions changed.')
-        emittersByWorkspace[`${account}/${workspace}`].forEach(e => e.emit('extensionsUpdated'))
+        emittersByWorkspace[`${account}/${workspace}`].forEach(e =>
+          e.emit('extensionsUpdated')
+        )
         break
     }
   }
 
   source.onmessage = handler
-  source.onopen = () => console.log('[render] Connected to event server successfully')
-  source.onerror = () => console.log('[render] Connection to event server failed')
+  source.onopen = () =>
+    console.log('[render] Connected to event server successfully')
+  source.onerror = () =>
+    console.log('[render] Connection to event server failed')
 
   return source
 }
@@ -92,19 +114,27 @@ export const registerEmitter = (runtime: RenderRuntime, baseURI: string) => {
     return
   }
 
-  const {account, production, workspace} = runtime
+  const { account, production, workspace } = runtime
 
   // Share SSE connections for same account and workspace
   if (!emittersByWorkspace[`${account}/${workspace}`]) {
     emittersByWorkspace[`${account}/${workspace}`] = []
-    emittersByWorkspace[`${account}/${workspace}`].eventSource = initSSE(account, workspace, baseURI)
+    emittersByWorkspace[`${account}/${workspace}`].eventSource = initSSE(
+      account,
+      workspace,
+      baseURI
+    )
 
     if (!production) {
       document.addEventListener('visibilitychange', () => {
         const es = emittersByWorkspace[`${account}/${workspace}`].eventSource
         // Ensure SSE server connection
         if (!document.hidden && es && es.readyState === CONNECTION_CLOSED) {
-          emittersByWorkspace[`${account}/${workspace}`].eventSource = initSSE(account, workspace, baseURI)
+          emittersByWorkspace[`${account}/${workspace}`].eventSource = initSSE(
+            account,
+            workspace,
+            baseURI
+          )
         }
       })
     }

--- a/react/utils/extension.tsx
+++ b/react/utils/extension.tsx
@@ -19,7 +19,7 @@ interface ExtensionContext {
 }
 
 interface Props {
-  children({ extension } : ExtensionContext): ReactElement<any> | null
+  children({ extension }: ExtensionContext): ReactElement<any> | null
 }
 
 const ExtensionConsumer = ({ children }: Props) => {

--- a/react/utils/extension.tsx
+++ b/react/utils/extension.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { useRuntime } from '../components/RenderContext'
 import { useTreePath } from './treePath'

--- a/react/utils/host.ts
+++ b/react/utils/host.ts
@@ -1,4 +1,4 @@
-import {canUseDOM} from 'exenv'
+import { canUseDOM } from 'exenv'
 
 const isRenderServedPage = () => {
   const generatorMetaTag = document.querySelector(`meta[name='generator']`)
@@ -7,11 +7,13 @@ const isRenderServedPage = () => {
 }
 
 export const getBaseURI = (runtime: RenderRuntime) => {
-  const {account, workspace, publicEndpoint, rootPath = ''} = runtime
+  const { account, workspace, publicEndpoint, rootPath = '' } = runtime
   if (!canUseDOM) {
     return `${workspace}--${account}.${publicEndpoint}`
   } else {
-    const {location: {hostname}} = window
+    const {
+      location: { hostname },
+    } = window
     return hostname.endsWith(`.${publicEndpoint}`) || isRenderServedPage()
       ? hostname + rootPath
       : `${hostname}/api/io`

--- a/react/utils/locales.ts
+++ b/react/utils/locales.ts
@@ -1,10 +1,12 @@
-import {addLocaleData as addReactLocaleData} from 'react-intl'
-import {addScriptToPage, shouldAddScriptToPage} from '../utils/assets'
+import { addLocaleData as addReactLocaleData } from 'react-intl'
+import { addScriptToPage, shouldAddScriptToPage } from '../utils/assets'
 
 const getLang = (locale: string) => locale.split('-')[0]
 
 const loadReactIntlData = (locale: string) => {
-  const path = `https://unpkg.com/react-intl@2.4.0/locale-data/${getLang(locale)}.js`
+  const path = `https://unpkg.com/react-intl@2.4.0/locale-data/${getLang(
+    locale
+  )}.js`
   return shouldAddScriptToPage(path)
     ? addScriptToPage(path).then(() => addLocaleData(locale))
     : Promise.resolve()
@@ -12,18 +14,16 @@ const loadReactIntlData = (locale: string) => {
 
 const loadIntlData = (locale: string) => {
   const path = `https://unpkg.com/intl@1.2.5/locale-data/jsonp/${locale}.js`
-  return window.IntlPolyfill && shouldAddScriptToPage(path) ? addScriptToPage(path) : Promise.resolve()
+  return window.IntlPolyfill && shouldAddScriptToPage(path)
+    ? addScriptToPage(path)
+    : Promise.resolve()
 }
 
 export const loadLocaleData = (locale: string) => {
-  return Promise.all([
-    loadReactIntlData(locale),
-    loadIntlData(locale),
-  ])
+  return Promise.all([loadReactIntlData(locale), loadIntlData(locale)])
 }
 
 export const addLocaleData = (locale: string) => {
   const lang = getLang(locale)
   addReactLocaleData(window.ReactIntlLocaleData[lang])
 }
-

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -1,7 +1,5 @@
 import { pluck, zipObj } from 'ramda'
 
-const YEAR_IN_MS = 12 * 30 * 24 * 60 * 60 * 1000
-
 export const parseMessages = (messages: KeyedString[] | null) => {
   return messages && zipObj(pluck('key', messages), pluck('message', messages))
 }

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -130,14 +130,19 @@ function getRouteFromPageName(
   return path ? { id, path, params } : null
 }
 
-function getCanonicalPath (canonicalPathTemplate: string, params: Record<string, string>): string | false {
+function getCanonicalPath(
+  canonicalPathTemplate: string,
+  params: Record<string, string>
+): string | false {
   const properPathTemplate = adjustTemplate(canonicalPathTemplate)
   const canonicalPath = new RouteParser(properPathTemplate).reverse(params)
   if (canonicalPath) {
     return canonicalPath
   }
 
-  console.warn(`Canonical path template '${canonicalPathTemplate}' could not be created with params: ${params}`)
+  console.warn(
+    `Canonical path template '${canonicalPathTemplate}' could not be created with params: ${params}`
+  )
   return false
 }
 
@@ -146,7 +151,7 @@ export function getRouteFromPath(
   pages: Pages,
   query?: string
 ): NavigationRoute | null {
-  const queryMap = query ?  queryStringToMap(query) : {}
+  const queryMap = query ? queryStringToMap(query) : {}
   const routeMatch = routeIdFromPathAndQuery(path, queryMap, pages)
   if (!routeMatch) {
     return null
@@ -169,15 +174,12 @@ const mergePersistingQueries = (currentQuery: string, query: string) => {
   const current = queryStringToMap(currentQuery)
   const next = queryStringToMap(query)
   const has = (value?: string) => !!value || value === null
-  const persisting = KEYS.reduce<Record<string, any>>(
-    (cur, key) => {
-      if (has(current[key]) && current[key] !== 'false') {
-        cur[key] = current[key]
-      }
-      return cur
-    },
-    {}
-  )
+  const persisting = KEYS.reduce<Record<string, any>>((cur, key) => {
+    if (has(current[key]) && current[key] !== 'false') {
+      cur[key] = current[key]
+    }
+    return cur
+  }, {})
   return mapToQueryString({ ...persisting, ...next })
 }
 
@@ -288,14 +290,17 @@ function polyfillScrollTo(options: ScrollToOptions) {
   }
 }
 
-function routeMatchForMappedURL(mappedSegments: string[], routes: Pages): RouteMatch | null {
+function routeMatchForMappedURL(
+  mappedSegments: string[],
+  routes: Pages
+): RouteMatch | null {
   let id: string | undefined
   let score: number
   let highScore: number = Number.NEGATIVE_INFINITY
 
   // tslint:disable-next-line:forin
   for (const name in routes) {
-    const {map = [], path: routePath} = routes[name]
+    const { map = [], path: routePath } = routes[name]
     if (!routePath || map.length === 0 || !startsWith(map, mappedSegments)) {
       continue
     }
@@ -313,14 +318,14 @@ function routeMatchForMappedURL(mappedSegments: string[], routes: Pages): RouteM
     return null
   }
 
-  const {path} = routes[id]
+  const { path } = routes[id]
   const pathSegments = path.split('/')
   const slicedPathSegments = pathSegments.slice(0, highScore + 1)
   const newPath = slicedPathSegments.join('/')
 
   return {
     id,
-    path: newPath
+    path: newPath,
   }
 }
 
@@ -357,11 +362,15 @@ function routeMatchFromPath(path: string, routes: Pages): RouteMatch | null {
   return {
     canonical: routes[id].canonical,
     id,
-    path: getPagePath(id, routes)
+    path: getPagePath(id, routes),
   }
 }
 
-function routeIdFromPathAndQuery(path: string, query: Record<string, string>, routes: Pages) {
+function routeIdFromPathAndQuery(
+  path: string,
+  query: Record<string, string>,
+  routes: Pages
+) {
   const mappedSegments = query.map ? query.map.split(',') : []
   let routeMatch: RouteMatch | null = null
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -2,7 +2,7 @@ import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
 import { difference, is, isEmpty, keys, startsWith } from 'ramda'
-import * as RouteParser from 'route-parser'
+import RouteParser from 'route-parser'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
 
@@ -10,7 +10,6 @@ function getScore(path: string) {
   const catchAll = (path.match(/\*/g) || []).length
   const catchOne = (path.match(/:/g) || []).length
   const fixed = (path.match(/\/[\w_-]+/g) || []).length
-  // tslint:disable-next-line:no-bitwise
   return ~((catchAll << 12) + (catchOne << 6) + ((1 << 6) - fixed - 1))
 }
 
@@ -33,7 +32,7 @@ function createLocationDescriptor(
   }: Pick<NavigateOptions, 'query' | 'scrollOptions' | 'fetchPage'>
 ): LocationDescriptorObject {
   return {
-    pathname: navigationRoute.path!,
+    pathname: navigationRoute.path,
     state: {
       fetchPage,
       navigationRoute,
@@ -170,14 +169,14 @@ const mergePersistingQueries = (currentQuery: string, query: string) => {
   const current = queryStringToMap(currentQuery)
   const next = queryStringToMap(query)
   const has = (value?: string) => !!value || value === null
-  const persisting = KEYS.reduce(
+  const persisting = KEYS.reduce<Record<string, any>>(
     (cur, key) => {
       if (has(current[key]) && current[key] !== 'false') {
         cur[key] = current[key]
       }
       return cur
     },
-    {} as Record<string, any>
+    {}
   )
   return mapToQueryString({ ...persisting, ...next })
 }
@@ -217,7 +216,7 @@ export function navigate(
 
   const navigationRoute = page
     ? getRouteFromPageName(page, pages, params)
-    : getRouteFromPath(to!, pages, query)
+    : getRouteFromPath(to, pages, query)
 
   if (!navigationRoute) {
     console.warn(

--- a/react/utils/registerComponent.tsx
+++ b/react/utils/registerComponent.tsx
@@ -17,7 +17,10 @@ export const isComponentType = (Arg: any): Arg is ComponentType => {
    * get treated as components, so they can be callable.
    */
   if (isFunction) {
-    const name: string | undefined = path(['prototype', 'constructor', 'name'], Arg)
+    const name: string | undefined = path(
+      ['prototype', 'constructor', 'name'],
+      Arg
+    )
     if (!name) {
       return true
     }
@@ -42,12 +45,19 @@ const idToAppAtMajor = (appId: string) => {
   return `${name}@${major}.x`
 }
 
-export default (module: Module, InitialImplementer: any, app: string, name: string) => {
+export default (
+  module: Module,
+  InitialImplementer: any,
+  app: string,
+  name: string
+) => {
   const Implementer = isComponentType(InitialImplementer)
     ? scopeMessages(app, InitialImplementer)
     : InitialImplementer
   const wrappedComponent = maybeWrapWithHMR(module, Implementer)
   window.__RENDER_8_COMPONENTS__[`${app}/${name}`] = wrappedComponent
-  window.__RENDER_8_COMPONENTS__[`${idToAppAtMajor(app)}/${name}`] = wrappedComponent
+  window.__RENDER_8_COMPONENTS__[
+    `${idToAppAtMajor(app)}/${name}`
+  ] = wrappedComponent
   return wrappedComponent
 }

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -2,7 +2,9 @@ import navigationPageQuery from '../queries/navigationPage.graphql'
 import routePreviews from '../queries/routePreviews.graphql'
 import { parseMessages } from './messages'
 
-const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryResponse => {
+const parsePageQueryResponse = (
+  page: PageQueryResponse
+): ParsedPageQueryResponse => {
   const {
     appsEtag,
     appsSettingsJSON,
@@ -14,10 +16,7 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     page: {
       blockId,
       canonicalPath,
-      pageContext: {
-        id,
-        type,
-      }
+      pageContext: { id, type },
     },
   } = page
 
@@ -37,25 +36,22 @@ const parsePageQueryResponse = (page: PageQueryResponse): ParsedPageQueryRespons
     matchingPage: {
       blockId,
       canonicalPath,
-      pageContext: {id, type}
+      pageContext: { id, type },
     },
     messages: parseMessages(messages),
     pages,
-    settings
+    settings,
   }
 }
 
-const parseDefaultPagesQueryResponse = (defaultPages: DefaultPagesQueryResponse): ParsedDefaultPagesQueryResponse => {
-  const {
-    componentsJSON,
-    extensionsJSON,
-    messages,
-  } = defaultPages
+const parseDefaultPagesQueryResponse = (
+  defaultPages: DefaultPagesQueryResponse
+): ParsedDefaultPagesQueryResponse => {
+  const { componentsJSON, extensionsJSON, messages } = defaultPages
 
-  const [components, extensions] = [
-    componentsJSON,
-    extensionsJSON,
-  ].map(json => JSON.parse(json))
+  const [components, extensions] = [componentsJSON, extensionsJSON].map(json =>
+    JSON.parse(json)
+  )
 
   return {
     components,
@@ -71,20 +67,28 @@ export const fetchNavigationPage = ({
   production,
   paramsJSON,
   renderMajor,
-  query
-}: FetchNavigationDataInput) => apolloClient.query<{navigationPage: PageQueryResponse}>({
-  fetchPolicy: production ? 'cache-first' : 'network-only',
-  query: navigationPageQuery,
-  variables: {
-    declarer,
-    params: paramsJSON,
-    production,
-    query,
-    renderMajor,
-    routeId
-  }
-}).then<ParsedPageQueryResponse>(({data: {navigationPage: pageData}, errors}: GraphQLResult<'navigationPage', PageQueryResponse>) =>
-      errors ? Promise.reject(errors) : parsePageQueryResponse(pageData))
+  query,
+}: FetchNavigationDataInput) =>
+  apolloClient
+    .query<{ navigationPage: PageQueryResponse }>({
+      fetchPolicy: production ? 'cache-first' : 'network-only',
+      query: navigationPageQuery,
+      variables: {
+        declarer,
+        params: paramsJSON,
+        production,
+        query,
+        renderMajor,
+        routeId,
+      },
+    })
+    .then<ParsedPageQueryResponse>(
+      ({
+        data: { navigationPage: pageData },
+        errors,
+      }: GraphQLResult<'navigationPage', PageQueryResponse>) =>
+        errors ? Promise.reject(errors) : parsePageQueryResponse(pageData)
+    )
 
 const getRoutesParam = (routeIds: string[], pages: Pages) => {
   return routeIds
@@ -104,12 +108,16 @@ export const fetchDefaultPages = ({
   routeIds,
   renderMajor,
 }: FetchDefaultPages) => {
-  return apolloClient.query<{defaultPages: DefaultPagesQueryResponse}>({
-    query: routePreviews,
-    variables: { renderMajor, routes: getRoutesParam(routeIds, pages)}
-  }).then<ParsedDefaultPagesQueryResponse>(
-    ({data: {defaultPages}, errors}: DefaultPagesQueryResult) => {
-      return errors ? Promise.reject(errors) : parseDefaultPagesQueryResponse(defaultPages)
-    }
-  )
+  return apolloClient
+    .query<{ defaultPages: DefaultPagesQueryResponse }>({
+      query: routePreviews,
+      variables: { renderMajor, routes: getRoutesParam(routeIds, pages) },
+    })
+    .then<ParsedDefaultPagesQueryResponse>(
+      ({ data: { defaultPages }, errors }: DefaultPagesQueryResult) => {
+        return errors
+          ? Promise.reject(errors)
+          : parseDefaultPagesQueryResponse(defaultPages)
+      }
+    )
 }

--- a/react/utils/session.tsx
+++ b/react/utils/session.tsx
@@ -5,10 +5,14 @@ import Session from '../components/Session'
 
 export const withSession = () => {
   // tslint:disable-next-line:only-arrow-functions
-  return function <TOriginalProps>(Component: ComponentType<TOriginalProps>): ComponentType<TOriginalProps> {
+  return function<TOriginalProps>(
+    Component: ComponentType<TOriginalProps>
+  ): ComponentType<TOriginalProps> {
     class WithSession extends React.Component<TOriginalProps> {
       public static get displayName(): string {
-        return `WithSession(${Component.displayName || Component.name || 'Component'})`
+        return `WithSession(${Component.displayName ||
+          Component.name ||
+          'Component'})`
       }
 
       public static get WrappedComponent() {

--- a/react/utils/treePath.test.tsx
+++ b/react/utils/treePath.test.tsx
@@ -1,11 +1,28 @@
 import { escapeRegex, isDirectChild } from './treePath'
 
 describe('#escapeRegex', () => {
-  const specialRegexCharacters = ['[', ']','\\', '^', '$', '.', '|', '?', '*', '+', '(', ')']
+  const specialRegexCharacters = [
+    '[',
+    ']',
+    '\\',
+    '^',
+    '$',
+    '.',
+    '|',
+    '?',
+    '*',
+    '+',
+    '(',
+    ')',
+  ]
 
-  it(`should prefix regex special characters: [ '${specialRegexCharacters.join(`', '`)}' ] with \\`, () => {
-    specialRegexCharacters.forEach((specialRegexCharacter) => {
-      expect(escapeRegex(specialRegexCharacter)).toEqual(`\\${specialRegexCharacter}`)
+  it(`should prefix regex special characters: [ '${specialRegexCharacters.join(
+    `', '`
+  )}' ] with \\`, () => {
+    specialRegexCharacters.forEach(specialRegexCharacter => {
+      expect(escapeRegex(specialRegexCharacter)).toEqual(
+        `\\${specialRegexCharacter}`
+      )
     })
   })
 
@@ -24,7 +41,9 @@ describe('#isDirectChild', () => {
   })
 
   it('should allow regex special characters on names', () => {
-    expect(isDirectChild('store/home/$before_0/shelf_0', 'store/home/$before_0')).toBe(true)
+    expect(
+      isDirectChild('store/home/$before_0/shelf_0', 'store/home/$before_0')
+    ).toBe(true)
   })
 
   it('should return false for 2 levels nesting', () => {

--- a/react/utils/treePath.tsx
+++ b/react/utils/treePath.tsx
@@ -1,12 +1,16 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import React, {ComponentType, useContext} from 'react'
+import React, { ComponentType, useContext } from 'react'
 
 const relative = (parent: string, id: string) => id.replace(`${parent}/`, '')
 
-export const escapeRegex = (s: string) => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+export const escapeRegex = (s: string) =>
+  s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
 
 export const isDirectChild = (id: string, parent: string) => {
-  return id !== parent && (new RegExp(`^${escapeRegex(parent)}/[a-zA-Z0-9-_#]+$`)).test(id)
+  return (
+    id !== parent &&
+    new RegExp(`^${escapeRegex(parent)}/[a-zA-Z0-9-_#]+$`).test(id)
+  )
 }
 
 const parseId = (id: string) => {
@@ -23,20 +27,23 @@ const parseId = (id: string) => {
 
 export const getDirectChildren = (extensions: Extensions, treePath: string) => {
   return Object.entries(extensions)
-    .filter(([id, extension]) => extension.component && isDirectChild(id, treePath))
+    .filter(
+      ([id, extension]) => extension.component && isDirectChild(id, treePath)
+    )
     .map(([id]) => relative(treePath, id))
     .sort((idA, idB) => {
       const [textA, numberA] = parseId(idA)
       const [textB, numberB] = parseId(idB)
-      const [valueA, valueB] = (textA === textB)
-        ? [numberA, numberB]
-        : [textA, textB]
+      const [valueA, valueB] =
+        textA === textB ? [numberA, numberB] : [textA, textB]
 
       return valueA < valueB ? -1 : 1
     })
 }
 
-export const TreePathContext = React.createContext<TreePathProps>({treePath: ''})
+export const TreePathContext = React.createContext<TreePathProps>({
+  treePath: '',
+})
 
 export const useTreePath = () => {
   return useContext(TreePathContext)
@@ -46,10 +53,14 @@ export interface TreePathProps {
   treePath: string
 }
 
-export function withTreePath <TOriginalProps>(Component: ComponentType<TOriginalProps & TreePathProps>): ComponentType<TOriginalProps> {
+export function withTreePath<TOriginalProps>(
+  Component: ComponentType<TOriginalProps & TreePathProps>
+): ComponentType<TOriginalProps> {
   class TreePath extends React.Component<TOriginalProps, TreePathProps> {
     public static get displayName(): string {
-      return `TreePath(${Component.displayName || Component.name || 'Component'})`
+      return `TreePath(${Component.displayName ||
+        Component.name ||
+        'Component'})`
     }
 
     public static get WrappedComponent() {
@@ -59,11 +70,14 @@ export function withTreePath <TOriginalProps>(Component: ComponentType<TOriginal
     public render() {
       return (
         <TreePathContext.Consumer>
-        {({treePath}) => <Component {...this.props} treePath={treePath}/>}
+          {({ treePath }) => <Component {...this.props} treePath={treePath} />}
         </TreePathContext.Consumer>
       )
     }
   }
 
-  return hoistNonReactStatics<TOriginalProps, TreePathProps>(TreePath, Component)
+  return hoistNonReactStatics<TOriginalProps, TreePathProps>(
+    TreePath,
+    Component
+  )
 }

--- a/react/utils/treePath.tsx
+++ b/react/utils/treePath.tsx
@@ -3,14 +3,20 @@ import React, {ComponentType, useContext} from 'react'
 
 const relative = (parent: string, id: string) => id.replace(`${parent}/`, '')
 
-export const escapeRegex = (s: string) => s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+export const escapeRegex = (s: string) => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
 
 export const isDirectChild = (id: string, parent: string) => {
   return id !== parent && (new RegExp(`^${escapeRegex(parent)}/[a-zA-Z0-9-_#]+$`)).test(id)
 }
 
 const parseId = (id: string) => {
-  const [, text, numericText] = /^(.*?)(\d+)?$/.exec(id)!
+  const matches = /^(.*?)(\d+)?$/.exec(id)
+
+  if (matches === null) {
+    return []
+  }
+
+  const [, text, numericText] = matches
   const numbericValue = numericText ? parseInt(numericText, 10) : 0
   return [text, numbericValue]
 }

--- a/react/utils/vteximg.ts
+++ b/react/utils/vteximg.ts
@@ -2,7 +2,7 @@ const SECURE_PROTOCOL = 'https://'
 const PROTOCOL_RELATIVE_PREFIX = '//'
 const ARQUIVOS_RELATIVE_PREFIX = '/arquivos'
 const ASSETS_RELATIVE_PREFIX = '/assets'
-const FILE_MANAGER_PATH_REGEX = /url\(\"?(.*\/)assets\/vtex\.file-manager-graphql/
+const FILE_MANAGER_PATH_REGEX = /url\("?(.*\/)assets\/vtex\.file-manager-graphql/
 
 export function optimizeSrcForVtexImg (vtexImgHost: string, src?: any) {
   try {

--- a/react/utils/vteximg.ts
+++ b/react/utils/vteximg.ts
@@ -4,13 +4,17 @@ const ARQUIVOS_RELATIVE_PREFIX = '/arquivos'
 const ASSETS_RELATIVE_PREFIX = '/assets'
 const FILE_MANAGER_PATH_REGEX = /url\("?(.*\/)assets\/vtex\.file-manager-graphql/
 
-export function optimizeSrcForVtexImg (vtexImgHost: string, src?: any) {
+export function optimizeSrcForVtexImg(vtexImgHost: string, src?: any) {
   try {
     if (src && src.indexOf(PROTOCOL_RELATIVE_PREFIX) === 0) {
       return src.replace(PROTOCOL_RELATIVE_PREFIX, SECURE_PROTOCOL)
     }
 
-    if (src && (src.indexOf(ARQUIVOS_RELATIVE_PREFIX) === 0 || src.indexOf(ASSETS_RELATIVE_PREFIX) === 0)) {
+    if (
+      src &&
+      (src.indexOf(ARQUIVOS_RELATIVE_PREFIX) === 0 ||
+        src.indexOf(ASSETS_RELATIVE_PREFIX) === 0)
+    ) {
       return vtexImgHost + src
     }
 
@@ -21,12 +25,15 @@ export function optimizeSrcForVtexImg (vtexImgHost: string, src?: any) {
   }
 }
 
-export function optimizeStyleForVtexImg (vtexImgHost: string, style?: any) {
+export function optimizeStyleForVtexImg(vtexImgHost: string, style?: any) {
   try {
     if (style && style.backgroundImage) {
       const match = FILE_MANAGER_PATH_REGEX.exec(style.backgroundImage)
       if (match && match[1]) {
-        style.backgroundImage = style.backgroundImage.replace(match[1], vtexImgHost + '/')
+        style.backgroundImage = style.backgroundImage.replace(
+          match[1],
+          vtexImgHost + '/'
+        )
       }
     }
 

--- a/react/utils/withHMR.tsx
+++ b/react/utils/withHMR.tsx
@@ -28,14 +28,18 @@ export default (module: Module, InitialImplementer: any) => {
     }
   }
 
-  class HMRComponent extends Component<any, {lastUpdate?: number}> {
+  class HMRComponent extends Component<any, { lastUpdate?: number }> {
     public static propTypes = {
       __clearError: PropTypes.func,
       __errorInstance: PropTypes.node,
     }
 
     public static get displayName(): string {
-      return HMRComponent.Implementer.displayName || HMRComponent.Implementer.name || 'Component'
+      return (
+        HMRComponent.Implementer.displayName ||
+        HMRComponent.Implementer.name ||
+        'Component'
+      )
     }
 
     public static hotReload = (NewImplementer: ComponentType) => {
@@ -47,16 +51,20 @@ export default (module: Module, InitialImplementer: any) => {
     private static Implementer = InitialImplementer as ComponentType
 
     public updateComponent = () => {
-      const {__emitter, treePath, __clearError, __errorInstance} = this.props
+      const { __emitter, treePath, __clearError, __errorInstance } = this.props
       __emitter.emit('build.status', 'hmr:success')
 
       if (__clearError && __errorInstance) {
         __clearError()
       } else {
-        this.setState({lastUpdate: Date.now()})
+        this.setState({ lastUpdate: Date.now() })
       }
 
-      console.log(`[render] Component updated. treePath=${treePath} updated=${HMRComponent.displayName}`)
+      console.log(
+        `[render] Component updated. treePath=${treePath} updated=${
+          HMRComponent.displayName
+        }`
+      )
     }
 
     public componentDidMount() {
@@ -68,10 +76,15 @@ export default (module: Module, InitialImplementer: any) => {
     }
 
     public render() {
-      const {__emitter, __clearError, __errorInstance, ...props} = this.props
-      return this.props.__errorInstance || <HMRComponent.Implementer {...props} />
+      const { __emitter, __clearError, __errorInstance, ...props } = this.props
+      return (
+        this.props.__errorInstance || <HMRComponent.Implementer {...props} />
+      )
     }
   }
 
-  return hoistNonReactStatics(withEmitter(withTreePath(HMRComponent)), InitialImplementer)
+  return hoistNonReactStatics(
+    withEmitter(withTreePath(HMRComponent)),
+    InitialImplementer
+  )
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -832,6 +832,44 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
 
+"@typescript-eslint/eslint-plugin@^1.4.2":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.9.0.tgz#29d73006811bf2563b88891ceeff1c5ea9c8d9c6"
+  integrity sha512-FOgfBorxjlBGpDIw+0LaZIXRX6GEEUfzj8LXwaQIUCp+gDOvkI+1WgugJ7SmWiISqK9Vj5r8S7NDKO/LB+6X9A==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "1.9.0"
+    "@typescript-eslint/parser" "1.9.0"
+    eslint-utils "^1.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/experimental-utils@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.9.0.tgz#a92777d0c92d7bc8627abd7cdb06cdbcaf2b39e8"
+  integrity sha512-1s2dY9XxBwtS9IlSnRIlzqILPyeMly5tz1bfAmQ84Ul687xBBve5YsH5A5EKeIcGurYYqY2w6RkHETXIwnwV0A==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.9.0"
+
+"@typescript-eslint/parser@1.9.0", "@typescript-eslint/parser@^1.4.2":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.9.0.tgz#5796cbfcb9a3a5757aeb671c1ac88d7a94a95962"
+  integrity sha512-CWgC1XrQ34H/+LwAU7vY5xteZDkNqeAkeidEpJnJgkKu0yqQ3ZhQ7S+dI6MX4vmmM1TKRbOrKuXc6W0fIHhdbA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "1.9.0"
+    "@typescript-eslint/typescript-estree" "1.9.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.9.0.tgz#5d6d49be936e96fb0f859673480f89b070a5dd9b"
+  integrity sha512-7Eg0TEQpCkTsEwsl1lIzd6i7L3pJLQFWesV08dS87bNz0NeSjbL78gNAP1xCKaCejkds4PhpLnZkaAjx9SU8OA==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -847,6 +885,11 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+
 acorn-walk@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
@@ -859,6 +902,11 @@ acorn@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
 
+acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
 ajv@^6.5.5:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
@@ -868,7 +916,17 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escapes@^3.0.0:
+ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
 
@@ -883,6 +941,11 @@ ansi-regex@^3.0.0:
 ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1035,6 +1098,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1050,6 +1121,14 @@ arr-union@^3.1.0:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1076,6 +1155,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -1107,7 +1191,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+axobject-query@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
+  integrity sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==
+  dependencies:
+    ast-types-flow "0.0.7"
+
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1736,10 +1827,6 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1806,7 +1893,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -1814,13 +1901,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 charenc@~0.0.1:
   version "0.0.2"
@@ -1847,6 +1931,13 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
 cli-table3@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
@@ -1855,6 +1946,11 @@ cli-table3@^0.5.0:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1899,9 +1995,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+commander@^2.11.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -1966,7 +2063,7 @@ cosmiconfig@^5.0.5:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -2007,6 +2104,11 @@ csstype@^2.2.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
 
+damerau-levenshtein@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz#780cf7144eb2e8dbd1c3bb83ae31100ccc31a414"
+  integrity sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2031,7 +2133,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   dependencies:
@@ -2114,16 +2216,19 @@ diff-sequences@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.0.0.tgz#cdf8e27ed20d8b8d3caccb4e0c0d8fe31a173013"
 
-diff@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-
-doctrine@0.7.2, doctrine@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
-    esutils "^1.1.6"
-    isarray "0.0.1"
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-testing-library@^3.13.1:
   version "3.16.5"
@@ -2155,6 +2260,11 @@ electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.47:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
 
+emoji-regex@^7.0.1, emoji-regex@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2177,7 +2287,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
+es-abstract@^1.11.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   dependencies:
@@ -2211,6 +2321,150 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^4.0.0, eslint-config-prettier@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
+  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
+  dependencies:
+    get-stdin "^6.0.0"
+
+eslint-config-vtex-react@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-4.1.0.tgz#ff3af3a9fbff717e42fa0d207e0344ec1ec19a0f"
+  integrity sha512-DJJ4HQEAx4EVvJPE9zz52IlRbf+GL+Rscr50fDJQkM8UTUlndAHXCuYrqir1VvSps9+xvFNnc+LnwdjQv5dIlw==
+  dependencies:
+    eslint-config-prettier "^4.2.0"
+    eslint-config-vtex "^10.0.0"
+    eslint-plugin-jsx-a11y "^6.2.1"
+    eslint-plugin-react "^7.0.0"
+    eslint-plugin-react-hooks "^1.0.0"
+
+eslint-config-vtex@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-10.1.0.tgz#cd5f802c5ce2f2fa79f889ff4c7e7ca9fcce6ccc"
+  integrity sha512-WgkdsXpTgJbOfGRRB3kAKDZNT+1Qeo5GlNxs3SXwCmQ7NNh/AHvY3ClLO2BmDKBf/t2Mkfe+piXrk8A4DkjRrQ==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^1.4.2"
+    "@typescript-eslint/parser" "^1.4.2"
+    eslint-config-prettier "^4.0.0"
+    eslint-plugin-lodash "^5.1.0"
+    eslint-plugin-prettier "^3.0.1"
+
+eslint-plugin-jsx-a11y@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz#4ebba9f339b600ff415ae4166e3e2e008831cf0c"
+  integrity sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==
+  dependencies:
+    aria-query "^3.0.0"
+    array-includes "^3.0.3"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.2"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^7.0.2"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
+
+eslint-plugin-lodash@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-5.1.0.tgz#f7dc6c14f104cacb169a18d17c27d9c015a53924"
+  integrity sha512-mMKmf1OMLS8VExtaHCcrwBmsYIiOVYEibnAFDzXrbJdtFGOcLEw37tryN/WGYKBiJy6nAIGC43i5Wh3KA9lO2g==
+  dependencies:
+    lodash "4.17.11"
+
+eslint-plugin-prettier@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
+  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
+eslint-plugin-react@^7.0.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.1.0"
+    object.fromentries "^2.0.0"
+    prop-types "^15.7.2"
+    resolve "^1.10.1"
+
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.13.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
+
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
@@ -2219,13 +2473,23 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-estraverse@^4.2.0:
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-
-esutils@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -2308,6 +2572,15 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+external-editor@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2338,6 +2611,11 @@ extsprintf@^1.2.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -2375,6 +2653,20 @@ fclone@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
 
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 fileset@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
@@ -2404,6 +2696,20 @@ find-up@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   dependencies:
     locate-path "^3.0.0"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 flux@^3.1.3:
   version "3.1.3"
@@ -2455,6 +2761,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2471,6 +2782,11 @@ gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -2520,6 +2836,11 @@ global@^4.3.0:
 globals@^11.1.0:
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2669,7 +2990,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -2681,12 +3002,25 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
   dependencies:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@^2.0.0:
   version "2.0.0"
@@ -2717,6 +3051,25 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+inquirer@^6.2.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
 
 intl-format-cache@^2.0.5:
   version "2.1.0"
@@ -2866,6 +3219,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -2893,10 +3251,6 @@ is-windows@^1.0.2:
 is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3337,9 +3691,10 @@ js-yaml@^3.12.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.7.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3403,6 +3758,11 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3431,6 +3791,13 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz#0ee4e2c971fb9601c67b5641b71be80faecf0b36"
+  integrity sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==
+  dependencies:
+    array-includes "^3.0.3"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3470,7 +3837,7 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -3521,11 +3888,16 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
+lodash@4.17.11, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -3688,6 +4060,11 @@ ms@2.0.0:
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 myvtex-sse@^1.2.0:
   version "1.2.0"
@@ -3866,6 +4243,16 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  integrity sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -3885,6 +4272,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -3892,7 +4286,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -3915,7 +4309,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3964,6 +4358,13 @@ p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -3986,6 +4387,11 @@ path-exists@^3.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
@@ -4037,6 +4443,18 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+
 pretty-format@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.0.0.tgz#cb6599fd73ac088e37ed682f61291e4678f48591"
@@ -4055,6 +4473,11 @@ process-nextick-args@~2.0.0:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise@^7.1.1:
   version "7.3.1"
@@ -4081,6 +4504,15 @@ prop-types@^15.6.2:
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.1.tgz#2fa61e0a699d428b40320127733ee2931f05d9d1"
   dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
@@ -4347,6 +4779,11 @@ regexp-tree@^0.1.0:
     colors "^1.1.2"
     yargs "^12.0.5"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -4451,6 +4888,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -4460,6 +4902,11 @@ resolve-cwd@^2.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-pathname@^2.2.0:
   version "2.2.0"
@@ -4479,17 +4926,32 @@ resolve@1.x, resolve@^1.10.0, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.10.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.3.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:
@@ -4502,6 +4964,20 @@ route-parser@^0.0.5:
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+  dependencies:
+    is-promise "^2.1.0"
+
+rxjs@^6.4.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4549,7 +5025,7 @@ scheduler@^0.13.6:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
-semver@^5.3.0:
+semver@5.5.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -4612,6 +5088,15 @@ slash@^1.0.0:
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4763,12 +5248,21 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -4794,6 +5288,13 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -4806,7 +5307,7 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -4834,6 +5335,16 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+table@^5.2.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.3.3.tgz#eae560c90437331b74200e011487a33442bd28b4"
+  integrity sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==
+  dependencies:
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
 tar@^4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
@@ -4855,9 +5366,26 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -4951,71 +5479,14 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@1.9.0, tslib@^1.0.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
-
-tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint-config-prettier@^1.6.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.10.0.tgz#5063c413d43de4f6988c73727f65ecfc239054ec"
-
-tslint-config-vtex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-vtex/-/tslint-config-vtex-2.0.0.tgz#416c83bd3b4259aee3846198eb1bfa893c89feec"
-  dependencies:
-    tslint-config-prettier "^1.6.0"
-    tslint-eslint-rules "^4.1.1"
-
-tslint-eslint-rules@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz#7c30e7882f26bc276bff91d2384975c69daf88ba"
-  dependencies:
-    doctrine "^0.7.2"
-    tslib "^1.0.0"
-    tsutils "^1.4.0"
-
-tslint-eslint-rules@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.1.0.tgz#3232b318da55dbb5a83e3f5d657c1ddbb27b9ff2"
-  dependencies:
-    doctrine "0.7.2"
-    tslib "1.9.0"
-    tsutils "2.8.0"
-
-tslint@^5.2.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.7.0"
-    minimatch "^3.0.4"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.12.1"
-
-tsutils@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
-  dependencies:
-    tslib "^1.7.1"
-
-tsutils@^1.4.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
-
-tsutils@^2.12.1:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.22.2.tgz#0b9f3d87aa3eb95bd32d26ce2b88aa329a657951"
+tsutils@^3.7.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
   dependencies:
     tslib "^1.8.1"
 
@@ -5035,9 +5506,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"
@@ -5238,6 +5710,13 @@ write-file-atomic@2.4.1:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
**Note: highly recommended that you review this PR commit by commit**

these changes are linked in [this](https://lucas--storecomponents.myvtex.com/shirt/Clothing?map=ft%2Cc) workspace.

8c6130b: removes tslint packages and config files and add eslint based on [this recipe](https://docs.google.com/document/d/1ePi5Mn3pe1dOorKrMtC-MclBDiIDimVzf0Uj61W8lA4/edit), with some additional disabled rules so we don't have to deal with them _right now_.

9c2e11e: with the linter change, some errors showed up regarding some unused variables, and a few other things. this commit addresses all **errors**, but some warnings were ignored (or disabled in the first commit)

aaf2923: this is just prettier's work, you can probably skip this.