### PR TITLE
Print operation id on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Link to catch GraphQL errors, store and show them when a component crashes.
+- Sending `domain` and `page` to Sentry as tags.
+
+### Changed
+- Hide some runtime keys before sending it to Sentry.
+- Broke the runtime extra sent to Sentry into smaller `runtime.${key}` extras.
+- Inlined sentry config to remove one file from pages fetching phase.
+
+### Fixed
+- Global typings.
+
 ## [8.31.1] - 2019-05-25
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.32.0] - 2019-05-27
+
 ### Added
 - Link to catch GraphQL errors, store and show them when a component crashes.
 - Sending `domain` and `page` to Sentry as tags.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.31.1",
+  "version": "8.32.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,0 @@
-{
-  "sentryDSN": "https://2fac72ea180d48ae9bf1dbb3104b4000@sentry.io/1292015"
-}

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -116,10 +116,19 @@ class ExtensionPointComponent extends PureComponent<
     // Only log 10 percent of the errors so we dont exceed our quota
     if (production && Math.random() < 0.1) {
       Sentry.withScope(scope => {
-        const blacklistedRuntimeKeys = ['cacheHints', 'components', 'culture', 'emitter', 'history', 'messages']
+        const blacklistedRuntimeKeys = [
+          'cacheHints',
+          'components',
+          'culture',
+          'emitter',
+          'history',
+          'messages',
+        ]
 
         const filteredRuntime = pickBy((val, key) => {
-          return typeof val !== 'function' && !blacklistedRuntimeKeys.includes(key)
+          return (
+            typeof val !== 'function' && !blacklistedRuntimeKeys.includes(key)
+          )
         }, runtime)
 
         forEachObjIndexed((value, key) => {

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -115,7 +115,7 @@ class ExtensionPointComponent extends PureComponent<
     const operationIds = graphQLErrorsStore.getOperationIds()
     // Only log 10 percent of the errors so we dont exceed our quota
     if (production && Math.random() < 0.1) {
-      Sentry.configureScope(scope => {
+      Sentry.withScope(scope => {
         const blacklistedRuntimeKeys = ['cacheHints', 'components', 'culture', 'emitter', 'history', 'messages']
 
         const filteredRuntime = pickBy((val, key) => {
@@ -135,8 +135,8 @@ class ExtensionPointComponent extends PureComponent<
         scope.setTag('component', component || '')
         scope.setTag('domain', runtime.route.domain)
         scope.setTag('page', runtime.page)
+        Sentry.captureException(error)
       })
-      Sentry.captureException(error)
     }
 
     this.setState({

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/browser'
 import PropTypes from 'prop-types'
+import { chain, pluck } from 'ramda'
 import React, { ErrorInfo, PureComponent } from 'react'
 
 import { getImplementation } from '../utils/assets'
@@ -112,10 +113,13 @@ class ExtensionPointComponent extends PureComponent<
         scope.setExtra('runtime', runtime)
         scope.setExtra('treePath', path)
         scope.setExtra('props', componentProps)
+        scope.setExtra('operationIds', chain(pluck('operationId'), window.graphQLErrors))
 
         scope.setTag('account', account)
         scope.setTag('workspace', workspace)
         scope.setTag('component', component || '')
+        scope.setTag('domain', runtime.route.domain)
+        scope.setTag('page', runtime.page)
       })
       Sentry.captureException(error)
     }

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -5,6 +5,7 @@ interface Props {
   treePath: string
   error?: Error
   errorInfo?: ErrorInfo | null
+  operationIds: string[]
 }
 
 interface State {
@@ -30,8 +31,9 @@ class ExtensionPointError extends PureComponent<Props, State> {
   }
 
   public render() {
-    const { treePath, error, errorInfo } = this.props
+    const { treePath, error, errorInfo, operationIds } = this.props
     const { errorDetails } = this.state
+
     const componentStack = errorInfo && errorInfo.componentStack
 
     return (
@@ -49,13 +51,13 @@ class ExtensionPointError extends PureComponent<Props, State> {
         {errorDetails && error && (
           <>
             <ul className="f6 list pl0">
-              {window && window.graphQLErrors && window.graphQLErrors[0] ? window.graphQLErrors[0].map(
-                (graphQLError) => (
-                  <li key={graphQLError.operationId}>
-                    <span>Operation ID:</span> <span className="i">{graphQLError.operationId}</span>
+              {operationIds.map(
+                (operationId) => (
+                  <li key={operationId}>
+                    <span>Operation ID:</span> <span className="i">{operationId}</span>
                   </li>
                 )
-              ) : null}
+              )}
             </ul>
           <pre>
             <code className="f6">{error.stack}</code>

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -59,9 +59,9 @@ class ExtensionPointError extends PureComponent<Props, State> {
                 )
               )}
             </ul>
-          <pre>
-            <code className="f6">{error.stack}</code>
-          </pre>
+            <pre>
+              <code className="f6">{error.stack}</code>
+            </pre>
           </>
         )}
         {errorDetails && componentStack && (

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -51,13 +51,12 @@ class ExtensionPointError extends PureComponent<Props, State> {
         {errorDetails && error && (
           <>
             <ul className="f6 list pl0">
-              {operationIds.map(
-                (operationId) => (
-                  <li key={operationId}>
-                    <span>Operation ID:</span> <span className="i">{operationId}</span>
-                  </li>
-                )
-              )}
+              {operationIds.map(operationId => (
+                <li key={operationId}>
+                  <span>Operation ID:</span>{' '}
+                  <span className="i">{operationId}</span>
+                </li>
+              ))}
             </ul>
             <pre>
               <code className="f6">{error.stack}</code>

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -47,9 +47,20 @@ class ExtensionPointError extends PureComponent<Props, State> {
           ({errorDetails ? 'hide' : 'show'} details)
         </button>
         {errorDetails && error && (
+          <>
+            <ul className="f6 list pl0">
+              {window && window.graphQLErrors && window.graphQLErrors[0] ? window.graphQLErrors[0].map(
+                (graphQLError) => (
+                  <li key={graphQLError.operationId}>
+                    <span>Operation ID:</span> <span className="i">{graphQLError.operationId}</span>
+                  </li>
+                )
+              ) : null}
+            </ul>
           <pre>
             <code className="f6">{error.stack}</code>
           </pre>
+          </>
         )}
         {errorDetails && componentStack && (
           <pre>

--- a/react/package.json
+++ b/react/package.json
@@ -1,9 +1,7 @@
 {
-  "name": "vtex.render-runtime",
-  "version": null,
   "license": "UNLICENSED",
   "scripts": {
-    "lint": "tsc --noEmit --pretty && eslint --ext ts,tsx .",
+    "lint": "tsc --noEmit --pretty && eslint --fix --ext ts,tsx .",
     "test": "jest"
   },
   "dependencies": {

--- a/react/package.json
+++ b/react/package.json
@@ -10,6 +10,7 @@
     "@types/react-content-loader": "^3.1.4",
     "apollo-cache-inmemory": "^1.2.5",
     "apollo-client": "^2.5.1",
+    "apollo-link-error": "^1.1.10",
     "apollo-link-http": "^1.5.4",
     "apollo-link-persisted-queries": "^0.2.1",
     "apollo-upload-client": "^8.1.0",

--- a/react/start.ts
+++ b/react/start.ts
@@ -1,14 +1,15 @@
 import * as Sentry from '@sentry/browser'
 import { canUseDOM } from 'exenv'
 
+const sentryDSN = 'https://2fac72ea180d48ae9bf1dbb3104b4000@sentry.io/1292015'
+
 if (canUseDOM && window.__RUNTIME__.production) {
-  const { config = null, version = '' } = window.__RUNTIME__.runtimeMeta || {}
-  const dsn = config && config.sentryDSN
+  const { version = '' } = window.__RUNTIME__.runtimeMeta || {}
   Sentry.init({
     beforeSend: (event: Sentry.SentryEvent) =>
       event.tags && event.tags.component ? event : null,
     defaultIntegrations: true,
-    dsn,
+    dsn: sentryDSN,
     environment: canUseDOM ? 'browser' : 'ssr',
     release: version,
   })

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -456,4 +456,11 @@ declare global {
     myvtexSSE: any
     rendered: Promise<RenderedSuccess> | RenderedFailure
   }
+
+  namespace NodeJS {
+    interface Global extends Window {}
+  }
+  interface NodeModule {
+    hot: any
+  }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -458,8 +458,11 @@ declare global {
   }
 
   namespace NodeJS {
-    interface Global extends Window {}
+    interface Global extends Window {
+      myvtexSSE: any
+    }
   }
+
   interface NodeModule {
     hot: any
   }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -127,6 +127,7 @@ declare global {
   }
 
   interface Route {
+    domain: string
     blockId: string
     canonicalPath?: string
     id: string

--- a/react/typings/node.d.ts
+++ b/react/typings/node.d.ts
@@ -2,8 +2,6 @@ interface Module {
   hot: any
 }
 
-declare var global: Window
-
 declare var module: Module
 
 declare module '*.graphql' {

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -5,6 +5,7 @@ import {
 } from 'apollo-cache-inmemory'
 import { ApolloClient } from 'apollo-client'
 import { ApolloLink } from 'apollo-link'
+import { onError } from 'apollo-link-error'
 import { createHttpLink } from 'apollo-link-http'
 import { createPersistedQueryLink } from 'apollo-link-persisted-queries'
 import { createUploadLink } from 'apollo-upload-client'
@@ -59,6 +60,10 @@ export const getState = (runtime: RenderRuntime) => {
   return apolloClient ? apolloClient.cache.extract() : {}
 }
 
+if (canUseDOM) {
+  window.graphQLErrors = []
+}
+
 export const getClient = (
   runtime: RenderRuntime,
   baseURI: string,
@@ -99,7 +104,20 @@ export const getClient = (
 
     const cacheLink = cacheControl ? [cachingLink(cacheControl)] : []
 
+    const errorLink = onError(({ graphQLErrors }) => {
+      const ignoredErrorTypes = ['UserInputError', 'AuthenticationError', 'ForbiddenError']
+      if (graphQLErrors) {
+        const relevantGraphQLErrors = graphQLErrors.filter(({extensions}) => {
+          return extensions && !ignoredErrorTypes.includes(extensions.exception.name)
+        })
+        if (relevantGraphQLErrors.length > 0) {
+          window.graphQLErrors = [relevantGraphQLErrors, ...window.graphQLErrors]
+        }
+      }
+    })
+
     const link = ApolloLink.from([
+      errorLink,
       omitTypenameLink,
       versionSplitterLink,
       runtimeContextLink,

--- a/react/utils/graphQLErrorsStore.ts
+++ b/react/utils/graphQLErrorsStore.ts
@@ -12,18 +12,27 @@ export interface ExtendedGraphQLError extends GraphQLError {
   }
 }
 
-export function isExtendedGraphQLError (error: GraphQLError): error is ExtendedGraphQLError {
+export function isExtendedGraphQLError(
+  error: GraphQLError
+): error is ExtendedGraphQLError {
   return 'operationId' in error
 }
 
-const ignoredErrorTypes = ['UserInputError', 'AuthenticationError', 'ForbiddenError']
+const ignoredErrorTypes = [
+  'UserInputError',
+  'AuthenticationError',
+  'ForbiddenError',
+]
 
 class GraphQLErrorsStore {
   private operationIds: string[] = []
 
-  public addOperationIds(errors: ReadonlyArray<GraphQLError>) {
+  public addOperationIds(errors: readonly GraphQLError[]) {
     const operationIds = errors.reduce<string[]>((acc, error) => {
-      if (isExtendedGraphQLError(error) && !ignoredErrorTypes.includes(error.extensions.exception.name || '')) {
+      if (
+        isExtendedGraphQLError(error) &&
+        !ignoredErrorTypes.includes(error.extensions.exception.name || '')
+      ) {
         return acc.concat(error.operationId)
       }
       return acc

--- a/react/utils/graphQLErrorsStore.ts
+++ b/react/utils/graphQLErrorsStore.ts
@@ -1,0 +1,43 @@
+import { GraphQLError } from 'graphql'
+import { pluck } from 'ramda'
+
+export interface ExtendedGraphQLError extends GraphQLError {
+  operationId: string
+  extensions: {
+    code: string
+    exception: {
+      stacktrace: string
+      name?: string
+    }
+  }
+}
+
+export function isExtendedGraphQLError (error: GraphQLError): error is ExtendedGraphQLError {
+  return 'operationId' in error
+}
+
+const ignoredErrorTypes = ['UserInputError', 'AuthenticationError', 'ForbiddenError']
+
+class GraphQLErrorsStore {
+  private operationIds: string[] = []
+
+  public addOperationIds(errors: ReadonlyArray<GraphQLError>) {
+    const operationIds = errors.reduce<string[]>((acc, error) => {
+      if (isExtendedGraphQLError(error) && !ignoredErrorTypes.includes(error.extensions.exception.name || '')) {
+        return acc.concat(error.operationId)
+      }
+      return acc
+    }, [])
+    this.operationIds = this.operationIds.concat(operationIds)
+  }
+
+  public getOperationIds() {
+    const operationIds = this.operationIds.slice()
+    this.operationIds = []
+    return operationIds
+  }
+}
+
+const Store = new GraphQLErrorsStore()
+
+export default Store

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1005,6 +1005,24 @@ apollo-link-dedup@^1.0.0:
   dependencies:
     apollo-link "^1.2.6"
 
+apollo-link-error@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.10.tgz#ce57f0793f0923b598655de5bf5e028d4cf4fba6"
+  integrity sha512-itG5UV7mQqaalmRkuRsF0cUS4zW2ja8XCbxkMZnIEeN24X3yoJi5hpJeAaEkXf0KgYNsR0+rmtCQNruWyxDnZQ==
+  dependencies:
+    apollo-link "^1.2.11"
+    apollo-link-http-common "^0.2.13"
+    tslib "^1.9.3"
+
+apollo-link-http-common@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"
+  integrity sha512-Uyg1ECQpTTA691Fwx5e6Rc/6CPSu4TB4pQRTGIpwZ4l5JDOQ+812Wvi/e3IInmzOZpwx5YrrOfXrtN8BrsDXoA==
+  dependencies:
+    apollo-link "^1.2.11"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.4, apollo-link-http-common@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz#d094beb7971523203359bf830bfbfa7b4e7c30ed"
@@ -1038,6 +1056,16 @@ apollo-link@^1.2.1:
   dependencies:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.10"
+
+apollo-link@^1.2.11:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.11.tgz#493293b747ad3237114ccd22e9f559e5e24a194d"
+  integrity sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==
+  dependencies:
+    apollo-utilities "^1.2.1"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.18"
 
 apollo-upload-client@^8.1.0:
   version "8.1.0"
@@ -5465,6 +5493,13 @@ ts-invariant@^0.3.0:
   dependencies:
     tslib "^1.9.3"
 
+ts-invariant@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.3.3.tgz#b5742b1885ecf9e29c31a750307480f045ec0b16"
+  integrity sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==
+  dependencies:
+    tslib "^1.9.3"
+
 ts-jest@^23.10.5:
   version "23.10.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
@@ -5770,6 +5805,14 @@ zen-observable-ts@^0.8.10, zen-observable-ts@^0.8.13:
   version "0.8.13"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.13.tgz#ae1fd77c84ef95510188b1f8bca579d7a5448fc2"
   dependencies:
+    zen-observable "^0.8.0"
+
+zen-observable-ts@^0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz#ade44b1060cc4a800627856ec10b9c67f5f639c8"
+  integrity sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==
+  dependencies:
+    tslib "^1.9.3"
     zen-observable "^0.8.0"
 
 zen-observable@^0.8.0:


### PR DESCRIPTION
In this PR:

- [x] Create `apollo-link` to catch errors, store the operation IDs of the failed requests and show them on the `ExtensionPointError` component.
- [x] Change the Sentry reporting tags and extra infos.
- [x] Fix global typings.
- [x] Change Sentry scope configuration to use `withScope` ([explanation](https://docs.sentry.io/enriching-error-data/scopes/?platform=javascript#local-scopes)).

[Workspace](https://operationiderror--storecomponents.myvtex.com/)

I wasn't able to send an event in the workspace :(. Any idea why? What I did was commenting the `if` around the Sentry functions and using the `prod` environment instead of `staging`...