### PR TITLE
Fix updateRuntime params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.29.3] - 2019-05-20
 ### Fixed
 - Fixed `paramsJSON` when refetching page due to `updateRuntime`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed `paramsJSON` when refetching page due to `updateRuntime`.
 
 ## [8.29.2] - 2019-05-20
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.29.2",
+  "version": "8.29.3",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -691,9 +691,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     } = this.state
     const declarer = pagesState[page] && pagesState[page].declarer
     const { pathname } = window.location
-    const paramsJSON = JSON.stringify(
-      (pagesState[page] && pagesState[page].params) || {}
-    )
+    const paramsJSON = JSON.stringify(route.params || {})
 
     return fetchNavigationPage({
       apolloClient: this.apolloClient,


### PR DESCRIPTION
The `paramsJSON` sent when calling `updateRuntime` is always empty. It makes pages-graphql response wrong, because it can not identify the page properly.