### PR TITLE
Feature - Add messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Method to add messages to Runtime (`addMessages`).
+- `addMessages` and `messages` to Render context.
+
+### Changed
+
+- `sendInfoFromIframe` signature.
+- `updateExtension` and `updateRuntime` now await for `setState` to be finished.
+
+### Deprecated
+
+- `RenderProvider`'s `updateMessages` private method.
+- `sendInfoFromIframe`'s 4th argument (`setMessages`).
 
 ## [8.29.3] - 2019-05-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.30.0] - 2019-05-21
 ### Added
 
 - Method to add messages to Runtime (`addMessages`).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.29.3",
+  "version": "8.30.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "defaultLocale": "pt-BR",

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -817,17 +817,19 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.setState({ device })
   }
 
-  public addMessages = (newMessages: RenderRuntime['messages']) => {
+  public addMessages = async (newMessages: RenderRuntime['messages']) => {
     const newStateMessages = { ...this.state.messages, ...newMessages }
 
-    this.setState(
-      {
-        messages: newStateMessages,
-      },
-      () => {
-        this.sendInfoFromIframe()
-      }
-    )
+    await new Promise<void>(resolve => {
+      this.setState(
+        {
+          messages: newStateMessages,
+        },
+        resolve
+      )
+    })
+
+    await this.sendInfoFromIframe()
   }
 
   public render() {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -159,6 +159,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         this.getChildContext(),
         this.state.messages,
         (params && params.shouldUpdateRuntime) || false,
+        // Deprecated
         this.updateMessages
       )
     },
@@ -873,6 +874,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     )
   }
 
+  // Deprecated
   private updateMessages = (newMessages: RenderProviderState['messages']) => {
     this.setState(
       prevState => ({

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -720,7 +720,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       ...options,
     })
 
-    return new Promise<void>(resolve => {
+    await new Promise<void>(resolve => {
       this.setState(
         {
           appsEtag,
@@ -733,13 +733,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           route,
           settings,
         },
-        async () => {
-          await this.sendInfoFromIframe()
-
-          resolve()
-        }
+        resolve
       )
     })
+
+    await this.sendInfoFromIframe()
   }
 
   public createEnsureSessionLink() {
@@ -798,7 +796,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public updateExtension = async (name: string, extension: Extension) => {
     const { extensions } = this.state
 
-    return new Promise<void>(resolve => {
+    await new Promise<void>(resolve => {
       this.setState(
         {
           extensions: {
@@ -806,15 +804,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             [name]: extension,
           },
         },
-        async () => {
-          if (name !== 'store/__overlay') {
-            await this.sendInfoFromIframe()
-          }
-
-          resolve()
-        }
+        resolve
       )
     })
+
+    if (name !== 'store/__overlay') {
+      await this.sendInfoFromIframe()
+    }
   }
 
   public handleSetDevice = (device: ConfigurationDevice) => {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -180,6 +180,7 @@ declare global {
 
   interface RenderContext {
     account: RenderRuntime['account']
+    addMessages: (newMessages: RenderContext['messages']) => void
     components: RenderRuntime['components']
     culture: RenderRuntime['culture']
     device: ConfigurationDevice
@@ -190,6 +191,7 @@ declare global {
     getSettings: (app: string) => any
     hints: RenderHints
     history: History | null
+    messages: RenderRuntime['messages']
     navigate: (options: NavigateOptions) => boolean
     onPageChanged: (location: RenderHistoryLocation) => void
     page: RenderRuntime['page']

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -180,7 +180,7 @@ declare global {
 
   interface RenderContext {
     account: RenderRuntime['account']
-    addMessages: (newMessages: RenderContext['messages']) => void
+    addMessages: (newMessages: RenderContext['messages']) => Promise<void>
     components: RenderRuntime['components']
     culture: RenderRuntime['culture']
     device: ConfigurationDevice

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -203,8 +203,8 @@ declare global {
     publicEndpoint: RenderRuntime['publicEndpoint']
     setDevice: (device: ConfigurationDevice) => void
     updateComponentAssets: (availableComponents: Components) => void
-    updateExtension: (name: string, extension: Extension) => void
-    updateRuntime: (options?: PageContextOptions) => Subscription
+    updateExtension: (name: string, extension: Extension) => Promise<void>
+    updateRuntime: (options?: PageContextOptions) => Promise<void>
     workspace: RenderRuntime['workspace']
     route: RenderRuntime['route']
     query: RenderRuntime['query']
@@ -437,7 +437,7 @@ declare global {
       messages: Record<string, string>,
       shouldUpdateRuntime: boolean,
       setMessages: (messages: RenderRuntime['messages']) => void
-    ) => void
+    ) => Promise<void>
     browserHistory: History
     ReactIntlLocaleData: any
     IntlPolyfill: any


### PR DESCRIPTION
### Changes

#### Added

- Method to add messages to Runtime (`addMessages`).
- `addMessages` and `messages` to Render context.

#### Changed

- `sendInfoFromIframe` signature.
- `updateExtension` and `updateRuntime` now await for `setState` to be finished.

#### Deprecated

- `RenderProvider`'s `updateMessages` private method.
- `sendInfoFromIframe`'s 4th argument (`setMessages`).