### PR TITLE
Removes cache hints from navigation queries

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -6,7 +6,6 @@ import debounce from 'debounce'
 import { canUseDOM } from 'exenv'
 import { History, UnregisterCallback } from 'history'
 import PropTypes from 'prop-types'
-import { merge, mergeWith } from 'ramda'
 import React, { Component, Fragment, ReactElement } from 'react'
 import { ApolloProvider } from 'react-apollo'
 import { Helmet } from 'react-helmet'
@@ -552,7 +551,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     }).then(
       ({
         appsEtag,
-        cacheHints,
         components,
         extensions,
         matchingPage,
@@ -564,7 +562,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         this.setState(
           {
             appsEtag,
-            cacheHints: mergeWith(merge, this.state.cacheHints, cacheHints),
             components: { ...this.state.components, ...components },
             extensions: { ...this.state.extensions, ...extensions },
             loadedPages: loadedPages.add(page),
@@ -703,7 +700,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     const {
       appsEtag,
-      cacheHints,
       components,
       extensions,
       messages,
@@ -727,7 +723,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       this.setState(
         {
           appsEtag,
-          cacheHints,
           components,
           extensions,
           messages,

--- a/react/queries/navigationPage.graphql
+++ b/react/queries/navigationPage.graphql
@@ -16,7 +16,6 @@ query NavigationPage (
   ) {
     appsEtag
     appsSettingsJSON
-    cacheHintsJSON
     componentsJSON
     extensionsJSON
     messages {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -328,7 +328,6 @@ declare global {
     pages: RenderRuntime['pages']
     appsEtag: RenderRuntime['appsEtag']
     settings: RenderRuntime['settings']
-    cacheHints: RenderRuntime['cacheHints']
     matchingPage: MatchingPage
   }
 

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -8,7 +8,6 @@ const parsePageQueryResponse = (
   const {
     appsEtag,
     appsSettingsJSON,
-    cacheHintsJSON,
     componentsJSON,
     extensionsJSON,
     messages,
@@ -22,8 +21,7 @@ const parsePageQueryResponse = (
     },
   } = page
 
-  const [cacheHints, components, extensions, pages, settings] = [
-    cacheHintsJSON,
+  const [components, extensions, pages, settings] = [
     componentsJSON,
     extensionsJSON,
     pagesJSON,
@@ -32,7 +30,6 @@ const parsePageQueryResponse = (
 
   return {
     appsEtag,
-    cacheHints,
     components,
     extensions,
     matchingPage: {


### PR DESCRIPTION
Cache hints are a static map and generated the same way in ServerPage and in NavigationPage. This PR removes the cache-hints retrieval for navigation page