### PR TITLE
Fix navigation to a URL that have a search term as the first path, fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix navigation to a URL that have a search term as the first path, followed by the subcategory paths.
+
 ## [8.36.0] - 2019-06-13
 
 ### Added

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,7 +1,7 @@
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
-import { difference, is, isEmpty, keys, startsWith } from 'ramda'
+import { difference, is, isEmpty, keys, includes } from 'ramda'
 import RouteParser from 'route-parser'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
@@ -309,7 +309,7 @@ function routeMatchForMappedURL(
 
   for (const name in routes) {
     const { map = [], path: routePath } = routes[name]
-    if (!routePath || map.length === 0 || !startsWith(map, mappedSegments)) {
+    if (!routePath || map.length === 0 || !includes(map.join(','), mappedSegments.join(','))) {
       continue
     }
 


### PR DESCRIPTION
…llowed by the subcategory paths

How to reproduce the bug:

1. Open https://storecomponents.myvtexdev.com/top/Apparel---Accessories/Hats?map=ft%2Cc%2Cc
2. Click on the subcategory "Panama"
3. It will load a wrong page layout.

This happens because the render-runtime thinks it's loading a search#custom.

If you do the same here:

https://breno--storecomponents.myvtexdev.com/top/Apparel---Accessories/Hats?map=ft%2Cc%2Cc

It won't happen.