### PR TITLE
Feature b2b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Sets every URI scope to `private` whenever the workspace's root interface declarer has a `requiresAuthorization` setting with value `true`.
 
 ## [8.34.1] - 2019-06-03
 

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -1,4 +1,5 @@
 import { ApolloLink, NextLink, Operation } from 'apollo-link'
+import { path } from 'ramda'
 import { canUseDOM } from 'exenv'
 import {
   ASTNode,
@@ -89,6 +90,8 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
         provider,
         sender,
       } = extractHints(operation.query, cacheHints[hash])
+      const requiresAuthorization = path(['settings', `vtex.${runtime.route.domain}`, 'requiresAuthorization'], runtime)
+      const customScope = requiresAuthorization ? 'private' : scope
       const oldMethod = fetchOptions.method || 'POST'
       const protocol = canUseDOM ? 'https:' : 'http:'
       const method =
@@ -103,7 +106,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
       return {
         ...oldContext,
         fetchOptions: { ...fetchOptions, method },
-        uri: `${protocol}//${baseURI}/_v/${scope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
       }
     })
     return forward ? forward(operation) : null


### PR DESCRIPTION
This PR makes the following changes:
- Sets every URI scope to `private` whenever the workspace's root interface app has a `requiresAuthorization` setting with value `true`.