### PR TITLE
Revert automatic src to data-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Revert setting `data-src` and removing `src` for every image (but continue supporting lazysizes as opt-in).
+
 ## [8.37.0] - 2019-06-13
 ### Added
 - Sets every URI scope to `private` whenever the workspace's root interface declarer has a `requiresAuthorization` setting with value `true`.

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -185,14 +185,13 @@ function start() {
       }
 
       if (type === 'img') {
-        props['data-src'] = optimizeSrcForVtexImg(vtexImgHost, props.src)
-        delete props.src
+        props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
         props.className = props.className
           ? props.className + ' lazyload'
           : 'lazyload'
         if (
-          typeof props['data-src'] === 'string' &&
-          props['data-src'].startsWith(vtexImgHost)
+          typeof props.src === 'string' &&
+          props.src.startsWith(vtexImgHost)
         ) {
           props.crossOrigin = props.crossOrigin || 'anonymous'
         }


### PR DESCRIPTION
For example, https://shop.samsung.com/ar/ has a hanging script which makes images not load for a long time. 

Still enables lazysizes as opt-in