### PR TITLE
Fix/graphql error swallowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent graphQLErrorsStore from swallowing up errors when exception is undefined
 
 ## [8.37.2] - 2019-06-14
 

--- a/react/utils/graphQLErrorsStore.ts
+++ b/react/utils/graphQLErrorsStore.ts
@@ -30,7 +30,9 @@ class GraphQLErrorsStore {
     const operationIds = errors.reduce<string[]>((acc, error) => {
       if (
         isExtendedGraphQLError(error) &&
-        !ignoredErrorTypes.includes(error.extensions.exception.name || '')
+        !ignoredErrorTypes.includes(
+          (error.extensions.exception && error.extensions.exception.name) || ''
+        )
       ) {
         return acc.concat(error.operationId)
       }


### PR DESCRIPTION
Prevent graphQLErrorsStore from swallowing up errors when exception is undefined