### PR TITLE
Copy externals.json to react folder

### DIFF
--- a/react/externals.json
+++ b/react/externals.json
@@ -1,0 +1,150 @@
+{
+  "commons": {
+    "dev": [
+      {
+        "path": "npm:bluebird@3.5.1/js/browser/bluebird.js",
+        "serverOnly": true
+      },
+      {
+        "path": "npm:regenerator-runtime@0.11.1/runtime.js"
+      },
+      {
+        "global": "PropTypes",
+        "import": "prop-types",
+        "path": "npm:prop-types@15.6.2/prop-types.js"
+      },
+      {
+        "global": "React",
+        "import": "react",
+        "path": "npm:react@16.8.6/umd/react.development.js"
+      },
+      {
+        "global": "ReactDOM",
+        "import": "react-dom",
+        "path": "npm:react-dom@16.8.6/umd/react-dom.development.js"
+      },
+      {
+        "global": "ReactDOMServer",
+        "import": "react-dom/server",
+        "path": "npm:react-dom@16.8.6/umd/react-dom-server.browser.development.js"
+      },
+      {
+        "global": "ReactIntl",
+        "import": "react-intl",
+        "path": "npm:react-intl@2.7.2/dist/react-intl.js"
+      },
+      {
+        "global": "History",
+        "import": "history",
+        "path": "npm:history@4.7.2/umd/history.js"
+      },
+      {
+        "global": "Sentry",
+        "import": "@sentry/browser",
+        "path": "npm:@sentry/browser@4.4.1/build/bundle.js"
+      },
+      {
+        "global": "R",
+        "import": "ramda",
+        "path": "npm:ramda@0.26.1/dist/ramda.js"
+      },
+      {
+        "path": "npm:intl@1.2.5/dist/Intl.js",
+        "serverOnly": true
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:fg-loadcss@2.1.0/dist/cssrelpreload.min.js"
+      },
+      {
+        "cssRelPreload": true,
+        "path": "npm:animate.css@3.7.0/animate.css"
+      },
+      {
+        "path": "npm:vtex-tachyons@3.1.0/tachyons.css"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:vtex-render-session@1.2.1/dist/index.js"
+      }
+    ],
+    "prod": [
+      {
+        "path": "npm:bluebird@3.5.1/js/browser/bluebird.min.js",
+        "serverOnly": true
+      },
+      {
+        "path": "npm:regenerator-runtime@0.11.1/runtime.js"
+      },
+      {
+        "global": "PropTypes",
+        "import": "prop-types",
+        "path": "npm:prop-types@15.6.2/prop-types.min.js"
+      },
+      {
+        "global": "React",
+        "import": "react",
+        "path": "npm:react@16.8.6/umd/react.production.min.js"
+      },
+      {
+        "global": "ReactDOM",
+        "import": "react-dom",
+        "path": "npm:react-dom@16.8.6/umd/react-dom.production.min.js"
+      },
+      {
+        "global": "ReactDOMServer",
+        "import": "react-dom/server",
+        "path": "npm:react-dom@16.8.6/umd/react-dom-server.browser.production.min.js"
+      },
+      {
+        "global": "ReactIntl",
+        "import": "react-intl",
+        "path": "npm:react-intl@2.7.2/dist/react-intl.min.js"
+      },
+      {
+        "global": "History",
+        "import": "history",
+        "path": "npm:history@4.7.2/umd/history.min.js"
+      },
+      {
+        "global": "Sentry",
+        "import": "@sentry/browser",
+        "path": "npm:@sentry/browser@4.4.1/build/bundle.min.js"
+      },
+      {
+        "global": "R",
+        "import": "ramda",
+        "path": "npm:ramda@0.26.1/dist/ramda.min.js"
+      },
+      {
+        "path": "npm:intl@1.2.5/dist/Intl.min.js",
+        "serverOnly": true
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:fg-loadcss@2.1.0/dist/cssrelpreload.min.js"
+      },
+      {
+        "cssRelPreload": true,
+        "path": "npm:animate.css@3.7.0/animate.min.css"
+      },
+      {
+        "path": "npm:vtex-tachyons@3.1.0/tachyons.min.css"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:vtex-render-session@1.2.1/dist/index.min.js"
+      }
+    ]
+  },
+  "vtex": {},
+  "gocommerce": {}
+}

--- a/react/package.json
+++ b/react/package.json
@@ -73,6 +73,6 @@
     "react-testing-library": "^5.6.0",
     "regenerator-runtime": "^0.13.1",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.4.5"
+    "typescript": "3.5.2"
   }
 }

--- a/react/utils/client/links/versionSplitterLink.ts
+++ b/react/utils/client/links/versionSplitterLink.ts
@@ -1,6 +1,7 @@
 import {
   ApolloLink,
   createOperation,
+  FetchResult,
   GraphQLRequest,
   NextLink,
   Observable,
@@ -183,7 +184,7 @@ const observableFromOperations = (operations: Operation[], forward: NextLink) =>
         },
       })
     )
-  })
+  }) as Observable<FetchResult<{ [key: string]: any }, Record<string, any>, Record<string, any>>>
 
 export const versionSplitterLink = new ApolloLink(
   (operation: Operation, forward?: NextLink) => {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5561,10 +5561,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
This temporarily maintains `externals.json` in two folders (`public/` and `react/`) to make it compatible with Builder-hub's buildExports feature. Once https://github.com/vtex/builder-hub/pull/564 is merged, the old location can be safely deleted.