### PR TITLE
Avoid recreating React elements when block has composition children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid recreating React elements when block has composition children.
 
 ## [8.38.2] - 2019-06-21
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { mergeDeepRight, reduce } from 'ramda'
-import React, { Component, Fragment } from 'react'
+import React, { Component, Fragment, FunctionComponent } from 'react'
 import ReactDOM from 'react-dom'
 
 import { getImplementation } from '../utils/assets'
@@ -178,27 +178,13 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
         runtime.extensions && runtime.extensions[childTreePath]
       const childProps = childExtension ? childExtension.props : {}
 
-      /* This ExtensionPointWrapper thing is done so the user can read
-       * the props that were passed through the blocks.json file to
-       * its children in a standard, React-ish way; that is:
-       * `React.Children.map(children, child => child.props)`
-       *
-       * The problem was, if the user passed a prop that conflicted with
-       * ExtensionPoint props (most notabily, `id`), just destructuring
-       * the `childProps` over ExtensionPoint would override the
-       * ExtensionPoint props, which would break the rendering.
-       * (or vice versa, which would cause wrong values being read by
-       * the user component).
-       */
-      const ExtensionPointWrapper = (blockProps: object) => (
-        <ExtensionPoint
+      return (
+        <ExtensionPointWrapper
+          key={i}
           id={child.extensionPointId}
           treePath={treePath}
-          blockProps={blockProps}
-        />
+          blockProps={childProps} />
       )
-
-      return <ExtensionPointWrapper key={i} {...childProps} />
     })
   }
 
@@ -283,6 +269,33 @@ class ExtensionPoint extends Component<ExtendedProps, State> {
       element.removeAttribute('data-extension-point')
     }
   }
+}
+
+ /* This ExtensionPointWrapper thing is done so the user can read
+  * the props that were passed through the blocks.json file to
+  * its children in a standard, React-ish way; that is:
+  * `React.Children.map(children, child => child.props)`
+  *
+  * The problem was, if the user passed a prop that conflicted with
+  * ExtensionPoint props (most notabily, `id`), just destructuring
+  * the `childProps` over ExtensionPoint would override the
+  * ExtensionPoint props, which would break the rendering.
+  * (or vice versa, which would cause wrong values being read by
+  * the user component).
+  */
+const ExtensionPointWrapper: FunctionComponent<ExtensionPointWrapperProps> = ({ id, treePath, blockProps } ) => {
+  return (
+    <ExtensionPoint
+      id={id}
+      treePath={treePath}
+      blockProps={blockProps} />
+  )
+}
+
+interface ExtensionPointWrapperProps {
+  id: string
+  treePath: string
+  blockProps: object
 }
 
 export default withTreePath(ExtensionPoint)

--- a/react/utils/client/links/versionSplitterLink.ts
+++ b/react/utils/client/links/versionSplitterLink.ts
@@ -187,7 +187,7 @@ const observableFromOperations = (operations: Operation[], forward: NextLink) =>
   }) as Observable<FetchResult<{ [key: string]: any }, Record<string, any>, Record<string, any>>>
 
 export const versionSplitterLink = new ApolloLink(
-  (operation: Operation, forward?: NextLink) => {
+  (operation: Operation, forward?: NextLink) : any => {
     if (forward) {
       const query = operation.query
       const operations = operationByRuntimeMetaDirective(operation)


### PR DESCRIPTION
Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/60200112-d49b5780-981b-11e9-8765-62276c940f57.png) | ![image](https://user-images.githubusercontent.com/284515/60200003-8c7c3500-981b-11e9-8510-460f250f1333.png)

https://breno--alssports.myvtex.com/billab-crossfire-x-short/p?skuId=400192