### PR TITLE
Fix hash navigation in Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Hash navigation in Link component.
+
 ## [8.39.2] - 2019-06-27
 ### Fixed
 - Refrain from rendering Preview if its height is 0.

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -226,6 +226,13 @@ export function navigate(
     )
   }
 
+  // If the prop `to` is something like `to="#header"`
+  // just change the hash using location, avoid doing a history navigation
+  if (inputTo.indexOf('#') === 0 && inputTo.indexOf('?') === -1) {
+    window.location.hash = inputTo
+    return true
+  }
+
   const [to, extractedQuery] = (is(String, inputTo) ? inputTo : '').split('?')
   const [realQuery, hash] = (is(String, extractedQuery)
     ? extractedQuery


### PR DESCRIPTION
Fix issue if one tried to use:

```jsx
<Link to="#foo" />
```
It would redirect to the wrong page. 

Example:
https://hashbug--storecomponents.myvtex.com/shirt/p
Click in "2 Reviews"
It goes to https://hashbug--storecomponents.myvtex.com/shirt/#reviews (?)

Now it just use the `location.hash` instead of trying to find which page it's trying to go, a history navigation, etc.

Linked workspace:
https://breno--storecomponents.myvtex.com/shirt/p
Click in "2 Reviews"
It goes to https://breno--storecomponents.myvtex.com/shirt/p#reviews