### PR TITLE
Feature extensions content schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Add
+- Add hasContentSchema information to extensions
 
 ## [8.39.4] - 2019-07-01
 ### Fixed

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -79,6 +79,7 @@ declare global {
     render?: RenderStrategy
     preview?: Preview
     composition?: Composition
+    hasContentSchema?: boolean
   }
 
   interface Extensions {
@@ -482,6 +483,7 @@ declare global {
     blocks?: BlockInsertion[]
     component: string
     composition?: Composition
+    hasContentSchema: boolean
     props?: Record<string, any>
     context?: {
       component: string

--- a/react/utils/blocks.ts
+++ b/react/utils/blocks.ts
@@ -42,6 +42,7 @@ const createExtensions = (
       composition: block.composition,
       content: contentMap[blockContentId] || contentMap[contentId] || {},
       context: block.context,
+      hasContentSchema: block.hasContentSchema,
       preview: block.preview,
       props: block.props,
       render: block.render,


### PR DESCRIPTION
Pass hasContentSchema information from blocks to extensions

Should be merged after this PR: https://github.com/vtex/pages-graphql/pull/241
Workspace to test: https://jey2--storecomponents.myvtex.com

How to test:
1 - Open https://jey2--storecomponents.myvtex.com
2 - Open the dev console 
3 - See that inside each `__RUNTIME__.extensions` we have an attribute called `hasContentSchema`