### PR TITLE
Removes trailing parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Support for optional parameters in routes containing `map`
 
 ## [8.40.0] - 2019-07-01
 ### Add

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,10 +1,14 @@
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
-import { difference, is, isEmpty, keys, includes } from 'ramda'
+import { difference, includes, is, isEmpty, keys } from 'ramda'
 import RouteParser from 'route-parser'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
+
+const removeTrailingParenthesis = (path: string) => path.endsWith('(')
+  ? path.substr(0, path.length-1)
+  : path
 
 export function getComparablePrecedence(path: string): string {
   return path
@@ -354,7 +358,7 @@ function routeMatchForMappedURL(
 
   return {
     id,
-    path: newPath,
+    path: removeTrailingParenthesis(newPath)
   }
 }
 


### PR DESCRIPTION
Fixes the optional parameters support in routes containing `map`