### PR TITLE
useDevice hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `DeviceQuery` component and `useDevice` hooks, for consistent device detection both on SSR and CSR.
+- `useSSR` hook, as a hook counterpart for the `NoSSR` component.
+
+### Changed
+- Use internal `NoSSR` component logic instead of using the `react-no-ssr` package.
 
 ## [8.40.2] - 2019-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `DeviceDetector` component and `useDevice` hooks, for consistent device detection both on SSR and CSR.
-- `useSSR` hook, as a hook counterpart for the `NoSSR` component.
+- `DeviceDetector` component and `useDevice` hook, for consistent device detection on both SSR and CSR.
+- `useSSR` hook, as a counterpart for the `NoSSR` component.
 
 ### Changed
 - Use internal `NoSSR` component logic instead of using the `react-no-ssr` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `DeviceQuery` component and `useDevice` hooks, for consistent device detection both on SSR and CSR.
+- `DeviceDetector` component and `useDevice` hooks, for consistent device detection both on SSR and CSR.
 - `useSSR` hook, as a hook counterpart for the `NoSSR` component.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,13 +21,26 @@ This app handles runtime execution of React apps in the VTEX IO Platform.
 Navigation related component that, when clicked, redirects to another route. Details [here](#link-1).
 
 ### NoSSR
-This wrapper component removes its children from the subject of the Server Side Rendering(SSR). It may be useful for Components that use DOM related data _(e.g: document)_. We use [`react-no-ssr`](https://github.com/kadirahq/react-no-ssr) under the hood. You can provide an optional prop _noSSR_ with a component to render instead when in SSR mode.
+This wrapper component removes its children from the subject of the Server Side Rendering(SSR). It may be useful for Components that use DOM related data _(e.g: document)_. You can provide an optional prop _onSSR_ with a component to render instead when in SSR mode.
 
 ```javascript
 <NoSSR onSSR={<div>Loading...</div>}>
   <DomRelatedComponent/> 
 </NoSSR>
 ```
+
+In addition, you can use it as a React hook, with `useSSR`.
+
+```javascript
+const isSSR = useSSR()
+
+if (isSSR) {
+  return <div>Loading...</div>
+}
+
+return <DomRelatedComponent/>
+```
+
 
 ## Navigation
 The Render framework provides a built-in navigation solution that provides great experience and modularity for our sites. Building a store, alongside `blocks.json` and ` interfaces.json`, you can provide a `routes.json` file that describes **routes** that a user is able to access. A route looks like this:

--- a/react/components/Device.tsx
+++ b/react/components/Device.tsx
@@ -4,11 +4,11 @@ import { useSSR } from './NoSSR'
 import { useRuntime } from './RenderContext'
 
 interface DeviceInfo {
-  device: DeviceType
+  device: Device
   isMobile: boolean
 }
 
-enum DeviceType {
+enum Device {
   phone = 'phone',
   tablet = 'tablet',
   desktop = 'desktop',
@@ -27,25 +27,25 @@ const useDevice = () => {
   if (isSSR) {
     return {
       device: hints.phone
-        ? DeviceType.phone
+        ? Device.phone
         : hints.tablet
-        ? DeviceType.tablet
-        : DeviceType.desktop,
+        ? Device.tablet
+        : Device.desktop,
       isMobile: hints.mobile,
     }
   }
 
   return {
     device: isScreenLarge
-      ? DeviceType.desktop
+      ? Device.desktop
       : isScreenMedium
-      ? DeviceType.tablet
-      : DeviceType.phone,
+      ? Device.tablet
+      : Device.phone,
     isMobile: !isScreenLarge,
   }
 }
 
-const Device = ({
+const DeviceDetector = ({
   children,
 }: {
   children: (deviceInfo: DeviceInfo) => React.ReactNode
@@ -55,4 +55,4 @@ const Device = ({
   return children({ device, isMobile })
 }
 
-export { useDevice, Device }
+export { useDevice, DeviceDetector }

--- a/react/components/Device.tsx
+++ b/react/components/Device.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { useMedia } from 'use-media'
+import { useSSR } from './NoSSR'
+import { useRuntime } from './RenderContext'
+
+interface DeviceInfo {
+  device: Device
+  isMobile: boolean
+}
+
+enum Device {
+  phone = 'phone',
+  tablet = 'tablet',
+  desktop = 'desktop',
+}
+
+const useDevice = () => {
+  const isSSR = useSSR()
+  const { hints } = useRuntime()
+
+  /** These screensizes are hardcoded, based on the default
+   * Tachyons breakpoints. They should probably be the ones
+   * configured via the style.json file, if available. */
+  const isScreenMedium = useMedia({ minWidth: '40rem' })
+  const isScreenLarge = useMedia({ minWidth: '64rem' })
+
+  if (isSSR) {
+    return {
+      device: hints.phone
+        ? Device.phone
+        : hints.tablet
+        ? Device.tablet
+        : Device.desktop,
+      isMobile: hints.mobile,
+    }
+  }
+
+  return {
+    device: isScreenLarge
+      ? Device.desktop
+      : isScreenMedium
+      ? Device.tablet
+      : Device.phone,
+    isMobile: !isScreenLarge,
+  }
+}
+
+const DeviceQuery = ({
+  children,
+}: {
+  children: (deviceInfo: DeviceInfo) => React.ReactNode
+}) => {
+  const { device, isMobile } = useDevice()
+
+  return children({ device, isMobile })
+}
+
+export { useDevice, DeviceQuery }

--- a/react/components/Device.tsx
+++ b/react/components/Device.tsx
@@ -4,11 +4,11 @@ import { useSSR } from './NoSSR'
 import { useRuntime } from './RenderContext'
 
 interface DeviceInfo {
-  device: Device
+  device: DeviceType
   isMobile: boolean
 }
 
-enum Device {
+enum DeviceType {
   phone = 'phone',
   tablet = 'tablet',
   desktop = 'desktop',
@@ -27,25 +27,25 @@ const useDevice = () => {
   if (isSSR) {
     return {
       device: hints.phone
-        ? Device.phone
+        ? DeviceType.phone
         : hints.tablet
-        ? Device.tablet
-        : Device.desktop,
+        ? DeviceType.tablet
+        : DeviceType.desktop,
       isMobile: hints.mobile,
     }
   }
 
   return {
     device: isScreenLarge
-      ? Device.desktop
+      ? DeviceType.desktop
       : isScreenMedium
-      ? Device.tablet
-      : Device.phone,
+      ? DeviceType.tablet
+      : DeviceType.phone,
     isMobile: !isScreenLarge,
   }
 }
 
-const DeviceQuery = ({
+const Device = ({
   children,
 }: {
   children: (deviceInfo: DeviceInfo) => React.ReactNode
@@ -55,4 +55,4 @@ const DeviceQuery = ({
   return children({ device, isMobile })
 }
 
-export { useDevice, DeviceQuery }
+export { useDevice, Device }

--- a/react/components/NoSSR.tsx
+++ b/react/components/NoSSR.tsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect, FunctionComponent } from 'react'
+
+const useSSR = () => {
+  const [isCSRAvailable, setCSR] = useState(false)
+
+  useEffect(() => {
+    setCSR(true)
+  }, [])
+
+  return !isCSRAvailable
+}
+
+interface Props {
+  onSSR?: React.ReactNode
+}
+
+const NoSSR: FunctionComponent<Props> = ({ children, onSSR }) => {
+  const isSSR = useSSR()
+
+  return <>{isSSR ? onSSR : children}</>
+}
+
+export default NoSSR
+
+export { useSSR }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -267,13 +267,13 @@ export {
   withRuntimeContext,
   ChildBlock,
   useChildBlock,
-  // These unstable APIs should be deprecated shortly
-  ChildBlock as Unstable__ChildBlock,
-  useChildBlock as useChildBlock__unstable,
   useRuntime,
   useTreePath,
   withSession,
   Loading,
   buildCacheLocator,
   renderExtension,
+  // These unstable APIs should be deprecated shortly
+  ChildBlock as Unstable__ChildBlock,
+  useChildBlock as useChildBlock__unstable,
 }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -13,7 +13,8 @@ import React, { ReactElement } from 'react'
 import { getDataFromTree } from 'react-apollo'
 import { hydrate, render as renderDOM } from 'react-dom'
 import { Helmet } from 'react-helmet'
-import NoSSR from 'react-no-ssr'
+import NoSSR, { useSSR } from '../components/NoSSR'
+import { useDevice, DeviceQuery } from '../components/Device'
 import { isEmpty } from 'ramda'
 import Loading from '../components/Loading'
 
@@ -257,6 +258,9 @@ export {
   Helmet,
   Link,
   NoSSR,
+  useSSR,
+  DeviceQuery,
+  useDevice,
   RenderContextConsumer,
   TreePathContextConsumer,
   canUseDOM,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -14,7 +14,7 @@ import { getDataFromTree } from 'react-apollo'
 import { hydrate, render as renderDOM } from 'react-dom'
 import { Helmet } from 'react-helmet'
 import NoSSR, { useSSR } from '../components/NoSSR'
-import { useDevice, DeviceQuery } from '../components/Device'
+import { useDevice, Device } from '../components/Device'
 import { isEmpty } from 'ramda'
 import Loading from '../components/Loading'
 
@@ -47,7 +47,7 @@ import {
   optimizeStyleForVtexImg,
 } from '../utils/vteximg'
 import withHMR from '../utils/withHMR'
-import { generateExtensions } from '../utils/blocks';
+import { generateExtensions } from '../utils/blocks'
 
 let emitter: EventEmitter | null = null
 
@@ -165,13 +165,16 @@ function setLazyCookie(setCookie: string) {
 
 function start() {
   try {
-    if (window.__RUNTIME__.blocksTree && !isEmpty(window.__RUNTIME__.blocksTree)) {
+    if (
+      window.__RUNTIME__.blocksTree &&
+      !isEmpty(window.__RUNTIME__.blocksTree)
+    ) {
       window.__RUNTIME__.hasNewExtensions = true
       window.__RUNTIME__.extensions = generateExtensions(
         window.__RUNTIME__.blocksTree,
         window.__RUNTIME__.blocks!,
         window.__RUNTIME__.contentMap!,
-        window.__RUNTIME__.pages[window.__RUNTIME__.page],
+        window.__RUNTIME__.pages[window.__RUNTIME__.page]
       )
     }
 
@@ -259,7 +262,7 @@ export {
   Link,
   NoSSR,
   useSSR,
-  DeviceQuery,
+  Device,
   useDevice,
   RenderContextConsumer,
   TreePathContextConsumer,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -14,7 +14,7 @@ import { getDataFromTree } from 'react-apollo'
 import { hydrate, render as renderDOM } from 'react-dom'
 import { Helmet } from 'react-helmet'
 import NoSSR, { useSSR } from '../components/NoSSR'
-import { useDevice, Device } from '../components/Device'
+import { useDevice, DeviceDetector } from '../components/Device'
 import { isEmpty } from 'ramda'
 import Loading from '../components/Loading'
 
@@ -262,7 +262,7 @@ export {
   Link,
   NoSSR,
   useSSR,
-  Device,
+  DeviceDetector,
   useDevice,
   RenderContextConsumer,
   TreePathContextConsumer,

--- a/react/package.json
+++ b/react/package.json
@@ -71,6 +71,7 @@
     "react-dom": "^16.8.6",
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.4.0",
+    "react-no-ssr": "^1.1.0",
     "react-testing-library": "^5.6.0",
     "regenerator-runtime": "^0.13.1",
     "ts-jest": "^24.0.1",

--- a/react/package.json
+++ b/react/package.json
@@ -5,7 +5,6 @@
     "test": "vtex-test-tools test"
   },
   "dependencies": {
-    "@types/react-content-loader": "^3.1.4",
     "apollo-cache-inmemory": "^1.6.2",
     "apollo-client": "^2.6.3",
     "apollo-link-error": "^1.1.10",
@@ -30,8 +29,8 @@
     "react-content-loader": "^4.0.1",
     "react-helmet": "^5.2.0",
     "react-json-view": "^1.19.1",
-    "react-no-ssr": "^1.1.0",
-    "route-parser": "^0.0.5"
+    "route-parser": "^0.0.5",
+    "use-media": "^1.3.0"
   },
   "devDependencies": {
     "@sentry/browser": "^4.0.6",
@@ -48,7 +47,8 @@
     "@types/qs": "^6.5.1",
     "@types/query-string": "^5.1.0",
     "@types/ramda": "^0.25.47",
-    "@types/react": "^16.8.2",
+    "@types/react": "^16.8.23",
+    "@types/react-content-loader": "^3.1.4",
     "@types/react-dom": "^16.8.0",
     "@types/react-helmet": "^5.0.5",
     "@types/react-hot-loader": "^4.1.0",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -182,6 +182,7 @@ declare global {
     desktop: boolean
     mobile: boolean
     tablet: boolean
+    phone: boolean
   }
 
   interface RenderContext {
@@ -498,7 +499,7 @@ declare global {
   }
 
   interface TreeEntry {
-    blockIdMap: Record<string, BlockId>,
+    blockIdMap: Record<string, BlockId>
     contentIdMap: Record<string, string>
   }
 

--- a/react/typings/react-no-ssr.d.ts
+++ b/react/typings/react-no-ssr.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-no-ssr' {}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2475,7 +2475,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -6017,6 +6017,13 @@ react-json-view@^1.19.1:
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-no-ssr@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-no-ssr/-/react-no-ssr-1.1.0.tgz#313b48d2e26020f969ed98e472f10481604e3cc8"
+  integrity sha1-MTtI0uJgIPlp7ZjkcvEEgWBOPMg=
+  dependencies:
+    babel-runtime "6.x.x"
 
 react-side-effect@^1.1.0:
   version "1.1.5"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1412,18 +1412,14 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.15.tgz#699afb07a91adced2d6183a0ad156bf82542fc7d"
   integrity sha512-x6ypl5Uzly+j23hbxmMzf12Eb4lOhIEqQz0HuczpTUa1KIx1GpbN/o4E3aAED20UoEsdK0wvyY8QcffuWSLDkw==
 
-"@types/prop-types@*":
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+"@types/prop-types@*", "@types/prop-types@^15.7.0":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
 "@types/prop-types@^15.5.2":
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
-
-"@types/prop-types@^15.7.0":
-  version "15.7.1"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
-  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
 "@types/qs@^6.5.1":
   version "6.5.1"
@@ -1441,6 +1437,7 @@
 "@types/react-content-loader@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@types/react-content-loader/-/react-content-loader-3.1.4.tgz#ceb75c2b20b6e697e249c063ddc2b4f9ad32bb5e"
+  integrity sha512-CJhW+3D5xTpMqTEM/coWOHhJ3sXBWqZUuWGUNhHNgMJYYqqmC+LuqPpJMETmuMnZoIWScReeXjppyPjQMUnkuQ==
   dependencies:
     "@types/react" "*"
 
@@ -1476,9 +1473,10 @@
   version "16.0.40"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.40.tgz#caabc2296886f40b67f6fc80f0f3464476461df9"
 
-"@types/react@^16.8.2":
-  version "16.8.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
+"@types/react@^16.8.23":
+  version "16.8.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
+  integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2477,7 +2475,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2923,8 +2921,9 @@ cssstyle@^1.0.0:
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.5"
@@ -6019,12 +6018,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-no-ssr@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-no-ssr/-/react-no-ssr-1.1.0.tgz#313b48d2e26020f969ed98e472f10481604e3cc8"
-  dependencies:
-    babel-runtime "6.x.x"
-
 react-side-effect@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
@@ -7025,6 +7018,11 @@ uri-js@^4.2.2:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use-media@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.3.0.tgz#be26102fd954c78895b4934744f977d2b23ecfbb"
+  integrity sha512-1JuB/QVAxCXsIsexSMTMZ34egbroSEjmvOVFbvGqLACruJcaH4wZjnUqqwQh/iVtbWi73LDCbfYJDsdyDfJe+g==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Creates a `useDevice` hook (along with a `<DeviceDetector>` component) for consistent device detection across both SSR and CSR.

Example of usage can be seen here: https://github.com/vtex-apps/store-header/pull/98/commits/fed84f93e78efc812aedf8ec49b3ef12f198d742

Also adds a `useSSR` hook for SSR detection.

Also uses internal code for the SSR detection, removing the `react-no-ssr` package. 