### PR TITLE
Get block title when mounting extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Pass `block.title` to extensions.
+
 ## [8.40.2] - 2019-07-05
 
 ## [8.40.1] - 2019-07-02

--- a/react/utils/blocks.ts
+++ b/react/utils/blocks.ts
@@ -46,6 +46,7 @@ const createExtensions = (
       preview: block.preview,
       props: block.props,
       render: block.render,
+      title: block.title,
       track: block.track,
     }
   }]
@@ -83,6 +84,6 @@ export const generateExtensions = (
   routeResult.forEach(eachResult => {
     extensions[eachResult.treePath] = eachResult.extension
   })
-  
+
   return extensions
 }


### PR DESCRIPTION
Pass `block.title` to `generateExtension` function result.

[ch14958]