### PR TITLE
Refrain from rendering empty extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ExtensionPoint` render is interrupted earlier if no extension is found, and refrains from rendering `ExtensionPointComponent` if so.
 
 ### Fixed
-- `Loading` gets its block props from context again.
+- `Loading` gets its block props from context again, thus fixing issue where it wouldn't appear if inserted on a component.
 
 ## [8.42.7] - 2019-07-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `ExtensionPoint` render is interrupted earlier if no extension is found, and refrains from rendering `ExtensionPointComponent` if so.
+
+### Fixed
+- `Loading` gets its block props from context again.
 
 ## [8.42.7] - 2019-07-26
 ### Changed

--- a/react/components/ChildBlock.tsx
+++ b/react/components/ChildBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useExtension } from '../utils/extension'
+import { useExtension } from '../hooks/extension'
 
 export function useChildBlock(childBlock: ChildBlock): Block | null {
   if (typeof childBlock === 'string') {

--- a/react/components/ChildBlock.tsx
+++ b/react/components/ChildBlock.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { useTreePath } from '../utils/treePath'
-import { useRuntime } from './RenderContext'
+import { useExtension } from '../utils/extension'
 
 export function useChildBlock(childBlock: ChildBlock): Block | null {
   if (typeof childBlock === 'string') {
@@ -15,16 +14,12 @@ export function useChildBlock(childBlock: ChildBlock): Block | null {
     throw new Error('The id you are sending to useChildBlock is empty')
   }
 
-  const runtime = useRuntime()
-  const { treePath } = useTreePath()
-
-  const childPath = mountTreePath(id, treePath)
-  const block = runtime.extensions && runtime.extensions[childPath]
+  const extension = useExtension({ children: id })
 
   // We are explicitly not exposing the private API here
-  return block
+  return extension
     ? {
-        props: block.props,
+        props: extension.props,
       }
     : null
 }
@@ -45,8 +40,4 @@ interface Block {}
 
 interface ChildBlockProps extends ChildBlock {
   children(block: Block | null): React.ReactNode
-}
-
-function mountTreePath(currentId: string, parentTreePath: string) {
-  return [parentTreePath, currentId].filter(id => !!id).join('/')
 }

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -6,7 +6,6 @@ import Loading from './Loading'
 import { useRuntime } from './RenderContext'
 import { useTreePath } from '../utils/treePath'
 import { useSSR } from './NoSSR'
-// import TrackEventsWrapper from './TrackEventsWrapper'
 
 interface Props {
   id: string
@@ -122,7 +121,6 @@ const ExtensionPoint: FC<Props> = props => {
     content = {},
     render: renderStrategy = null,
     props: extensionProps = {},
-    // track = [],
   } = extension || {}
 
   const mergedProps = React.useMemo(() => {

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -145,10 +145,10 @@ const ExtensionPoint: FC<Props> = props => {
 
   if (
     /* Prevents a client-only block from being inserted into the wrong element */
-    renderStrategy === 'client' && isSSR
+    (renderStrategy === 'client' && isSSR) ||
     /* Stops rendering if the extension is not found. Useful for optional ExtensionPoints */
-    || !extension
-   ) {
+    !extension
+  ) {
     return null
   }
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -143,8 +143,12 @@ const ExtensionPoint: FC<Props> = props => {
 
   const isSSR = useSSR()
 
-  /* Prevents a client-only block from being inserted into the wrong element */
-  if (renderStrategy === 'client' && isSSR) {
+  if (
+    /* Prevents a client-only block from being inserted into the wrong element */
+    renderStrategy === 'client' && isSSR
+    /* Stops rendering if the extension is not found. Useful for optional ExtensionPoints */
+    || !extension
+   ) {
     return null
   }
 
@@ -162,18 +166,14 @@ const ExtensionPoint: FC<Props> = props => {
     before,
     newTreePath,
     mergedProps,
-    component ? (
-      <ExtensionPointComponent
-        component={component}
-        props={mergedProps}
-        runtime={runtime}
-        treePath={newTreePath}
-      >
-        {componentChildren}
-      </ExtensionPointComponent>
-    ) : (
-      <Loading extension={extension} />
-    )
+    <ExtensionPointComponent
+      component={component}
+      props={mergedProps}
+      runtime={runtime}
+      treePath={newTreePath}
+    >
+      {component ? componentChildren : <Loading />}
+    </ExtensionPointComponent>
   )
 
   return extensionPointComponent

--- a/react/components/Loading.tsx
+++ b/react/components/Loading.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 
 import Preview from './Preview'
 
-const Loading = ({ extension }: { extension?: Extension }) => {
+import { useExtension } from '../utils/extension'
+
+const Loading = () => {
+  const extension = useExtension()
+
   if (!extension) {
     return null
   }

--- a/react/components/Loading.tsx
+++ b/react/components/Loading.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Preview from './Preview'
 
-import { useExtension } from '../utils/extension'
+import { useExtension } from '../hooks/extension'
 
 const Loading = () => {
   const extension = useExtension()

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -40,6 +40,7 @@ import { addLocaleData } from '../utils/locales'
 import registerComponent from '../utils/registerComponent'
 import { withSession } from '../utils/session'
 import { TreePathContext, useTreePath } from '../utils/treePath'
+import { useExtension, ExtensionConsumer } from '../utils/extension'
 import {
   isStyleWritable,
   optimizeSrcForVtexImg,
@@ -275,6 +276,8 @@ export {
   useChildBlock,
   useRuntime,
   useTreePath,
+  useExtension,
+  ExtensionConsumer,
   withSession,
   Loading,
   buildCacheLocator,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -40,7 +40,6 @@ import { addLocaleData } from '../utils/locales'
 import registerComponent from '../utils/registerComponent'
 import { withSession } from '../utils/session'
 import { TreePathContext, useTreePath } from '../utils/treePath'
-import { useExtension, ExtensionConsumer } from '../utils/extension'
 import {
   isStyleWritable,
   optimizeSrcForVtexImg,
@@ -276,8 +275,6 @@ export {
   useChildBlock,
   useRuntime,
   useTreePath,
-  useExtension,
-  ExtensionConsumer,
   withSession,
   Loading,
   buildCacheLocator,

--- a/react/hooks/extension.tsx
+++ b/react/hooks/extension.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react'
 
 import { useRuntime } from '../components/RenderContext'
-import { useTreePath } from './treePath'
+import { useTreePath } from '../utils/treePath'
 
 function mountTreePath(base: string, children: string[]) {
   return [base, ...children].filter(id => !!id).join('/')

--- a/react/hooks/extension.tsx
+++ b/react/hooks/extension.tsx
@@ -12,8 +12,7 @@ interface Options {
 }
 
 const useExtension = ({ children }: Options = {}): Extension | null => {
-  const runtime = useRuntime()
-  const { extensions } = runtime
+  const { extensions } = useRuntime()
 
   const { treePath: baseTreePath } = useTreePath()
 

--- a/react/utils/extension.tsx
+++ b/react/utils/extension.tsx
@@ -3,11 +3,26 @@ import { ReactElement } from 'react'
 import { useRuntime } from '../components/RenderContext'
 import { useTreePath } from './treePath'
 
-const useExtension = () => {
+function mountTreePath(base: string, children: string[]) {
+  return [base, ...children].filter(id => !!id).join('/')
+}
+
+interface Options {
+  children?: string[] | string
+}
+
+const useExtension = ({ children }: Options = {}): Extension | null => {
   const runtime = useRuntime()
   const { extensions } = runtime
 
-  const { treePath } = useTreePath()
+  const { treePath: baseTreePath } = useTreePath()
+
+  const treePath = children
+    ? mountTreePath(
+        baseTreePath,
+        Array.isArray(children) ? children : [children]
+      )
+    : baseTreePath
 
   const extension = treePath && extensions[treePath]
 

--- a/react/utils/extension.tsx
+++ b/react/utils/extension.tsx
@@ -1,10 +1,13 @@
 import { ReactElement } from 'react'
 
 import { useRuntime } from '../components/RenderContext'
+import { useTreePath } from './treePath'
 
-const useExtension = (treePath: string) => {
+const useExtension = () => {
   const runtime = useRuntime()
   const { extensions } = runtime
+
+  const { treePath } = useTreePath()
 
   const extension = treePath && extensions[treePath]
 
@@ -17,11 +20,10 @@ interface ExtensionContext {
 
 interface Props {
   children({ extension }: ExtensionContext): ReactElement<any> | null
-  treePath: string
 }
 
-const ExtensionConsumer = ({ children, treePath }: Props) => {
-  const extension = useExtension(treePath)
+const ExtensionConsumer = ({ children }: Props) => {
+  const extension = useExtension()
 
   return children({ extension })
 }


### PR DESCRIPTION
`ExtensionPoint` render is interrupted earlier if no extension is found, and refrains from rendering `ExtensionPointComponent` if so.

Also fixes an issue on the Loading component which wouldn't render properly if inserted by an app.

https://lbebber--alssports.myvtex.com/