### PR TITLE
Fix/templates map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Revert behaviour introduced in 8.36.1 regarding templates from `maps`. It now gets the template from the first parameter of the `map` query string.
 
 ## [8.42.3] - 2019-07-15
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -1,7 +1,7 @@
 import { canUseDOM } from 'exenv'
 import { History, LocationDescriptorObject } from 'history'
 import queryString from 'query-string'
-import { difference, includes, is, isEmpty, keys } from 'ramda'
+import { difference, is, isEmpty, keys, startsWith } from 'ramda'
 import RouteParser from 'route-parser'
 
 const EMPTY_OBJECT = (Object.freeze && Object.freeze({})) || {}
@@ -332,11 +332,7 @@ function routeMatchForMappedURL(
 
   for (const name in routes) {
     const { map = [], path: routePath } = routes[name]
-    if (
-      !routePath ||
-      map.length === 0 ||
-      !includes(map.join(','), mappedSegments.join(','))
-    ) {
+    if (!routePath || map.length === 0 || !startsWith(map, mappedSegments)) {
       continue
     }
 


### PR DESCRIPTION
Reverts behaviour introduced in 8.36.1 regarding templates from `maps`. It now gets the template from the first parameter of the `map` query string

Test in https://lbebber--btpt.myvtex.com/make-b, and click on "CABELO" on the left filter bar. Notice that the banner stays the same ("make B"). Compare with https://btpt.myvtex.com/make-b, where doing the same changes the banner to a department one.