### PR TITLE
Change href for links inside admin iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Omit `/app/` in href for links inside iframe.
 
 ## [8.42.6] - 2019-07-25
 ### Fixed

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -76,7 +76,7 @@ const Link: React.FunctionComponent<Props> = ({
 
   const href = getHref()
   // Href inside admin iframe should omit the `/app/` path
-  const hrefWithoutIframePrefix = domain === 'admin' && href.startsWith('/admin/app/') ? href.replace('/admin/app/', '/admin/') : href
+  const hrefWithoutIframePrefix = domain && domain === 'admin' && href.startsWith('/admin/app/') ? href.replace('/admin/app/', '/admin/') : href
 
   return (
     <a href={hrefWithoutIframePrefix} {...linkProps} onClick={handleClick}>

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -26,7 +26,7 @@ const Link: React.FunctionComponent<Props> = ({
   children,
   ...linkProps
 }) => {
-  const { pages, navigate, rootPath = '' } = useRuntime()
+  const { pages, navigate, rootPath = '', route: { domain } } = useRuntime()
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>) => {
@@ -74,8 +74,12 @@ const Link: React.FunctionComponent<Props> = ({
     return '#'
   }
 
+  const href = getHref()
+  // Href inside admin iframe should omit the `/app/` path
+  const hrefWithoutAppForAdmin = domain === 'admin' && href.startsWith('/admin/app/') ? href.replace('/admin/app/', '/admin/') : href
+
   return (
-    <a href={getHref()} {...linkProps} onClick={handleClick}>
+    <a href={hrefWithoutAppForAdmin} {...linkProps} onClick={handleClick}>
       {children}
     </a>
   )

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -76,10 +76,10 @@ const Link: React.FunctionComponent<Props> = ({
 
   const href = getHref()
   // Href inside admin iframe should omit the `/app/` path
-  const hrefWithoutAppForAdmin = domain === 'admin' && href.startsWith('/admin/app/') ? href.replace('/admin/app/', '/admin/') : href
+  const hrefWithoutIframePrefix = domain === 'admin' && href.startsWith('/admin/app/') ? href.replace('/admin/app/', '/admin/') : href
 
   return (
-    <a href={hrefWithoutAppForAdmin} {...linkProps} onClick={handleClick}>
+    <a href={hrefWithoutIframePrefix} {...linkProps} onClick={handleClick}>
       {children}
     </a>
   )


### PR DESCRIPTION
In admin builder, all internal links must be `/admin/app/*anything` to proper appear inside of the iframe.
But due to this, if user access the link directly, like when you open in a new tap, he will open the `/admin/app/` url, and will se the admin without the sidebar.

![Screen Shot 2019-07-24 at 15 07 43](https://user-images.githubusercontent.com/3163867/61821134-f1cc4180-ae2c-11e9-93fe-84ed9474eca9.png)
![Screen Shot 2019-07-24 at 15 08 08](https://user-images.githubusercontent.com/3163867/61821135-f1cc4180-ae2c-11e9-8e93-3e0666b4e7f1.png)

With this change, the href show properly, so now user can open in a new tap without worry:

![Screen Shot 2019-07-24 at 15 09 52](https://user-images.githubusercontent.com/3163867/61821262-1c1dff00-ae2d-11e9-8bc9-c6b224346df2.png)

**How this works**
The `href` attribute is just a fallback for the browser, when the user click in a link, he will call the function on `onClick`, and this one will still use the correct `/admin/app/` pattern.