### PR TITLE
Feature separate admin lang from store lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Separate admin language from store language
 
 ## [8.42.8] - 2019-07-29
 ### Changed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -694,21 +694,28 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     return assetsPromise
   }
 
-  public onLocaleSelected = (locale: string) => {
+  public onLocaleSelected = (locale: string, domain?: string) => {
     if (locale !== this.state.culture.locale) {
-      const sessionData = {
-        public: {
-          cultureInfo: {
-            value: locale,
+      const sessionData = { public: { } }
+      if(domain && domain === 'admin'){
+        sessionData.public = {
+            admin_cultureInfo: {
+              value: locale,
           },
-        },
+        }
+      } else {
+        sessionData.public = {
+            cultureInfo: {
+              value: locale,
+            },
+        }
       }
       Promise.all([this.patchSession(sessionData)])
         .then(() => window.location.reload())
         .catch(e => {
           console.log('Failed to fetch new locale file.')
           console.error(e)
-        })
+      })
     }
   }
 

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -80,7 +80,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
         runtime: { appsEtag, cacheHints },
       } = oldContext
       const { extensions } = operation
-      const { workspace } = runtime
+      const { workspace, route: { domain } } = runtime
       const hash = generateHash(operation.query)
       const {
         maxAge,
@@ -91,7 +91,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
         sender,
       } = extractHints(operation.query, cacheHints[hash])
       const requiresAuthorization = path(
-        ['settings', `vtex.${runtime.route.domain}`, 'requiresAuthorization'],
+        ['settings', `vtex.${domain}`, 'requiresAuthorization'],
         runtime
       )
       const customScope = requiresAuthorization ? 'private' : scope
@@ -109,7 +109,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
       return {
         ...oldContext,
         fetchOptions: { ...fetchOptions, method },
-        uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}`,
+        uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}&session_path=/${domain}&session_host=${baseURI}`,
       }
     })
     return forward ? forward(operation) : null

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -109,7 +109,7 @@ export const createUriSwitchLink = (baseURI: string, runtime: RenderRuntime) =>
       return {
         ...oldContext,
         fetchOptions: { ...fetchOptions, method },
-        uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}&session_path=/${domain}&session_host=${baseURI}`,
+        uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}&domain=${domain}`,
       }
     })
     return forward ? forward(operation) : null

--- a/react/utils/dom.tsx
+++ b/react/utils/dom.tsx
@@ -83,7 +83,8 @@ export const isSiteEditorIframe =
   canUseDOM &&
   window.top !== window.self &&
   window.top.__provideRuntime &&
-  !!window.top.__provideRuntime
+  !!window.top.__provideRuntime &&
+  window.__RUNTIME__.route.domain === 'store'
 
 export const getContainer = () => {
   return canUseDOM


### PR DESCRIPTION
It will change admin's language without changing store's language.
It should only be merged after this one: https://github.com/vtex/node-vtex-api/pull/190

Test: https://jey--storecomponents.myvtex.com/admin/cms/storefront
1 - Select an admin language.
2 - At storefront's topbar, select a different language for the store.
3 - Store language now should be different from admin's language.