### PR TITLE
Fix/client rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issue where client-only blocks would render under the wrong parent element.
 
 ## [8.42.5] - 2019-07-24
 ### Added

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -5,6 +5,7 @@ import ExtensionPointComponent from './ExtensionPointComponent'
 import Loading from './Loading'
 import { useRuntime } from './RenderContext'
 import { useTreePath } from '../utils/treePath'
+import { useSSR } from './NoSSR'
 // import TrackEventsWrapper from './TrackEventsWrapper'
 
 interface Props {
@@ -119,6 +120,7 @@ const ExtensionPoint: FC<Props> = props => {
     around = [],
     before = [],
     content = {},
+    render: renderStrategy = null,
     props: extensionProps = {},
     // track = [],
   } = extension || {}
@@ -140,6 +142,13 @@ const ExtensionPoint: FC<Props> = props => {
       { params, query },
     ])
   }, [parentProps, extensionProps, blockProps, content, params, query])
+
+  const isSSR = useSSR()
+
+  /* Prevents a client-only block from being inserted into the wrong element */
+  if (renderStrategy === 'client' && isSSR) {
+    return null
+  }
 
   const isCompositionChildren =
     extension && extension.composition === 'children'


### PR DESCRIPTION
Fix issue where client-only blocks would render under the wrong parent element.

Before: 
![image](https://user-images.githubusercontent.com/5691711/61905262-155fbc80-aeff-11e9-9e28-4a81f1b38b93.png)

(Notice that the stars are aligned to the left; this is caused due to them being inserted into the wrong div)

After:
![image](https://user-images.githubusercontent.com/5691711/61905327-33c5b800-aeff-11e9-9255-6d249c0ca311.png)

https://lbebber--alssports.myvtex.com/