### PR TITLE
Use IntrospectionFragmentMatcher instead of HeuristFragmentMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support for GraphQL `Unions` and `Interfaces`in ApolloClient's cache. This is done by using `IntrospectionFragmentMatcher` instead of `HeuristicFragmentMatcher` (https://www.apollographql.com/docs/react/advanced/fragments/).
+
 ## [8.43.0] - 2019-07-30
 ### Added
 - Separate admin language from store language

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -9,6 +9,7 @@ import { History, Location } from 'history'
 import { HelmetData } from 'react-helmet'
 import { TreePathProps } from '../utils/treePath'
 import { LayoutContainer } from '../core/main'
+import { IntrospectionResultData } from 'apollo-cache-inmemory'
 
 declare global {
   interface RenderMetric {
@@ -260,7 +261,7 @@ declare global {
   interface RenderComponent<P = {}, S = {}> {
     getCustomMessages?: (locale: string) => any
     WrappedComponent?: RenderComponent
-    new (): Component<P, S>
+    new(): Component<P, S>
   }
 
   interface ComponentsRegistry {
@@ -377,7 +378,7 @@ declare global {
     workspace: string
     disableSSR: boolean
     hints: any
-    introspectionResult: IntrospectionResult
+    introspectionResult: IntrospectionResultData
     page: string
     route: Route
     version: string
@@ -405,18 +406,6 @@ declare global {
     rootPath?: string
     workspaceCookie: string
     hasNewExtensions: boolean
-  }
-
-  interface IntrospectionResult {
-    __schema: {
-      types: Array<{
-        kind: string
-        name: string
-        possibleTypes: Array<{
-          name: string
-        }>
-      }>
-    }
   }
 
   interface CacheHints {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -377,6 +377,7 @@ declare global {
     workspace: string
     disableSSR: boolean
     hints: any
+    introspectionResult: IntrospectionResult
     page: string
     route: Route
     version: string
@@ -404,6 +405,18 @@ declare global {
     rootPath?: string
     workspaceCookie: string
     hasNewExtensions: boolean
+  }
+
+  interface IntrospectionResult {
+    __schema: {
+      types: Array<{
+        kind: string
+        name: string
+        possibleTypes: Array<{
+          name: string
+        }>
+      }>
+    }
   }
 
   interface CacheHints {

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -1,5 +1,7 @@
 import {
   HeuristicFragmentMatcher,
+  IntrospectionFragmentMatcher,
+  IntrospectionResultData,
   InMemoryCache,
   NormalizedCacheObject,
 } from 'apollo-cache-inmemory'
@@ -61,6 +63,8 @@ export const getState = (runtime: RenderRuntime) => {
   return apolloClient ? apolloClient.cache.extract() : {}
 }
 
+type FragmentMatcher = IntrospectionFragmentMatcher | HeuristicFragmentMatcher
+
 export const getClient = (
   runtime: RenderRuntime,
   baseURI: string,
@@ -68,13 +72,31 @@ export const getClient = (
   ensureSessionLink: ApolloLink,
   cacheControl?: PageCacheControl
 ) => {
-  const { account, workspace } = runtime
+  const {
+    account,
+    workspace,
+    introspectionResult,
+  }: {
+    account: string
+    workspace: string
+    introspectionResult: IntrospectionResultData
+  } = runtime
+
+  console.log(introspectionResult)
+  let fragmentMatcher: FragmentMatcher
+  if (introspectionResult) {
+    fragmentMatcher = new IntrospectionFragmentMatcher({
+      introspectionQueryResultData: introspectionResult,
+    })
+  } else {
+    fragmentMatcher = new HeuristicFragmentMatcher()
+  }
 
   if (!clientsByWorkspace[`${account}/${workspace}`]) {
     const cache = new InMemoryCache({
       addTypename: true,
       dataIdFromObject,
-      fragmentMatcher: new HeuristicFragmentMatcher(),
+      fragmentMatcher: fragmentMatcher,
     })
 
     const httpLink = ApolloLink.from([

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -82,7 +82,6 @@ export const getClient = (
     introspectionResult: IntrospectionResultData
   } = runtime
 
-  console.log(introspectionResult)
   let fragmentMatcher: FragmentMatcher
   if (introspectionResult) {
     fragmentMatcher = new IntrospectionFragmentMatcher({

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -1,5 +1,4 @@
 import {
-  HeuristicFragmentMatcher,
   IntrospectionFragmentMatcher,
   IntrospectionResultData,
   InMemoryCache,
@@ -63,8 +62,6 @@ export const getState = (runtime: RenderRuntime) => {
   return apolloClient ? apolloClient.cache.extract() : {}
 }
 
-type FragmentMatcher = IntrospectionFragmentMatcher | HeuristicFragmentMatcher
-
 export const getClient = (
   runtime: RenderRuntime,
   baseURI: string,
@@ -82,20 +79,13 @@ export const getClient = (
     introspectionResult: IntrospectionResultData
   } = runtime
 
-  let fragmentMatcher: FragmentMatcher
-  if (introspectionResult) {
-    fragmentMatcher = new IntrospectionFragmentMatcher({
-      introspectionQueryResultData: introspectionResult,
-    })
-  } else {
-    fragmentMatcher = new HeuristicFragmentMatcher()
-  }
-
   if (!clientsByWorkspace[`${account}/${workspace}`]) {
     const cache = new InMemoryCache({
       addTypename: true,
       dataIdFromObject,
-      fragmentMatcher: fragmentMatcher,
+      fragmentMatcher: new IntrospectionFragmentMatcher({
+        introspectionQueryResultData: introspectionResult,
+      }),
     })
 
     const httpLink = ApolloLink.from([


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use IntrospectionFragmentMatcher in `ApolloClient`'s cache so `Unions` and `Interfaces` can be used in graphql 🎉

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
