### PR TITLE
Enhanced `NoSSR` detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Enhanced `NoSSR` detection.
 
 ## [8.44.0] - 2019-07-31
 

--- a/react/components/NoSSR.tsx
+++ b/react/components/NoSSR.tsx
@@ -1,9 +1,14 @@
-import React, { useState, useEffect, FunctionComponent } from 'react'
+import React, { useState, useEffect, useLayoutEffect, FunctionComponent } from 'react'
+
+const useEnhancedEffect =
+  typeof window !== 'undefined'
+    ? useLayoutEffect
+    : useEffect
 
 const useSSR = () => {
   const [isCSRAvailable, setCSR] = useState(false)
 
-  useEffect(() => {
+  useEnhancedEffect(() => {
     setCSR(true)
   }, [])
 


### PR DESCRIPTION
In some cases, the `useEffect` was taking too long to finish.
One example is in GoCommerce admin navigation, the delay was of around 10s to show the page after load finish.

With this change, the delay was decreased to 1s.

Code inspiration from: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/NoSsr/NoSsr.js#L5