### PR TITLE
Fix/error boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added error boundaries on the ExtensionPoint component, limiting crashes to the component instead of breaking most of the page.
+- Hide errors on production mode.
 
 ## [8.44.1] - 2019-08-02
 ### Fixed

--- a/react/components/ErrorBoundary.tsx
+++ b/react/components/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import ExtensionPointError from './ExtensionPointError'
 import { useRuntime } from './RenderContext'
 
 interface Props {
-  runtime: any
+  runtime: RenderContext
 }
 
 class ErrorBoundary extends React.Component<Props> {

--- a/react/components/ErrorBoundary.tsx
+++ b/react/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import React, { ErrorInfo, FunctionComponent } from 'react'
+import ExtensionPointError from './ExtensionPointError'
+import { useRuntime } from './RenderContext'
+
+interface Props {
+  runtime: any
+}
+
+class ErrorBoundary extends React.Component<Props> {
+  state = {
+    error: undefined,
+    errorInfo: undefined,
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({
+      error,
+      errorInfo,
+    })
+  }
+
+  render() {
+    const {
+      production
+    } = this.props.runtime
+
+    const { error, errorInfo } = this.state
+    if (error) {
+      if (!production) {
+        return (
+          <ExtensionPointError
+            error={error}
+            errorInfo={errorInfo}
+          />
+        )
+      }
+      return null
+    }
+
+    return this.props.children
+  }
+}
+
+const ErrorBoundaryWithContext:FunctionComponent = ({children}) => {
+  const runtime = useRuntime()
+
+  return (
+    <ErrorBoundary runtime={runtime}>
+      {children}
+    </ErrorBoundary>
+  )
+}
+
+export default ErrorBoundaryWithContext
+
+export const withErrorBoundary = <P extends object>(
+  Component: React.ComponentType<P>
+) => (props: P) => (
+  <ErrorBoundaryWithContext>
+    <Component {...props} />
+  </ErrorBoundaryWithContext>
+)

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -6,6 +6,7 @@ import Loading from './Loading'
 import { useRuntime } from './RenderContext'
 import { useTreePath } from '../utils/treePath'
 import { useSSR } from './NoSSR'
+import { withErrorBoundary } from './ErrorBoundary'
 
 interface Props {
   id: string
@@ -184,4 +185,4 @@ ExtensionPoint.defaultProps = {
   treePath: '',
 }
 
-export default ExtensionPoint
+export default withErrorBoundary(ExtensionPoint)

--- a/react/components/ExtensionPointComponent.tsx
+++ b/react/components/ExtensionPointComponent.tsx
@@ -196,7 +196,7 @@ class ExtensionPointComponent extends PureComponent<
     // A children of this extension point throwed an uncaught error
     // Only show errors in production if the entire page explodes. (Ignore nested extension points)
     if (error) {
-      if (production && !pages[treePath] && !page.startsWith('admin/')) {
+      if (production && !page.startsWith('admin/')) {
         return null
       }
 

--- a/react/components/ExtensionPointError.tsx
+++ b/react/components/ExtensionPointError.tsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types'
 import React, { ErrorInfo, PureComponent } from 'react'
 
 interface Props {
-  treePath: string
+  treePath?: string
   error?: Error
   errorInfo?: ErrorInfo | null
-  operationIds: string[]
+  operationIds?: string[]
 }
 
 interface State {
@@ -51,7 +51,7 @@ class ExtensionPointError extends PureComponent<Props, State> {
         {errorDetails && error && (
           <>
             <ul className="f6 list pl0">
-              {operationIds.map(operationId => (
+              {operationIds && operationIds.map(operationId => (
                 <li key={operationId}>
                   <span>Operation ID:</span>{' '}
                   <span className="i">{operationId}</span>


### PR DESCRIPTION
Adds error boundaries on the ExtensionPoint component, limiting crashes to the component instead of breaking most of the page.
Also hides errors on production mode.

Before (simulating a crash on the Shelf component): https://lbebber--storecomponents.myvtex.com/?__disableSSR
After: https://lbebber2--storecomponents.myvtex.com/?__disableSSR