### PR TITLE
Fix/error boundary tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add displayName to ErrorBoundary HOC.
 
 ## [8.45.0] - 2019-08-05
 ### Changed

--- a/react/components/ErrorBoundary.tsx
+++ b/react/components/ErrorBoundary.tsx
@@ -55,8 +55,22 @@ export default ErrorBoundaryWithContext
 
 export const withErrorBoundary = <P extends object>(
   Component: React.ComponentType<P>
-) => (props: P) => (
-  <ErrorBoundaryWithContext>
-    <Component {...props} />
-  </ErrorBoundaryWithContext>
-)
+) => {
+  const WithErrorBoundary = (props: P) => {
+    const runtime = useRuntime()
+
+    return (
+      <ErrorBoundary runtime={runtime}>
+        <Component {...props} />
+      </ErrorBoundary>
+    )
+  }
+
+  const displayName = Component.displayName || Component.name
+
+  if (displayName) {
+    WithErrorBoundary.displayName = `withErrorBoundary(${displayName})`
+  }
+
+  return WithErrorBoundary
+}


### PR DESCRIPTION
Adds displayName for ErrorBoundary HOC.

Also makes the ErrorBoundary tree a little shallower.

Before:
<img width="430" alt="Screen Shot 2019-08-05 at 16 44 08" src="https://user-images.githubusercontent.com/5691711/62490914-f2f05d80-b7a0-11e9-8c52-ac969dcbf372.png">

After:
<img width="430" alt="Screen Shot 2019-08-05 at 16 46 58" src="https://user-images.githubusercontent.com/5691711/62490935-000d4c80-b7a1-11e9-880b-172e00aa69c6.png">

Test on https://lbebber--storecomponents.myvtex.com/?__disableSSR