### PR TITLE
Prevent overwriting older extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Prevent extensions overwriting after an `updateRuntime`
+
 ## [8.45.1] - 2019-08-05
 ### Fixed
 - Add displayName to ErrorBoundary HOC.

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -758,17 +758,20 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     await new Promise<void>(resolve => {
       this.setState(
-        {
+        (state) => ({
           appsEtag,
           cacheHints,
           components,
-          extensions,
+          extensions: {
+            ...state.extensions,
+            ...extensions,
+          },
           messages,
           page,
           pages,
           route,
           settings,
-        },
+        }),
         resolve
       )
     })


### PR DESCRIPTION
We have a very common scenario in GC where the admin crashes after a runtime update. One example is when removing an app. After the success we trigger  an `updateRuntime` effect, but we also need to redirect the user back to the app store. The admin crashes because the update removed the desired route from the extensions object.

To revoke an app: https://github.com/vtex/admin-apps/blob/master/react/withAppSetup.js#L121
It breaks here: https://github.com/vtex-apps/render-runtime/blob/master/react/components/MaybeContext.tsx#L19

<img width="647" alt="Screen Shot 2019-08-06 at 11 17 42" src="https://user-images.githubusercontent.com/7659279/62551091-bf194480-b841-11e9-81e9-3f012df1263d.png">
