### PR TITLE
Revert #370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Temporarily reverted changes made in #370 (8.46.0) because of problems rendering pages in IE11.
 
 ## [8.48.2] - 2019-08-19
 ### Fixed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -105,7 +105,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public static childContextTypes = {
     account: PropTypes.string,
     addMessages: PropTypes.func,
-    amp: PropTypes.bool,
     blocks: PropTypes.object,
     blocksTree: PropTypes.object,
     contentMap: PropTypes.object,
@@ -250,7 +249,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       production,
       query,
       route,
-      settings: settings || {},
+      settings,
     }
   }
 
@@ -310,7 +309,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     } = this.state
     const {
       account,
-      amp,
       emitter,
       hints,
       production,
@@ -323,7 +321,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     return {
       account,
       addMessages: this.addMessages,
-      amp,
       components,
       culture,
       defaultExtensions,
@@ -412,10 +409,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       scrollOptions = false,
     }: SetQueryOptions = {}
   ): boolean => {
-    const {
-      history,
-      runtime: { rootPath },
-    } = this.props
+    const { history, runtime: { rootPath } } = this.props
     const {
       pages,
       page,
@@ -441,10 +435,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   }
 
   public navigate = (options: NavigateOptions) => {
-    const {
-      history,
-      runtime: { rootPath },
-    } = this.props
+    const { history, runtime: { rootPath } } = this.props
     const { pages } = this.state
     options.rootPath = rootPath
     return pageNavigate(history, pages, options)
@@ -711,18 +702,18 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public onLocaleSelected = (locale: string, domain?: string) => {
     if (locale !== this.state.culture.locale) {
-      const sessionData = { public: {} }
-      if (domain && domain === 'admin') {
+      const sessionData = { public: { } }
+      if(domain && domain === 'admin'){
         sessionData.public = {
-          admin_cultureInfo: {
-            value: locale,
+            admin_cultureInfo: {
+              value: locale,
           },
         }
       } else {
         sessionData.public = {
-          cultureInfo: {
-            value: locale,
-          },
+            cultureInfo: {
+              value: locale,
+            },
         }
       }
       Promise.all([this.patchSession(sessionData)])
@@ -730,7 +721,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         .catch(e => {
           console.log('Failed to fetch new locale file.')
           console.error(e)
-        })
+      })
     }
   }
 
@@ -773,7 +764,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     await new Promise<void>(resolve => {
       this.setState(
-        state => ({
+        (state) => ({
           appsEtag,
           cacheHints,
           components,

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,6 @@
     "prop-types": "^15.6.0",
     "query-string": "^5.1.1",
     "ramda": "^0.26.1",
-    "react-amphtml": "^4.0.1",
     "react-apollo": "^2.5.6",
     "react-content-loader": "^4.0.1",
     "react-helmet": "^5.2.0",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -6,7 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "lib": ["es2017", "dom", "es2018.promise"],
-    "module": "esnext",
+    "module": "es6",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -32,7 +32,6 @@ declare global {
     maxAge: number
     page: string
     renderTimeMetric: RenderMetric
-    ampScripts?: string[]
   }
 
   type ClientRendered = Element
@@ -262,7 +261,7 @@ declare global {
   interface RenderComponent<P = {}, S = {}> {
     getCustomMessages?: (locale: string) => any
     WrappedComponent?: RenderComponent
-    new (): Component<P, S>
+    new(): Component<P, S>
   }
 
   interface ComponentsRegistry {
@@ -351,7 +350,7 @@ declare global {
     messages: RenderRuntime['messages']
   }
 
-  type Rendered = Promise<ClientRendered | NamedServerRendered>
+  type Rendered = ClientRendered | Promise<NamedServerRendered>
 
   interface ComponentTraversalResult {
     apps: string[]
@@ -374,7 +373,6 @@ declare global {
   }
 
   interface RenderRuntime {
-    amp: boolean
     account: string
     accountId: string
     appsEtag: string

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5910,13 +5910,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-amphtml@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-amphtml/-/react-amphtml-4.0.1.tgz#975157956962384aa9e1d21ee24740ba90cae869"
-  integrity sha512-XJ/+mss/xT9P8bHzswAJDe14hn0pmJaFxfgcztJDR/4+XFhHyts2qDvodkKw4ni5ynITXMtvP00RTn1LaOJJVw==
-  dependencies:
-    prop-types "^15.7.2"
-
 react-apollo@^2.5.2, react-apollo@^2.5.6:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"


### PR DESCRIPTION
This PR reverts #370 because the `react-amphtml` dependency added there was injecting ES5 code in the browser, hence causing problems rendering in browsers like IE11.