### PR TITLE
Delayed prefetch pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pool to prefetch pages
+- Delay to execute prefetch pages
+- Add querystring `__disablePrefetchPages`
 
 ## [8.49.0] - 2019-08-22
 ### Changed

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -261,7 +261,7 @@ declare global {
   interface RenderComponent<P = {}, S = {}> {
     getCustomMessages?: (locale: string) => any
     WrappedComponent?: RenderComponent
-    new(): Component<P, S>
+    new (): Component<P, S>
   }
 
   interface ComponentsRegistry {
@@ -482,6 +482,7 @@ declare global {
     hrtime: NodeJS.Process['hrtime']
     myvtexSSE: any
     rendered: Promise<RenderedSuccess> | RenderedFailure
+    requestIdleCallback: (callback: (...args) => any | void) => number
   }
 
   interface BlockEntry {


### PR DESCRIPTION
- Add a pool to prefetch pages to only execute it once.
- Execute prefetch pages when there is no cpu usage `requestIdleCallback ` or after waiting for 3 secs
- Add querystring to disable prefetchPages: `__disablePrefetchPages`