### PR TITLE
Deprecate semicolon as bundle files separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prepare to use comma instead of semicolon as bundle files separator
 
 ## [8.48.3] - 2019-08-21
 ### Fixed

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -259,6 +259,19 @@ function hasExtension(path: string, fileExtension: string) {
   return getExtension(path) === fileExtension
 }
 
+function parseFilesQueryString(filesQueryString: string) {
+  const hasSemicolon = filesQueryString.indexOf(';') !== -1
+
+  if (hasSemicolon) {
+    const [app, joinedPaths] = filesQueryString.split(';')
+    const assets = joinedPaths ? joinedPaths.split(',') : []
+    return { app, assets }
+  } else {
+    const [app, ...assets] = filesQueryString.split(',')
+    return { app, assets }
+  }
+}
+
 function groupAssetsByApp(assets: string[]): Record<string, string[]> {
   return assets.reduce((acc: Record<string, string[]>, asset) => {
     const parsedQuery = queryStringToMap(asset)
@@ -275,16 +288,15 @@ function groupAssetsByApp(assets: string[]): Record<string, string[]> {
         return
       }
 
-      const [app, assets] = files.split(';')
-      if (!assets) {
+      const { app, assets } = parseFilesQueryString(files)
+      if (!app || !assets || assets.length === 0) {
         return
       }
 
-      const appAssets = assets.split(',')
       if (!acc[app]) {
-        acc[app] = appAssets
+        acc[app] = assets
       } else {
-        acc[app].push(...appAssets)
+        acc[app].push(...assets)
       }
     })
     return acc


### PR DESCRIPTION
Some web servers (and maybe browsers) use semicolon as query separator (just like &) and it is causing errors on asset-server bundle endpoint

https://stackoverflow.com/questions/3481664/semicolon-as-url-query-separator