### PR TITLE
Prevent LayoutContainer from rendering unnecessary div

### DIFF
--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -41,8 +41,10 @@ class Container extends Component<ContainerProps> {
       if (elements === '__children__') {
         return children
       }
-      return (
-        <div className={isRow ? '' : className}>
+      return isRow ? (
+        <ExtensionPoint id={elements} {...props} />
+      ) : (
+        <div className={className}>
           <ExtensionPoint id={elements} {...props} />
         </div>
       )


### PR DESCRIPTION
#### What problem is this solving?

This prevents the `LayoutContainer` component from rendering an unnecessary outer div around an `<ExtensionPoint />`.

#### How should this be manually tested?

[Workspace](https://victorhmp--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
