### PR TITLE
stop encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop encoding query.
 
 ## [8.60.1] - 2019-09-10
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -106,7 +106,7 @@ export function queryStringToMap(query: string): Record<string, any> {
 }
 
 export function mapToQueryString(query: Record<string, any> = {}): string {
-  return queryString.stringify(query)
+  return queryString.stringify(query, { encode: false })
 }
 
 export function getPageParams(path: string, routePath: string) {


### PR DESCRIPTION
For SEO purposes, it was asked for us to stop encoding URL

on search, today we get: `/categoryA/categoryB?map=c%20c`, we will now have `/categoryA/categoryB?map=c,c`

We should watch this carefully

https://fidelis--invictastores.myvtex.com
https://encodequery--alssports.myvtex.com/
https://encodequery--samsungar.myvtex.com
https://encodequery--exitocol.myvtex.com