### PR TITLE
use useMemo on tree path provider

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Properly memo TreePathContextProvider.
 
 ## [8.55.0] - 2019-08-29
 ### Changed

--- a/react/utils/treePath.tsx
+++ b/react/utils/treePath.tsx
@@ -1,5 +1,5 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import React, { ComponentType, useContext } from 'react'
+import React, { ComponentType, useContext, FC, useMemo } from 'react'
 
 const relative = (parent: string, id: string) => id.replace(`${parent}/`, '')
 
@@ -46,13 +46,17 @@ export const TreePathContext = React.createContext<TreePathProps>({
 })
 TreePathContext.displayName = 'TreePathContext'
 
-export const TreePathContextProvider = React.memo<
-  React.PropsWithChildren<TreePathProps>
->(({ treePath, children }) => (
-  <TreePathContext.Provider value={{ treePath }}>
-    {children}
-  </TreePathContext.Provider>
-))
+export const TreePathContextProvider: FC<TreePathProps> = ({
+  treePath,
+  children,
+}) => {
+  const value = useMemo(() => ({ treePath }), [treePath])
+  return (
+    <TreePathContext.Provider value={value}>
+      {children}
+    </TreePathContext.Provider>
+  )
+}
 TreePathContextProvider.displayName = 'TreePathContextProvider'
 
 export const useTreePath = () => {


### PR DESCRIPTION
use React.memo with a component that uses the children prop can be quite problematic, using useMemo and tracking the treePath prop, is the better way