### PR TITLE
Fix/accordion: the return (quick win)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent the so-called accordion effect on root ExtensionPoints.
 
 ## [8.57.1] - 2019-09-03
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -76,10 +76,14 @@ function withOuterExtensions(
       query={props.query}
     />
   ))
+
+  const isRootTreePath = treePath.indexOf('/') === -1
+
   const wrapped = (
     <Fragment key={`wrapped-${treePath}`}>
       {beforeElements}
       {element}
+      {isRootTreePath && <div className="flex flex-grow-1" />}
       {afterElements}
     </Fragment>
   )


### PR DESCRIPTION
Prevents the so-called accordion effect on root ExtensionPoints.

Before (click around on the categories): https://lbebber--admitone.myvtex.com
After (do the same): https://accordion--admitone.myvtex.com/