### PR TITLE
Use browser fetch always

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -236,6 +236,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       baseURI,
       runtimeContextLink,
       ensureSessionLink,
+      this.fetcher,
       cacheControl
     )
 

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -593,6 +593,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     // the results of this query will probably remain the same.
     return isEnabled('RENDER_NAVIGATION')
       ? fetchServerPage({
+          fetcher: this.fetcher,
           path: navigationRoute.path,
           query,
         }).then(
@@ -787,6 +788,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       ? await fetchServerPage({
           path: route.path,
           query,
+          fetcher: this.fetcher,
         })
       : await fetchNavigationPage({
           apolloClient: this.apolloClient,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -178,6 +178,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   private unlisten!: UnregisterCallback | null
   private apolloClient: ApolloClient<NormalizedCacheObject>
   private prefetchRoutes: Set<string>
+  private fetcher: GlobalFetch['fetch']
 
   public constructor(props: Props) {
     super(props)
@@ -201,6 +202,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     } = props.runtime
     const { history, baseURI, cacheControl } = props
     const ignoreCanonicalReplacement = query && query.map
+    this.fetcher = fetch
 
     if (history) {
       const renderLocation: RenderHistoryLocation = {

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -71,6 +71,7 @@ export const getClient = (
   baseURI: string,
   runtimeContextLink: ApolloLink,
   ensureSessionLink: ApolloLink,
+  fetcher: GlobalFetch['fetch'],
   cacheControl?: PageCacheControl
 ) => {
   const {
@@ -97,6 +98,7 @@ export const getClient = (
       createHttpLink({
         credentials: 'include',
         useGETForQueries: false,
+        fetch: fetcher,
       }),
     ])
 

--- a/react/utils/fetch.ts
+++ b/react/utils/fetch.ts
@@ -26,14 +26,15 @@ const ok = (status: number) => 200 <= status && status < 300
 
 export const fetchWithRetry = (
   url: string,
-  init: RequestInit,
+  init: RequestInit & { fetcher: GlobalFetch['fetch'] },
   maxRetries: number = 3
 ) => {
   let status = 500
   const callFetch = (
     attempt: number = 0
   ): Promise<{ response: Response; error: any }> =>
-    fetch(url, init)
+    init
+      .fetcher(url, init)
       .then(response => {
         status = response.status
         return ok(status)

--- a/react/utils/flags.ts
+++ b/react/utils/flags.ts
@@ -1,5 +1,5 @@
 const flags = {
-  RENDER_NAVIGATION: false,
+  RENDER_NAVIGATION: true,
 }
 
 window.flags = flags

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -102,11 +102,13 @@ const runtimeFields = [
 ].join(',')
 
 export const fetchServerPage = async ({
+  fetcher,
   path,
   query: rawQuery,
 }: {
   path: string
   query?: Record<string, string>
+  fetcher: GlobalFetch['fetch']
 }): Promise<ParsedServerPageResponse> => {
   const query = stringify({
     ...rawQuery,
@@ -118,6 +120,7 @@ export const fetchServerPage = async ({
     headers: {
       accept: 'application/json',
     },
+    fetcher,
   }).then(({ response }) => response.json())
   const {
     blocksTree,


### PR DESCRIPTION
This PR adds window.fetch to render-runtime so we get immune to buggy monkey patch in window.fetch.

We are currently using the raw fetch for apollo queries and navigation

Also, this PR re-enables render navigation