### PR TITLE
Fix runtime navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Navigation bug of invalid fetch use
 
 ## [8.59.0] - 2019-09-06
+### Changed
+- Adds fetch to render provider 
 
 ## [8.58.1] - 2019-09-05
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.59.0",
+  "version": "8.59.1-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/utils/fetch.ts
+++ b/react/utils/fetch.ts
@@ -26,15 +26,15 @@ const ok = (status: number) => 200 <= status && status < 300
 
 export const fetchWithRetry = (
   url: string,
-  init: RequestInit & { fetcher: GlobalFetch['fetch'] },
+  init: RequestInit,
+  fetcher: GlobalFetch['fetch'],
   maxRetries: number = 3
 ) => {
   let status = 500
   const callFetch = (
     attempt: number = 0
   ): Promise<{ response: Response; error: any }> =>
-    init
-      .fetcher(url, init)
+    fetcher(url, init)
       .then(response => {
         status = response.status
         return ok(status)

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -115,13 +115,16 @@ export const fetchServerPage = async ({
     __pickRuntime: runtimeFields,
   })
   const url = `${path}?${query}`
-  const page: ServerPageResponse = await fetchWithRetry(url, {
-    credentials: 'same-origin',
-    headers: {
-      accept: 'application/json',
+  const page: ServerPageResponse = await fetchWithRetry(
+    url,
+    {
+      credentials: 'same-origin',
+      headers: {
+        accept: 'application/json',
+      },
     },
-    fetcher,
-  }).then(({ response }) => response.json())
+    fetcher
+  ).then(({ response }) => response.json())
   const {
     blocksTree,
     blocks,


### PR DESCRIPTION
There is a weird bug when adding fetch to its init. This pr fixes this problem by removing fetch from fetch's init