### PR TITLE
Use disableSSQ for AMP pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pass flag `disableSSQ` to AMP render.
 
 ## [8.66.2] - 2019-09-24
 ### Fixed

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -192,9 +192,12 @@ const ExtensionPoint: FC<Props> = props => {
     </ExtensionPointComponent>
   )
 
-  // `client` component assets are sent to server side rendering, but they should display a loading animation.
-  // `lazy` components might never be used, so they don't necessarily need a loading animation.
-  return renderStrategy === 'client' ? (
+  // "client" component assets are sent to server side rendering,
+  // but they should display a loading animation.
+  //
+  // "lazy" components might never be used, so they don't necessarily
+  // need a loading animation.
+  return renderStrategy === 'client' && !runtime.amp ? (
     <NoSSR onSSR={<Loading />}>{extensionPointComponent}</NoSSR>
   ) : (
     extensionPointComponent

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -166,14 +166,16 @@ const render = async (
         renderToStaticMarkup,
         runtime
       )
-      return renderToStringWithData(ampRoot, renderToStaticMarkup).then(
-        ({ markup, renderTimeMetric }) => ({
-          ...commonRenderResult,
-          markups: getMarkups(name, markup),
-          renderTimeMetric,
-          ...getExtraRenderedData(),
-        })
-      )
+      return renderToStringWithData(
+        ampRoot,
+        renderToStaticMarkup,
+        disableSSQ
+      ).then(({ markup, renderTimeMetric }) => ({
+        ...commonRenderResult,
+        markups: getMarkups(name, markup),
+        renderTimeMetric,
+        ...getExtraRenderedData(),
+      }))
     })
   }
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -188,6 +188,7 @@ declare global {
   }
 
   interface RenderContext {
+    amp: RenderRuntime['amp']
     account: RenderRuntime['account']
     addMessages: (newMessages: RenderContext['messages']) => Promise<void>
     amp: boolean


### PR DESCRIPTION
this PR updates the AMP page rendering to also disable server-side queries with the `disableSSQ` flag. I also moved some eslint configurations to the root folder, as it wasn't working correctly (at least in my editor).

I added some logic for the component lazy-load in the `ExtensionPoint` component, because we can't lazy load components in AMP pages, but if anyone feels a bit itchy about it I can remove that (right now I don't think it's working 100%, I still need to remove the `"render": "client"` on the Shelf app for it to render, if someone has any idea about it I'd highly appreciate hearing it).