### PR TITLE
Fix external react-amphtml usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Register react-amphtml global mocks that throw an explicitly error when trying to use AMP components on client-side or out of a `runtime.amp` check.
 
 ## [8.66.1] - 2019-09-24
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -28,6 +28,28 @@ if (module.hot) {
   })
 }
 
+if (!window.__RUNTIME__.amp) {
+  window.ReactAMPHTML = window.ReactAMPHTMLHelpers =
+    typeof Proxy !== 'undefined'
+      ? new Proxy(
+          {},
+          {
+            get: (_, key) => {
+              if (key === '__esModule' || key === 'constructor') {
+                return
+              }
+
+              const message = canUseDOM
+                ? 'You can not render AMP components on client-side'
+                : 'You must check runtime.amp to render AMP components'
+
+              throw new Error(message)
+            },
+          }
+        )
+      : {} // IE11 users will not have a clear error in this case
+}
+
 const sentryDSN = 'https://2fac72ea180d48ae9bf1dbb3104b4000@sentry.io/1292015'
 
 if (canUseDOM && window.__RUNTIME__.production) {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -499,33 +499,35 @@ declare global {
   }
 
   interface Window extends Window {
+    __APP_ID__: string
     __ERROR__: any
-    __RENDER_8_SESSION__: RenderSession
-    __RENDER_8_RUNTIME__: RuntimeExports
-    __RENDER_8_COMPONENTS__: ComponentsRegistry
-    __RENDER_8_HOT__: HotEmitterRegistry
-    __RUNTIME__: RenderRuntime
+    __hasPortals__: boolean
     __hostname__: string
     __pathname__: string
-    __STATE__: NormalizedCacheObject
-    __REQUEST_ID__: string
-    __APP_ID__: string
-    __hasPortals__: boolean
     __provideRuntime: (
       runtime: RenderContext | null,
       messages: Record<string, string>,
       shouldUpdateRuntime: boolean,
       setMessages: (messages: RenderRuntime['messages']) => void
     ) => Promise<void>
+    __RENDER_8_COMPONENTS__: ComponentsRegistry
+    __RENDER_8_HOT__: HotEmitterRegistry
+    __RENDER_8_RUNTIME__: RuntimeExports
+    __RENDER_8_SESSION__: RenderSession
+    __REQUEST_ID__: string
+    __RUNTIME__: RenderRuntime
+    __STATE__: NormalizedCacheObject
     browserHistory: History
-    ReactIntlLocaleData: any
-    IntlPolyfill: any
-    Intl: any
+    flags: Record<string, boolean>
     hrtime: NodeJS.Process['hrtime']
+    Intl: any
+    IntlPolyfill: any
     myvtexSSE: any
+    ReactAMPHTML: any
+    ReactAMPHTMLHelpers: any
+    ReactIntlLocaleData: any
     rendered: Promise<RenderedSuccess> | RenderedFailure
     requestIdleCallback: (callback: (...args) => any | void) => number
-    flags: Record<string, boolean>
   }
 
   interface BlockEntry {


### PR DESCRIPTION
Register `react-amphtml` global mocks that throw an explicitly error when trying to use AMP components on client-side or out of a `runtime.amp` check.