### PR TITLE
Keeps filters in path

### DIFF
--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -131,7 +131,11 @@ export function pathFromPageName(page: string, pages: Pages, params: any) {
   if (!validTemplate) {
     return null
   }
-  return new RouteParser(validTemplate).reverse(params) || null
+  const path = new RouteParser(validTemplate).reverse(params)
+  const filters = params
+    ? params.rest || (params.terms && `/${params.terms}`) || ''
+    : ''
+  return path ? `${path}${filters}` : null
 }
 
 export function queryStringToMap(query: string): Record<string, any> {


### PR DESCRIPTION
The function `pathFromPageName` was returning only the canonical path, losing the filters. This created a bug that when the `setQuery` function was called the querystring and the path changes.