### PR TITLE
Fixes navigation when there is a hashtag

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.66.6",
+  "version": "8.66.7-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -1,5 +1,6 @@
 import { stringify } from 'query-string'
 import { isEmpty } from 'ramda'
+import { parse, format } from 'url'
 
 import navigationPageQuery from '../queries/navigationPage.graphql'
 import routePreviews from '../queries/routePreviews.graphql'
@@ -110,11 +111,12 @@ export const fetchServerPage = async ({
   query?: Record<string, string>
   fetcher: GlobalFetch['fetch']
 }): Promise<ParsedServerPageResponse> => {
-  const query = stringify({
+  const parsedUrl = parse(path)
+  parsedUrl.query = {
     ...rawQuery,
     __pickRuntime: runtimeFields,
-  })
-  const url = `${path}?${query}`
+  } as any
+  const url = format(parsedUrl)
   const page: ServerPageResponse = await fetchWithRetry(
     url,
     {


### PR DESCRIPTION
Links containing `#` breaks navigation, since we add the querystring after the path. This PR addresses this issue by using functions `format` and `parse` to correctly build the url