### PR TITLE
Treats redirect JSON

### DIFF
--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -136,6 +136,9 @@ export const fetchServerPage = async ({
     route,
     route: { routeId },
   } = page
+  if (routeId === 'redirect') {
+    window.location.href = route.path
+  }
   const routePath = `${path}?${stringify(rawQuery || {})}`
 
   const extensions =


### PR DESCRIPTION
Allows to receive a `routeId` of the type `redirect`, that causes a redirect to the `path` of the JSON object.