### PR TITLE
Add support for special links to Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for special links `mailto:` and `tel:` to the `<Link />` component.
 
 ## [8.70.0] - 2019-10-15
 ### Added

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -9,8 +9,12 @@ const isModifiedEvent = (event: MouseEvent<HTMLAnchorElement>) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
 
 const absoluteRegex = /^https?:\/\/|^\/\//i
+const telephoneRegex = /^tel:/i
+const mailToRegex = /^mailto:/i
 
 const isAbsoluteUrl = (url: string) => absoluteRegex.test(url)
+const isTelephoneUrl = (url: string) => telephoneRegex.test(url)
+const isMailToUrl = (url: string) => mailToRegex.test(url)
 
 interface Props extends NavigateOptions {
   onClick: (event: React.MouseEvent) => void
@@ -38,7 +42,7 @@ const Link: React.FunctionComponent<Props> = ({
       if (
         isModifiedEvent(event) ||
         !isLeftClickEvent(event) ||
-        (to && isAbsoluteUrl(to))
+        (to && (isAbsoluteUrl(to) || isTelephoneUrl(to) || isMailToUrl(to)))
       ) {
         return
       }
@@ -63,8 +67,15 @@ const Link: React.FunctionComponent<Props> = ({
 
   const getHref = () => {
     if (to) {
-      // Prefix any non-absolute paths (e.g. http:// or https://) with runtime.rootPath
-      if (rootPath && !to.startsWith('http') && !to.startsWith(rootPath)) {
+      // Prefix any non-absolute paths (e.g. http:// or https://) and non-special links (e.g. mailto: or tel:)
+      // with runtime.rootPath
+      if (
+        rootPath &&
+        !to.startsWith('http') &&
+        !to.startsWith(rootPath) &&
+        !isTelephoneUrl(to) &&
+        !isMailToUrl(to)
+      ) {
         return rootPath + to
       }
       return to


### PR DESCRIPTION
#### What did you change? \*

Added support for special links using `mailto:` and `tel:` to the `<Link />` component.

#### Why? \*

Currently, this kind of link would result in a broken URL, as `runtime.rootPath` would get appended to the `href` attribute in the anchor tag rendered by `<Link />`.

#### How to test it? \*

Use the link in the header "Call Us" and "Mail Us"
https://speciallinksruntime--storecomponents.myvtex.com/

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
