### PR TITLE
Remove unnecessary "?" from path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Issue when client-side navigation added a `?` to the path in `RenderProvider`'s state, making `updateRuntime` not work as expected.
+
 ## [8.71.0] - 2019-10-16
 ### Added
 - Support for special links `mailto:` and `tel:` to the `<Link />` component.

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -139,7 +139,8 @@ export const fetchServerPage = async ({
   if (routeId === 'redirect') {
     window.location.href = route.path
   }
-  const routePath = `${path}?${stringify(rawQuery || {})}`
+  const queryString = stringify(rawQuery || {})
+  const routePath = `${path}${queryString ? '?' + queryString : queryString}`
 
   const extensions =
     !isEmpty(blocksTree) && blocksTree && blocks && contentMap


### PR DESCRIPTION
When there isn't a querystring, the routePath shouldn't have `?` in it.

It was causing some issues in `admin-pages`, because by having `?`, the `updateRuntime` function makes a request without `__pickRuntime` (returning a HTML instead of a JSON).

This PR aims to fix this by relying on the behaviour that `stringify({}) === ''`.