### PR TITLE
Receives queryData from render-server

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -221,21 +221,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       cacheControl
     )
     if (queryData) {
-      const { data, query, variables } = queryData
-      try {
-        this.apolloClient.writeQuery({
-          query: gql`
-            ${query}
-          `,
-          data: JSON.parse(data),
-          variables,
-        })
-      } catch (error) {
-        console.warn(
-          `Error writing query from render-server in Apollo's cache`,
-          error
-        )
-      }
+      this.hydrateApolloCache(queryData)
     }
 
     this.state = {
@@ -586,21 +572,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             queryData,
           }: ParsedServerPageResponse) => {
             if (queryData) {
-              const { data, query, variables } = queryData
-              try {
-                this.apolloClient.writeQuery({
-                  query: gql`
-                    ${query}
-                  `,
-                  data: JSON.parse(data),
-                  variables,
-                })
-              } catch (error) {
-                console.warn(
-                  `Error writing query from render-server in Apollo's cache`,
-                  error
-                )
-              }
+              this.hydrateApolloCache(queryData)
             }
             this.setState(
               {
@@ -976,6 +948,31 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         </TreePathContextProvider>
       </RenderContextProvider>
     )
+  }
+
+  private hydrateApolloCache = ({
+    data,
+    query,
+    variables,
+  }: {
+    data: string
+    query: string
+    variables: Record<string, any>
+  }) => {
+    try {
+      this.apolloClient.writeQuery({
+        query: gql`
+          ${query}
+        `,
+        data: JSON.parse(data),
+        variables,
+      })
+    } catch (error) {
+      console.warn(
+        `Error writing query from render-server in Apollo's cache`,
+        error
+      )
+    }
   }
 
   // Deprecated

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -228,7 +228,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             ${query}
           `,
           data: JSON.parse(data),
-          variables: { ...variables, skipCategoryTree: true },
+          variables,
         })
       } catch (error) {
         console.warn(
@@ -593,7 +593,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
                     ${query}
                   `,
                   data: JSON.parse(data),
-                  variables: { ...variables, skipCategoryTree: true },
+                  variables,
                 })
               } catch (error) {
                 console.warn(

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -343,6 +343,7 @@ declare global {
     pages: RenderRuntime['pages']
     route: MatchingServerPage
     settings: RenderRuntime['settings']
+    queryData: RenderRuntime['queryData']
   }
 
   interface PageQueryResponse {
@@ -457,6 +458,11 @@ declare global {
     rootPath?: string
     workspaceCookie: string
     hasNewExtensions: boolean
+    queryData?: {
+      query: string
+      variables: any
+      data: string
+    }
   }
 
   interface CacheHints {

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -97,6 +97,7 @@ const runtimeFields = [
   'page',
   'pages',
   'query',
+  'queryData',
   'route',
   'runtimeMeta',
   'settings',
@@ -135,10 +136,12 @@ export const fetchServerPage = async ({
     pages,
     route,
     route: { routeId },
+    queryData,
   } = page
   if (routeId === 'redirect') {
     window.location.href = route.path
   }
+
   const queryString = stringify(rawQuery || {})
   const routePath = `${path}${queryString ? '?' + queryString : queryString}`
 
@@ -154,6 +157,7 @@ export const fetchServerPage = async ({
       ...route,
       path: routePath,
     },
+    queryData,
   }
 }
 


### PR DESCRIPTION
Receives queryData from render-server and hydrates apollo cache with it.

### To test this PR
Render a product page, watch the product query made in browser. There should be none that gets all the product info.

This depends on https://github.com/vtex/render-server/pull/504