### PR TITLE
Do not share extensions between requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Revert the revert adding back the session ensurance for /segment and /private routes
+
+### Fixed
+- Fixed query split race condition with shared pointer
 
 ## [8.75.0] - 2019-10-29
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.75.0",
+  "version": "8.76.0-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -1,7 +1,6 @@
 import { NormalizedCacheObject } from 'apollo-cache-inmemory'
 import ApolloClient from 'apollo-client'
-import { Subscription } from 'apollo-client/util/Observable'
-import { ApolloLink, NextLink, Observable, Operation } from 'apollo-link'
+import { ApolloLink, NextLink, Operation } from 'apollo-link'
 import debounce from 'debounce'
 import { canUseDOM } from 'exenv'
 import { History, UnregisterCallback } from 'history'
@@ -15,8 +14,8 @@ import gql from 'graphql-tag'
 
 import {
   fetchAssets,
-  prefetchAssets,
   getLoadedImplementation,
+  prefetchAssets,
 } from '../utils/assets'
 import PageCacheControl from '../utils/cacheControl'
 import { getClient } from '../utils/client'
@@ -211,12 +210,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       ? window.__RENDER_8_SESSION__.sessionPromise
       : Promise.resolve()
     const runtimeContextLink = this.createRuntimeContextLink()
-    const ensureSessionLink = this.createEnsureSessionLink()
     this.apolloClient = getClient(
       props.runtime,
       baseURI,
       runtimeContextLink,
-      ensureSessionLink,
+      this.sessionPromise,
       this.fetcher,
       cacheControl
     )
@@ -801,32 +799,6 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     })
 
     await this.sendInfoFromIframe()
-  }
-
-  public createEnsureSessionLink() {
-    return new ApolloLink(
-      (operation: Operation, forward?: NextLink) =>
-        new Observable(observer => {
-          let handle: Subscription | undefined
-          this.sessionPromise
-            .then(() => {
-              handle =
-                forward &&
-                forward(operation).subscribe({
-                  complete: observer.complete.bind(observer),
-                  error: observer.error.bind(observer),
-                  next: observer.next.bind(observer),
-                })
-            })
-            .catch(observer.error.bind(observer))
-
-          return () => {
-            if (handle) {
-              handle.unsubscribe()
-            }
-          }
-        })
-    )
   }
 
   public createRuntimeContextLink() {

--- a/react/externals.json
+++ b/react/externals.json
@@ -2,6 +2,10 @@
   "commons": {
     "dev": [
       {
+        "clientOnly": true,
+        "path": "npm:vtex-render-session@1.6.0/dist/index.js"
+      },
+      {
         "path": "npm:bluebird@3.5.1/js/browser/bluebird.js",
         "serverOnly": true
       },
@@ -68,15 +72,15 @@
         "path": "npm:vtex-tachyons@3.1.0/tachyons.css"
       },
       {
-        "clientOnly": true,
-        "path": "npm:vtex-render-session@1.6.0/dist/index.js"
-      },
-      {
         "path": "runtime:AMP",
         "serverOnly": true
       }
     ],
     "prod": [
+      {
+        "clientOnly": true,
+        "path": "npm:vtex-render-session@1.6.0/dist/index.min.js"
+      },
       {
         "path": "npm:bluebird@3.5.1/js/browser/bluebird.min.js",
         "serverOnly": true
@@ -142,10 +146,6 @@
       },
       {
         "path": "npm:vtex-tachyons@3.1.0/tachyons.min.css"
-      },
-      {
-        "clientOnly": true,
-        "path": "npm:vtex-render-session@1.6.0/dist/index.min.js"
       },
       {
         "path": "runtime:AMP",

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -17,6 +17,7 @@ import graphQLErrorsStore from '../graphQLErrorsStore'
 import { generateHash } from './generateHash'
 import { toBase64Link } from './links/base64Link'
 import { cachingLink } from './links/cachingLink'
+import { ensureSessionLink } from './links/ensureSessionLink'
 import { createIOFetchLink } from './links/ioFetchLink'
 import { omitTypenameLink } from './links/omitVariableTypenameLink'
 import { createUriSwitchLink } from './links/uriSwitchLink'
@@ -70,7 +71,7 @@ export const getClient = (
   runtime: RenderRuntime,
   baseURI: string,
   runtimeContextLink: ApolloLink,
-  ensureSessionLink: ApolloLink,
+  sessionPromise: Promise<any>,
   fetcher: GlobalFetch['fetch'],
   cacheControl?: PageCacheControl
 ) => {
@@ -129,9 +130,9 @@ export const getClient = (
       omitTypenameLink,
       versionSplitterLink,
       runtimeContextLink,
-      ensureSessionLink,
       persistedQueryLink,
       uriSwitchLink,
+      ensureSessionLink(sessionPromise),
       ...cacheLink,
       fetcherLink, //this is a final link
     ])

--- a/react/utils/client/links/ensureSessionLink.ts
+++ b/react/utils/client/links/ensureSessionLink.ts
@@ -1,0 +1,36 @@
+import { ApolloLink, NextLink, Observable, Operation } from 'apollo-link'
+import { Subscription } from 'apollo-client/util/Observable'
+
+const sessionRequiredForScope = new Set(['segment', 'private'])
+
+export const ensureSessionLink = (sessionPromise: Promise<any>) => {
+  return new ApolloLink(
+    (operation: Operation, forward?: NextLink) =>
+      new Observable(observer => {
+        let handle: Subscription | undefined
+
+        const { scope } = operation.getContext()
+        const promise = sessionRequiredForScope.has(scope)
+          ? sessionPromise
+          : Promise.resolve()
+
+        promise
+          .then(() => {
+            handle =
+              forward &&
+              forward(operation).subscribe({
+                complete: observer.complete.bind(observer),
+                error: observer.error.bind(observer),
+                next: observer.next.bind(observer),
+              })
+          })
+          .catch(observer.error.bind(observer))
+
+        return () => {
+          if (handle) {
+            handle.unsubscribe()
+          }
+        }
+      })
+  )
+}

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -127,6 +127,7 @@ export const createUriSwitchLink = (
       }
       return {
         ...oldContext,
+        scope: customScope,
         fetchOptions: { ...fetchOptions, method },
         uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}&domain=${domain}&locale=${locale}`,
       }

--- a/react/utils/client/links/versionSplitterLink.ts
+++ b/react/utils/client/links/versionSplitterLink.ts
@@ -150,7 +150,11 @@ const mergeRecursively = (accumulator: any, value: any) => {
 const createOperationForQuery = (operation: Operation) => (
   query: DocumentNode
 ) => {
-  const graphQLRequest: GraphQLRequest = { ...operation, query }
+  const graphQLRequest: GraphQLRequest = {
+    ...operation,
+    query,
+    extensions: { ...operation.extensions },
+  }
   const op = validateOperation(transformOperation(graphQLRequest))
   return createOperation(operation.getContext(), op)
 }


### PR DESCRIPTION
Revert the revert adding back the session ensurance for /segment and /private routes by fixing query split race condition with shared pointer 