### PR TITLE
Fix 'Box' preview being showed before the 'Text' preview appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Box` preview is not being showed before `Text` preview appears anymore.
+
+### Removed
+- Remove `paragraph` preview option, since it became obsolete.
 
 ## [8.77.0] - 2019-11-07
 ### Added

--- a/react/components/Preview/Text.tsx
+++ b/react/components/Preview/Text.tsx
@@ -11,6 +11,8 @@ interface Props {
 }
 
 const Text = ({ width, height, fontSize = 16, lineHeight = 1.5 }: Props) => {
+  // Height needs to be a value in pixels in order to be able to split it properly into lines.
+  // Falls back to `Box` if it's e.g. `100%`
   if (typeof height === 'string') {
     return <Box width={width} height={height} />
   }
@@ -22,9 +24,6 @@ const Text = ({ width, height, fontSize = 16, lineHeight = 1.5 }: Props) => {
   return (
     <ContentLoader width={width} height={height}>
       {Array.from({ length: lines }).map((_, i) => {
-        /** TODO: Add support for changing the width of each line
-         * when width is a string (e.g. turning "100%" into "70%")
-         */
         const lineWidth = width
         return (
           <Rect

--- a/react/components/Preview/Text.tsx
+++ b/react/components/Preview/Text.tsx
@@ -22,7 +22,6 @@ const Text = ({ width, height, fontSize = 16, lineHeight = 1.5 }: Props) => {
   return (
     <ContentLoader width={width} height={height}>
       {Array.from({ length: lines }).map((_, i) => {
-        const isLast = i === lines - 1
         /** TODO: Add support for changing the width of each line
          * when width is a string (e.g. turning "100%" into "70%")
          */

--- a/react/components/Preview/Text.tsx
+++ b/react/components/Preview/Text.tsx
@@ -8,19 +8,10 @@ interface Props {
   height: number | string
   lineHeight?: number
   fontSize?: number
-  paragraph?: boolean
 }
 
-const Text = ({
-  width,
-  height,
-  fontSize = 16,
-  lineHeight = 1.5,
-  paragraph = true,
-}: Props) => {
-  const isSSR = useSSR()
-
-  if (isSSR || typeof width === 'string' || typeof height === 'string') {
+const Text = ({ width, height, fontSize = 16, lineHeight = 1.5 }: Props) => {
+  if (typeof height === 'string') {
     return <Box width={width} height={height} />
   }
 
@@ -32,8 +23,10 @@ const Text = ({
     <ContentLoader width={width} height={height}>
       {Array.from({ length: lines }).map((_, i) => {
         const isLast = i === lines - 1
-        const widthMultiplier = isLast && paragraph ? 0.7 : 1
-        const lineWidth = width * widthMultiplier
+        /** TODO: Add support for changing the width of each line
+         * when width is a string (e.g. turning "100%" into "70%")
+         */
+        const lineWidth = width
         return (
           <Rect
             key={i}

--- a/react/components/Preview/index.tsx
+++ b/react/components/Preview/index.tsx
@@ -50,7 +50,6 @@ export default class Preview extends React.PureComponent<Props, State> {
             height={height}
             fontSize={options.fontSize}
             lineHeight={options.lineHeight}
-            paragraph={options.paragraph}
           />
         )
       case 'grid':


### PR DESCRIPTION
The `Box` preview type (image 1) was being showed before the `Text` one (image 2), even when it was not necessary. 

**Image 1**

![image](https://user-images.githubusercontent.com/12574426/69173127-e5f04380-0add-11ea-9719-1d0e1548071f.png)

**Image 2**

![image](https://user-images.githubusercontent.com/12574426/69173344-55fec980-0ade-11ea-805c-3365f5f837b0.png)

This PR fix it.

