### PR TITLE
Change preview skeleton's gradient color contrast and velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Preview skeleton's animation velocity and colors contrast.
 
 ## [8.79.1] - 2019-12-02
 ### Fixed

--- a/react/components/Preview/ContentLoader.css
+++ b/react/components/Preview/ContentLoader.css
@@ -8,5 +8,5 @@
 }
 
 .slide {
-  animation: slide 1s infinite linear;
+  animation: slide 1.5s infinite linear;
 }

--- a/react/components/Preview/ContentLoader.tsx
+++ b/react/components/Preview/ContentLoader.tsx
@@ -3,7 +3,7 @@ import styles from './ContentLoader.css'
 
 // TODO: make these colors dynamic, probably based on
 // muted colors from the color theme
-const PRIMARY_COLOR = '#fafafa'
+const PRIMARY_COLOR = '#e8e8e8'
 const SECONDARY_COLOR = '#e0e0e0'
 
 interface RectProps {
@@ -40,8 +40,10 @@ const Rect: FunctionComponent<RectProps> = ({
         height: '100%',
         position: 'relative',
         left: -x,
-        backgroundColor: '#fff',
-        backgroundImage: `linear-gradient(90deg, ${PRIMARY_COLOR}, ${SECONDARY_COLOR}, ${PRIMARY_COLOR}, ${SECONDARY_COLOR}, ${PRIMARY_COLOR})`,
+        backgroundColor: SECONDARY_COLOR,
+        backgroundImage: `linear-gradient(90deg, ${SECONDARY_COLOR}, ${SECONDARY_COLOR} 50%, ${PRIMARY_COLOR} 60%, ${SECONDARY_COLOR} 65%, ${SECONDARY_COLOR})`,
+        backgroundSize: '50% 100%',
+        backgroundRepeat: 'repeat-x',
       }}
     />
   </div>


### PR DESCRIPTION
We decided that the preview skeleton's animation velocity and its color contrast should be smaller. This PR does it.

**How to test it?**

- Go to [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart)
- Open console dev tools
- Change network conditions to "Slow 3g", for instance.
- Reload

cc @lbebber @augustocb