### PR TITLE
Add client-side query to __RUNTIME__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add client-side query to __RUNTIME__
 
 ## [8.79.0] - 2019-11-21
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.79.0",
+  "version": "8.79.1-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/components/Preview/Text.tsx
+++ b/react/components/Preview/Text.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { ContentLoader, Rect } from './ContentLoader'
 import Box from './Box'
-import { useSSR } from '../NoSSR'
 
 interface Props {
   width: number | string

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -9,6 +9,7 @@ import * as EventEmitter from 'eventemitter3'
 import { canUseDOM } from 'exenv'
 import 'graphql'
 import { createBrowserHistory as createHistory } from 'history'
+import queryString from 'query-string'
 import React, { ReactElement } from 'react'
 import { getDataFromTree } from 'react-apollo'
 import { hydrate, render as renderDOM } from 'react-dom'
@@ -220,6 +221,14 @@ function start() {
         window.__RUNTIME__.contentMap!,
         window.__RUNTIME__.pages[window.__RUNTIME__.page]
       )
+    }
+
+    if (canUseDOM && window.location.search) {
+      const browserQuery = queryString.parse(window.location.search)
+      window.__RUNTIME__.query = {
+        ...browserQuery,
+        ...(window.__RUNTIME__.query || {}),
+      }
     }
 
     const runtime = window.__RUNTIME__

--- a/react/typings/exenv.d.ts
+++ b/react/typings/exenv.d.ts
@@ -1,3 +1,3 @@
 declare module 'exenv' {
-  var canUseDOM: boolean
+  const canUseDOM: boolean
 }

--- a/react/typings/node.d.ts
+++ b/react/typings/node.d.ts
@@ -2,7 +2,7 @@ interface Module {
   hot: any
 }
 
-declare var module: Module
+declare const module: Module
 
 declare module '*.graphql' {
   import { DocumentNode } from 'graphql'
@@ -12,7 +12,7 @@ declare module '*.graphql' {
 }
 
 declare module '*.png' {
-  var url: string
+  let url: string
   export = url
 }
 
@@ -21,4 +21,4 @@ declare module '*.css' {
   export default content
 }
 
-declare var vtex: any
+declare const vtex: any

--- a/react/typings/render.d.ts
+++ b/react/typings/render.d.ts
@@ -1,4 +1,4 @@
 declare module 'vtex.render-runtime' {
-  var runtimeExports: RuntimeExports
+  let runtimeExports: RuntimeExports
   export = runtimeExports
 }

--- a/react/utils/fetch.ts
+++ b/react/utils/fetch.ts
@@ -28,11 +28,11 @@ export const fetchWithRetry = (
   url: string,
   init: RequestInit,
   fetcher: GlobalFetch['fetch'],
-  maxRetries: number = 3
+  maxRetries = 3
 ) => {
   let status = 500
   const callFetch = (
-    attempt: number = 0
+    attempt = 0
   ): Promise<{ response: Response; error: any }> =>
     fetcher(url, init)
       .then(response => {

--- a/react/utils/reactApollo.tsx
+++ b/react/utils/reactApollo.tsx
@@ -11,9 +11,8 @@ class RenderRuntimeQuery extends PureComponent<{
     const { children, ...rest } = this.props
 
     return (
-      // @ts-ignore
-      <Query {...rest}>
-        {result => {
+      <Query {...(rest as any)}>
+        {(result: any) => {
           if (result.networkStatus === 1 && result.data === undefined) {
             result.data = {} as any
             result.refetch = noop as any
@@ -32,8 +31,7 @@ class RenderRuntimeMutation extends PureComponent<{
     const { children, ...rest } = this.props
 
     return (
-      // @ts-ignore
-      <Mutation {...rest}>
+      <Mutation {...(rest as any)}>
         {(mutateFunction: any, result: any) => {
           return children(mutateFunction, result)
         }}

--- a/react/utils/registerComponent.tsx
+++ b/react/utils/registerComponent.tsx
@@ -58,7 +58,7 @@ export default (
   InitialImplementer: any,
   app: string,
   name: string,
-  lazy: boolean = false
+  lazy = false
 ) => {
   const componentLocators = [`${app}/${name}`, `${idToAppAtMajor(app)}/${name}`]
 


### PR DESCRIPTION
Because of our CDN query string whitelist, only some query strings are available in `runtime.query`, not reflecting the truth on client-side.