### PR TITLE
Feature/inspector external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Block inspector when `__inspect` flag is enabled.
 
 ## [8.91.5] - 2020-02-19
 ### Fixed

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -1,5 +1,5 @@
 import { mergeDeepRight, reduce } from 'ramda'
-import React, { FC, Fragment } from 'react'
+import React, { FC, Fragment, Suspense } from 'react'
 
 import ExtensionPointComponent from './ExtensionPointComponent'
 import Loading from './Loading'
@@ -9,6 +9,16 @@ import NoSSR from './NoSSR'
 import { withErrorBoundary } from './ErrorBoundary'
 import GenericPreview from './Preview/GenericPreview'
 import LoadingBar from './LoadingBar'
+
+// TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
+const BlockWrapper = React.lazy(
+  () =>
+    new Promise<{ default: any }>(resolve => {
+      import('@vtex/blocks-inspector').then(BlocksInspector => {
+        resolve({ default: BlocksInspector.default.ExtensionPointWrapper })
+      })
+    })
+)
 
 interface Props {
   id: string
@@ -113,6 +123,8 @@ function withOuterExtensions(
 const ExtensionPoint: FC<Props> = props => {
   const runtime = useRuntime()
 
+  const { inspect } = runtime
+
   const treePathFromHook = useTreePath()
 
   const { children, params, query, id, blockProps, ...parentProps } = props
@@ -199,7 +211,7 @@ const ExtensionPoint: FC<Props> = props => {
   //
   // "lazy" components might never be used, so they don't necessarily
   // need a loading animation.
-  return (
+  const maybeClientExtension = (
     <Fragment>
       {runtime.preview && isRootTreePath && <LoadingBar />}
       {renderStrategy === 'client' && !runtime.amp ? (
@@ -209,6 +221,18 @@ const ExtensionPoint: FC<Props> = props => {
       )}
     </Fragment>
   )
+
+  if (inspect) {
+    return (
+      <Suspense fallback={maybeClientExtension}>
+        <BlockWrapper extension={extension} treePath={newTreePath}>
+          {maybeClientExtension}
+        </BlockWrapper>
+      </Suspense>
+    )
+  }
+
+  return maybeClientExtension
 }
 
 ExtensionPoint.defaultProps = {

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -11,7 +11,7 @@ import GenericPreview from './Preview/GenericPreview'
 import LoadingBar from './LoadingBar'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
-const BlockWrapper = React.lazy(
+const InspectBlockWrapper = React.lazy(
   () =>
     new Promise<{ default: any }>(resolve => {
       import('@vtex/blocks-inspector').then(BlocksInspector => {
@@ -222,12 +222,14 @@ const ExtensionPoint: FC<Props> = props => {
     </Fragment>
   )
 
+  /** If it's on inspect mode (?__inspect on querystring) wraps the block
+   * on a block-inspector wrapper */
   if (inspect) {
     return (
       <Suspense fallback={maybeClientExtension}>
-        <BlockWrapper extension={extension} treePath={newTreePath}>
+        <InspectBlockWrapper extension={extension} treePath={newTreePath}>
           {maybeClientExtension}
-        </BlockWrapper>
+        </InspectBlockWrapper>
       </Suspense>
     )
   }

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -6,7 +6,7 @@ import { canUseDOM } from 'exenv'
 import { History, UnregisterCallback } from 'history'
 import PropTypes from 'prop-types'
 import { forEach, merge, mergeWith, equals } from 'ramda'
-import React, { Component, Fragment, ReactElement } from 'react'
+import React, { Component, Fragment, ReactElement, Suspense } from 'react'
 import { ApolloProvider } from 'react-apollo'
 import { Helmet } from 'react-helmet'
 import { IntlProvider } from 'react-intl'
@@ -57,6 +57,16 @@ import { RenderContextProvider } from './RenderContext'
 import RenderPage from './RenderPage'
 import { appendLocationSearch } from '../utils/location'
 import { setCookie } from '../utils/cookie'
+
+// TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
+const InspectorPopover = React.lazy(
+  () =>
+    new Promise<{ default: any }>(resolve => {
+      import('@vtex/blocks-inspector').then(BlocksInspector => {
+        resolve({ default: BlocksInspector.default.InspectorPopover })
+      })
+    })
+)
 
 interface Props {
   children: ReactElement<any> | null
@@ -1057,6 +1067,11 @@ class RenderProvider extends Component<Props, RenderProviderState> {
                 {isSiteEditorIframe ? (
                   <ExtensionPoint id="store/__overlay" />
                 ) : null}
+                {inspect && (
+                  <Suspense fallback={null}>
+                    <InspectorPopover />
+                  </Suspense>
+                )}
               </Fragment>
             </IntlProvider>
           </ApolloProvider>

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -329,6 +329,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     if (
       publicEndpoint === 'myvtex.com' &&
+      !production &&
       '__inspect' in (this.state.query || {})
     ) {
       this.setState({ inspect: true })

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -312,7 +312,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
   public componentDidMount() {
     this.rendered = true
     const { history, runtime } = this.props
-    const { production, emitter } = runtime
+    const { production, emitter, publicEndpoint } = runtime
 
     this.unlisten = history && history.listen(this.onPageChanged)
     emitter.addListener('localesChanged', this.onLocaleSelected)
@@ -327,7 +327,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     this.sendInfoFromIframe()
     this.prefetchPages()
 
-    if ('__inspect' in (this.state.query || {})) {
+    if (
+      publicEndpoint === 'myvtex.com' &&
+      '__inspect' in (this.state.query || {})
+    ) {
       this.setState({ inspect: true })
     }
   }

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -75,6 +75,7 @@ export interface RenderProviderState {
   defaultExtensions: RenderRuntime['defaultExtensions']
   device: ConfigurationDevice
   extensions: RenderRuntime['extensions']
+  inspect: RenderRuntime['inspect']
   messages: RenderRuntime['messages']
   page: RenderRuntime['page']
   pages: RenderRuntime['pages']
@@ -132,6 +133,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     goBack: PropTypes.func,
     hints: PropTypes.object,
     history: PropTypes.object,
+    inspect: PropTypes.bool,
     messages: PropTypes.object,
     navigate: PropTypes.func,
     onPageChanged: PropTypes.func,
@@ -289,6 +291,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       query,
       route,
       settings: settings || {},
+      inspect: false,
     }
 
     this.prefetchRoutes = new Set<string>()
@@ -313,6 +316,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     this.sendInfoFromIframe()
     this.prefetchPages()
+
+    if ('__inspect' in (this.state.query || {})) {
+      this.setState({ inspect: true })
+    }
   }
 
   public UNSAFE_componentWillReceiveProps(nextProps: Props) {
@@ -348,6 +355,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       components,
       contentMap,
       extensions,
+      inspect,
       messages,
       page,
       pages,
@@ -358,6 +366,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       query,
       defaultExtensions,
     } = this.state
+
     const {
       account,
       amp,
@@ -391,6 +400,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       goBack: this.goBack,
       hints,
       history,
+      inspect,
       messages,
       navigate: this.navigate,
       onPageChanged: this.onPageChanged,
@@ -1012,6 +1022,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       page,
       query,
       production,
+      inspect,
     } = this.state
     const customMessages = this.getCustomMessages(locale)
     const mergedMessages = {

--- a/react/package.json
+++ b/react/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.3.9",
     "@formatjs/intl-relativetimeformat": "^4.5.1",
+    "@vtex/blocks-inspector": "^0.0.7",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "apollo-link-error": "^1.1.11",

--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.3.9",
     "@formatjs/intl-relativetimeformat": "^4.5.1",
-    "@vtex/blocks-inspector": "^0.0.7",
+    "@vtex/blocks-inspector": "^0.0.8",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "apollo-link-error": "^1.1.11",

--- a/react/typings/blocks-inspector.d.ts
+++ b/react/typings/blocks-inspector.d.ts
@@ -1,0 +1,1 @@
+declare module '@vtex/blocks-inspector'

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -215,6 +215,7 @@ declare global {
     goBack: () => void
     hints: RenderHints
     history: History | null
+    inspect: RenderRuntime['inspect']
     messages: RenderRuntime['messages']
     navigate: (options: NavigateOptions) => boolean
     onPageChanged: (location: RenderHistoryLocation) => void
@@ -441,6 +442,7 @@ declare global {
     disableSSQ: boolean
     hints: any
     introspectionResult: IntrospectionResultData
+    inspect: boolean
     page: string
     route: Route
     version: string

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2293,10 +2293,10 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
 
-"@vtex/blocks-inspector@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@vtex/blocks-inspector/-/blocks-inspector-0.0.7.tgz#f9dbd2f517fba43b5282a4c08d99fde52b2fc5a1"
-  integrity sha512-Ak2LsVJKR2hMonuMxcJrWHTcmgSBslem1ibnXUV9IWdCuRASLLJLFZ8wS62n+Xjuo6f7PigJvtBDD5fQECSbyA==
+"@vtex/blocks-inspector@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@vtex/blocks-inspector/-/blocks-inspector-0.0.8.tgz#905d47364948880322b1b22ac75cfe727a7d45ae"
+  integrity sha512-afW1Hom2DoH5XQz4XA2zrHCrrLCDHYGXhumcR2DAe6m+QwZVHmxmORe4QyOZQVA9zpPPSfpEVYAqTpNjQIafJQ==
   dependencies:
     throttle-debounce "^2.1.0"
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2293,6 +2293,13 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
 
+"@vtex/blocks-inspector@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@vtex/blocks-inspector/-/blocks-inspector-0.0.7.tgz#f9dbd2f517fba43b5282a4c08d99fde52b2fc5a1"
+  integrity sha512-Ak2LsVJKR2hMonuMxcJrWHTcmgSBslem1ibnXUV9IWdCuRASLLJLFZ8wS62n+Xjuo6f7PigJvtBDD5fQECSbyA==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
 "@vtex/test-tools@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.0.0.tgz#fbe0d5fa60a750d2098e707535924d1b9e86a35c"
@@ -7858,6 +7865,11 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 through@^2.3.6:
   version "2.3.8"


### PR DESCRIPTION
Adds inspector if `__inspect` is present on the query string

### Workspaces
On `production` workspaces it shouldn't be enabled--but of course it shouldn't break either:
https://lbebberinspect--biscoind.myvtex.com/?__inspect

On `development` workspaces it should work:
https://lbebberinspectdev--biscoind.myvtex.com/?__inspect