### PR TITLE
Fix/intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Case when only one polyfill was imported and promise would never resolve.
 
 ## [8.83.0] - 2019-12-12
 ### Changed

--- a/react/intl-polyfill.ts
+++ b/react/intl-polyfill.ts
@@ -32,31 +32,14 @@ myPromise = new Promise(resolve => {
     window.Intl.PluralRules.polyfilled && canUseDOM && lang
   const hasPolyfilledRelative =
     window.Intl.RelativeTimeFormat.polyfilled && canUseDOM && lang
-  let isPluralLocaleImported = false
-  let iRelativeLocaleImported = false
 
-  if (hasPolyfilledPlural) {
-    import('@formatjs/intl-pluralrules/dist/locale-data/' + lang).then(() => {
-      isPluralLocaleImported = true
-      if (isPluralLocaleImported && iRelativeLocaleImported) {
-        resolve()
-      }
-    })
-  }
-
-  if (hasPolyfilledRelative) {
-    import('@formatjs/intl-relativetimeformat/dist/locale-data/' + lang).then(
-      () => {
-        iRelativeLocaleImported = true
-        if (isPluralLocaleImported && iRelativeLocaleImported) {
-          resolve()
-        }
-      }
-    )
-  }
-  if (!hasPolyfilledPlural && !hasPolyfilledRelative) {
-    resolve()
-  }
+  const pluralPromise = hasPolyfilledPlural
+    ? import('@formatjs/intl-pluralrules/dist/locale-data/' + lang)
+    : Promise.resolve()
+  const relativeTimePromise = hasPolyfilledRelative
+    ? import('@formatjs/intl-relativetimeformat/dist/locale-data/' + lang)
+    : Promise.resolve()
+  Promise.all([pluralPromise, relativeTimePromise]).then(resolve)
 })
 
 export default myPromise


### PR DESCRIPTION
The bug that happened in iOS 13 was:
It had one of the two polyfills but not the other. So the promise would never resolve correctly.