### PR TITLE
Update props for Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Types for `Link` props
+
 ## [8.87.0] - 2019-12-26
 
 ## [8.86.1] - 2019-12-23

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -17,7 +17,8 @@ const isTelephoneUrl = (url: string) => telephoneRegex.test(url)
 const isMailToUrl = (url: string) => mailToRegex.test(url)
 
 interface Props extends NavigateOptions {
-  onClick: (event: React.MouseEvent) => void
+  onClick?: (event: React.MouseEvent) => void
+  className?: string
 }
 
 const Link: React.FunctionComponent<Props> = ({

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -295,13 +295,15 @@ export function navigate(
   }
 
   navigationRoute.path = navigationRootPath(navigationRoute.path, rootPath)
-  for (const modifier of modifiers) {
-    const { path, query: fixedQuery } = modifier({
-      path: navigationRoute.path,
-      query,
-    })
-    navigationRoute.path = path || navigationRoute.path
-    query = fixedQuery || query
+  if (modifiers) {
+    for (const modifier of modifiers) {
+      const { path, query: fixedQuery } = modifier({
+        path: navigationRoute.path,
+        query,
+      })
+      navigationRoute.path = path || navigationRoute.path
+      query = fixedQuery || query
+    }
   }
 
   if (history) {
@@ -485,7 +487,7 @@ export interface NavigateOptions {
   replace?: boolean
   fetchPage?: boolean
   rootPath?: string
-  modifiers: Set<NavigationRouteModifier>
+  modifiers?: Set<NavigationRouteModifier>
 }
 
 export interface NavigationRouteChange {


### PR DESCRIPTION
When using the `<Link />` component, one usually makes a link to a specific page by simply stating:
```jsx
<Link
    page={linkprops.page}
    query={linkprops.querystring}
    params={linkprops.params}
    className="c-on-base f5 ml-auto db no-underline pv4 ph5 hover-bg-muted-4"
>
   {option.label}
</Link>
```
As stated in this project's README.

However, when importing `Link` together with its types, one discovers that `onClick` and `modifiers` are required Link props, when in reality they never were. This proposed change, therefore, intends to fix the `Link`'s props types.

To test, visit [this link](https://test--sandboxintegracao.myvtex.com/admin/sellers) and click on the `Add Seller` link on the top right corner. It should cause a navigation to a new page as usual