### PR TITLE
Fix/page remount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent current page remount when performing a navigation
 
 ## [8.87.2] - 2019-12-26
 ### Fixed

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -198,7 +198,7 @@ const ExtensionPoint: FC<Props> = props => {
   // need a loading animation.
   return renderStrategy === 'client' && !runtime.amp ? (
     <NoSSR onSSR={<Loading />}>
-      {runtime.preview && !runtime.amp && <LoadingBar />}
+      {runtime.preview && isRootTreePath && <LoadingBar />}
       {extensionPointComponent}
     </NoSSR>
   ) : (

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -196,13 +196,18 @@ const ExtensionPoint: FC<Props> = props => {
   //
   // "lazy" components might never be used, so they don't necessarily
   // need a loading animation.
-  return renderStrategy === 'client' && !runtime.amp ? (
-    <NoSSR onSSR={<Loading />}>
+  return (
+    <Fragment>
       {runtime.preview && isRootTreePath && <LoadingBar />}
-      {extensionPointComponent}
-    </NoSSR>
-  ) : (
-    extensionPointComponent
+      {renderStrategy === 'client' && !runtime.amp ? (
+        <NoSSR onSSR={<Loading />}>
+          {runtime.preview && <LoadingBar />}
+          {extensionPointComponent}
+        </NoSSR>
+      ) : (
+        extensionPointComponent
+      )}
+    </Fragment>
   )
 }
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -200,10 +200,7 @@ const ExtensionPoint: FC<Props> = props => {
     <Fragment>
       {runtime.preview && isRootTreePath && <LoadingBar />}
       {renderStrategy === 'client' && !runtime.amp ? (
-        <NoSSR onSSR={<Loading />}>
-          {runtime.preview && <LoadingBar />}
-          {extensionPointComponent}
-        </NoSSR>
+        <NoSSR onSSR={<Loading />}>{extensionPointComponent}</NoSSR>
       ) : (
         extensionPointComponent
       )}

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -191,22 +191,16 @@ const ExtensionPoint: FC<Props> = props => {
     </ExtensionPointComponent>
   )
 
-  if (runtime.preview && isRootTreePath) {
-    return (
-      <Fragment>
-        <LoadingBar />
-        {extensionPointComponent}
-      </Fragment>
-    )
-  }
-
   // "client" component assets are sent to server side rendering,
   // but they should display a loading animation.
   //
   // "lazy" components might never be used, so they don't necessarily
   // need a loading animation.
   return renderStrategy === 'client' && !runtime.amp ? (
-    <NoSSR onSSR={<Loading />}>{extensionPointComponent}</NoSSR>
+    <NoSSR onSSR={<Loading />}>
+      {runtime.preview && !runtime.amp && <LoadingBar />}
+      {extensionPointComponent}
+    </NoSSR>
   ) : (
     extensionPointComponent
   )


### PR DESCRIPTION
Related to https://app.clubhouse.io/vtex/story/28702/admin-quando-navega-p%C3%A1gina-recarrega

Clicking in an item of a list perforrm an entire page remount (including queries and stuff). This changes do almost the same as before, but is more clever when rendering the loading bar.

https://augusto--mystore.mygocommerce.com/admin/catalog/products
https://augusto--storecomponents.myvtex.com/admin/apps/