### PR TITLE
Fix/page remount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where page wouldn't remount if params changed within the same page.
 
 ## [8.91.2] - 2020-02-17
 ### Fixed

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -15,6 +15,17 @@ const RenderPage: FC<Props> = props => {
     route: { params },
   } = runtime
 
+  let paramsString = ''
+
+  try {
+    paramsString = JSON.stringify(params)
+  } catch (e) {
+    console.warn(
+      "Unable to stringify params for page. This shouldn't be much of a problem, but might prevent components from being reset on page change. The params object is as follows:",
+      params
+    )
+  }
+
   return (
     <MaybeContext
       nestedPage={page}
@@ -23,7 +34,7 @@ const RenderPage: FC<Props> = props => {
       runtime={runtime}
     >
       <ExtensionPoint
-        key={`${page}/${JSON.stringify(params)}`}
+        key={`${page}/${paramsString}`}
         id={page}
         query={query}
         params={params}

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import ExtensionPoint from './ExtensionPoint'
 import MaybeContext from './MaybeContext'
 import { useRuntime } from './RenderContext'
@@ -22,7 +22,13 @@ const RenderPage: FC<Props> = props => {
       params={params}
       runtime={runtime}
     >
-      <ExtensionPoint id={page} query={query} params={params} {...props} />
+      <ExtensionPoint
+        key={`${page}/${JSON.stringify(params)}`}
+        id={page}
+        query={query}
+        params={params}
+        {...props}
+      />
     </MaybeContext>
   )
 }

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC } from 'react'
 import ExtensionPoint from './ExtensionPoint'
 import MaybeContext from './MaybeContext'
 import { useRuntime } from './RenderContext'


### PR DESCRIPTION
Fixes issue where page wouldn't remount if params changed within the same page.

To see the difference, go to https://redoxx.myvtex.com/ on mobile mode, click on the menu, click on a "Bags" item, and then do the same to another item. Notice that the drawer stays open.

![Kapture 2020-01-09 at 19 38 45](https://user-images.githubusercontent.com/5691711/72107044-51e96e00-330f-11ea-80d7-d665024d57bb.gif)

Compare with https://lbebber--redoxx.myvtex.com/, where doing the same closes the drawer, as it should.

![Kapture 2020-01-09 at 19 36 13](https://user-images.githubusercontent.com/5691711/72106912-09ca4b80-330f-11ea-96a8-aedcb4de0fc3.gif)

https://pageremount--boticario.myvtex.com/
https://pageremount--alssports.myvtex.com/