### PR TITLE
Modify unlisten to intercept page transitions

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -310,21 +310,20 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           return this.onPageChanged(location)
         }
 
-        const hasUnsaveData = this.callbacks
-          .map((callback: () => boolean) => callback())
-          .some(Boolean)
-
-        if (
-          hasUnsaveData &&
-          window.confirm('Are you sure you want to leave?')
-        ) {
-          this.hasGoBack = false
-          this.onPageChanged(location)
-        } else {
-          history.goBack()
-          this.hasGoBack = true
+        if (!isEmpty(this.callbacks)) {
+          this.callbacks.forEach((fn: any) => {
+            if (fn()) {
+              history.goBack()
+              this.hasGoBack = true
+            } else {
+              this.hasGoBack = false
+              this.onPageChanged(location)
+            }
+          })
         }
       })
+
+    emitter.addListener('localesChanged', this.onLocaleSelected)
 
     if (!production) {
       emitter.addListener('extensionsUpdated', this.updateRuntime)

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -235,6 +235,7 @@ declare global {
     updateExtension: (name: string, extension: Extension) => Promise<void>
     updateRuntime: (options?: PageContextOptions) => Promise<void>
     workspace: RenderRuntime['workspace']
+    registerCallback: RenderRuntime['registerCallback']
   }
 
   interface PageContextOptions {
@@ -469,6 +470,8 @@ declare global {
       variables: any
       data: string
     }>
+
+    registerCallback?: (callback: () => boolean) => any
   }
 
   interface CacheHints {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -471,7 +471,7 @@ declare global {
       data: string
     }>
 
-    registerCallback?: (callback: () => boolean) => any
+    registerCallback?: (id: string, callback: () => boolean) => any
   }
 
   interface CacheHints {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says. 

<!--- What is the motivation and context for this change? -->
#### What problem is this solving?
Add logic to register callbacks and intercept page transitions in cases we need to prevent user from navigating page when they are entering some data that can be lost.

#### How should this be manually tested?
1. [Access](https://mariana--storecomponents.myvtex.com/admin/collections).
2. Pick a collection.
3. Edit the collection and try to leave the page.

#### Screenshots or example usage
![draft](https://user-images.githubusercontent.com/20481790/71205352-f7657080-2280-11ea-965e-5bd3150a7890.gif)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
