### PR TITLE
Unify compositions

### DIFF
--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -31,25 +31,28 @@ function getChildExtensions(runtime: RenderContext, treePath: string) {
   const extension = runtime.extensions && runtime.extensions[treePath]
 
   if (!extension || !extension.blocks) {
-    return
+    return []
   }
 
-  return extension.blocks.map((child, i) => {
-    const childTreePath = mountTreePath(child.extensionPointId, treePath)
+  // This filter condition is for backwards compatibility
+  return extension.blocks
+    .filter(block => block.children !== false)
+    .map((child, i) => {
+      const childTreePath = mountTreePath(child.extensionPointId, treePath)
 
-    const childExtension =
-      runtime.extensions && runtime.extensions[childTreePath]
-    const childProps = childExtension ? childExtension.props : {}
+      const childExtension =
+        runtime.extensions && runtime.extensions[childTreePath]
+      const childProps = childExtension ? childExtension.props : {}
 
-    return (
-      <ExtensionPoint
-        key={`around-${treePath}-${i}`}
-        id={child.extensionPointId}
-        blockProps={childProps}
-        treePath={treePath}
-      />
-    )
-  })
+      return (
+        <ExtensionPoint
+          key={`around-${treePath}-${i}`}
+          id={child.extensionPointId}
+          blockProps={childProps}
+          treePath={treePath}
+        />
+      )
+    })
 }
 
 function withOuterExtensions(
@@ -161,10 +164,19 @@ const ExtensionPoint: FC<Props> = props => {
   const isCompositionChildren =
     extension && extension.composition === 'children'
 
-  const componentChildren =
-    isCompositionChildren && extension.blocks
-      ? getChildExtensions(runtime, newTreePath)
-      : children
+  let componentChildren = null
+
+  if (isCompositionChildren) {
+    componentChildren =
+      extension.blocks && extension.blocks.length > 0
+        ? getChildExtensions(runtime, newTreePath)
+        : children
+  } else {
+    componentChildren =
+      extension.blocks && extension.blocks.length > 0
+        ? [...getChildExtensions(runtime, newTreePath), children]
+        : children
+  }
 
   const isRootTreePath = newTreePath.indexOf('/') === -1
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -164,18 +164,12 @@ const ExtensionPoint: FC<Props> = props => {
   const isCompositionChildren =
     extension && extension.composition === 'children'
 
-  let componentChildren = null
+  let componentChildren = children
 
-  if (isCompositionChildren) {
-    componentChildren =
-      extension.blocks && extension.blocks.length > 0
-        ? getChildExtensions(runtime, newTreePath)
-        : children
-  } else {
-    componentChildren =
-      extension.blocks && extension.blocks.length > 0
-        ? [...getChildExtensions(runtime, newTreePath), children]
-        : children
+  if (extension.blocks && extension.blocks.length > 0) {
+    componentChildren = isCompositionChildren
+      ? getChildExtensions(runtime, newTreePath)
+      : [...getChildExtensions(runtime, newTreePath), children]
   }
 
   const isRootTreePath = newTreePath.indexOf('/') === -1

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -169,13 +169,16 @@ const ExtensionPoint: FC<Props> = props => {
   if (extension.blocks && extension.blocks.length > 0) {
     // This is for backwards compatibility with apps that were built before
     // https://github.com/vtex/builder-hub/pull/856
-    const hasOldChildrenBlocks =
-      isCompositionChildren &&
-      !extension.blocks.some(block => 'children' in block)
+    const hasBeenRebuilt = extension.blocks.some(block => 'children' in block)
 
-    componentChildren = hasOldChildrenBlocks
-      ? getChildExtensions(runtime, newTreePath)
-      : [...getChildExtensions(runtime, newTreePath), children]
+    if (hasBeenRebuilt) {
+      componentChildren = [
+        ...getChildExtensions(runtime, newTreePath),
+        children,
+      ]
+    } else if (isCompositionChildren) {
+      componentChildren = getChildExtensions(runtime, newTreePath)
+    }
   }
 
   const isRootTreePath = newTreePath.indexOf('/') === -1

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -167,7 +167,13 @@ const ExtensionPoint: FC<Props> = props => {
   let componentChildren = children
 
   if (extension.blocks && extension.blocks.length > 0) {
-    componentChildren = isCompositionChildren
+    // This is for backwards compatibility with apps that were built before
+    // https://github.com/vtex/builder-hub/pull/856
+    const hasOldChildrenBlocks =
+      isCompositionChildren &&
+      !extension.blocks.some(block => 'children' in block)
+
+    componentChildren = hasOldChildrenBlocks
       ? getChildExtensions(runtime, newTreePath)
       : [...getChildExtensions(runtime, newTreePath), children]
   }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -64,6 +64,7 @@ declare global {
   interface BlockInsertion {
     extensionPointId: string
     blockId: string
+    children?: boolean
   }
 
   interface Extension {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adapt `render-runtime` to the changes made in `pages@1.x` builder by https://github.com/vtex/builder-hub/pull/856 . This means handling the fact that newly built interfaces are always `composition: 'blocks'` but we still support `children` being passed to blocks since we support both at the same time.

#### How should this be manually tested?

Tested in the following accounts:

- [Store Components](https://killallowed--storecomponents.myvtex.com/)
- [Footnotes](https://killallowed--footnotes.myvtex.com/)
- [Eriks Bikes](https://killallowed--eriksbikeshop.myvtex.com/)
- [Texas Boots](https://killallowed--txboot.myvtex.com/)
- [Motorola ES](https://killallowed--motorolaes.myvtex.com/) (They have a bug with their logo not showing up, not caused by this version of `render-runtime`)
- [Bisco Ind.](https://killallowed--biscoind.myvtex.com/)
- [Redoxx](https://killallowed--redoxx.myvtex.com/)
- [Gympass BR](https://killallowed--gympassbr.myvtex.com)
- [Admit One](https://killallowed--admitone.myvtex.com/)
- [Carulla](https://killallowed--carulla.myvtex.com/)
- [PagueMenos](https://killallowed--paguemenos.myvtex.com/)
- [Boticário](https://runtimetest--boticario.myvtex.com/)
- [TBB](https://runtimetest--tbb.myvtex.com/)
- [Parque Dom Pedro](https://victormiranda--parquedpedro.myvtex.com/)
- [Samsung AR](https://victormiranda--samsungar.myvtex.com/)
- [Eco Water](https://victormiranda--ecowaterqa.myvtex.com/)
- [Motorola UK](https://victormiranda--motorolauk.myvtex.com/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.