### PR TITLE
Fix broken rendering with undefined children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Returning an array with `undefined` to be rendered with apps that were rebuilt.
 
 ## [8.90.0] - 2020-01-23
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -164,7 +164,7 @@ const ExtensionPoint: FC<Props> = props => {
   const isCompositionChildren =
     extension && extension.composition === 'children'
 
-  let componentChildren = children
+  let componentChildren: any = children
 
   if (extension.blocks && extension.blocks.length > 0) {
     // This is for backwards compatibility with apps that were built before
@@ -174,8 +174,11 @@ const ExtensionPoint: FC<Props> = props => {
     if (hasBeenRebuilt) {
       componentChildren = [
         ...getChildExtensions(runtime, newTreePath),
-        children || [],
+        ...(children ? [children] : []),
       ]
+      if (componentChildren.length === 0 && children === undefined) {
+        componentChildren = undefined
+      }
     } else if (isCompositionChildren) {
       componentChildren = getChildExtensions(runtime, newTreePath)
     }

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -31,12 +31,12 @@ function getChildExtensions(runtime: RenderContext, treePath: string) {
   const extension = runtime.extensions && runtime.extensions[treePath]
 
   if (!extension || !extension.blocks) {
-    return []
+    return
   }
 
   // This filter condition is for backwards compatibility
   return extension.blocks
-    .filter(block => block.children !== false)
+    .filter(block => block.children === undefined || block.children === true)
     .map((child, i) => {
       const childTreePath = mountTreePath(child.extensionPointId, treePath)
 
@@ -164,25 +164,10 @@ const ExtensionPoint: FC<Props> = props => {
   const isCompositionChildren =
     extension && extension.composition === 'children'
 
-  let componentChildren: any = children
-
-  if (extension.blocks && extension.blocks.length > 0) {
-    // This is for backwards compatibility with apps that were built before
-    // https://github.com/vtex/builder-hub/pull/856
-    const hasBeenRebuilt = extension.blocks.some(block => 'children' in block)
-
-    if (hasBeenRebuilt) {
-      componentChildren = [
-        ...getChildExtensions(runtime, newTreePath),
-        ...(children ? [children] : []),
-      ]
-      if (componentChildren.length === 0 && children === undefined) {
-        componentChildren = undefined
-      }
-    } else if (isCompositionChildren) {
-      componentChildren = getChildExtensions(runtime, newTreePath)
-    }
-  }
+  const componentChildren =
+    isCompositionChildren && extension.blocks
+      ? getChildExtensions(runtime, newTreePath)
+      : children
 
   const isRootTreePath = newTreePath.indexOf('/') === -1
 

--- a/react/components/ExtensionPoint.tsx
+++ b/react/components/ExtensionPoint.tsx
@@ -174,7 +174,7 @@ const ExtensionPoint: FC<Props> = props => {
     if (hasBeenRebuilt) {
       componentChildren = [
         ...getChildExtensions(runtime, newTreePath),
-        children,
+        children || [],
       ]
     } else if (isCompositionChildren) {
       componentChildren = getChildExtensions(runtime, newTreePath)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix rendering of children when it is `undefined`. This could cause an issue with components that use `React.cloneElement()`, as `undefined` could be passed to it.

#### How should this be manually tested?

The `vtex.tab-layout` was not being rendered properly after a build.

- [tack of the day](https://tack--tackoftheday.myvtex.com/)
- [Store Components](https://minicartchildren--storecomponents.myvtex.com/)
- [Boticário](https://runtimetest--boticario.myvtex.com/)
- [TBB](https://runtimetest--tbb.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.