### PR TITLE
Allowing the `extensions` argument to be optional on `fetchComponents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allowing the `extensions` argument from `fetchComponents` to be optional.
+- Exposing the `fetchComponents` function to the RenderProvider.
 
 ## [8.90.1] - 2020-01-24
 ### Fixed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -767,12 +767,14 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     extensions?: RenderRuntime['extensions']
   ) => {
     const { runtime } = this.props
+    // In order for only fetching `components`, we create corresponding extensions
+    // for them if they weren't passed
     if (!extensions) {
       const componentsNames = Object.keys(components)
-      extensions = componentsNames.reduce(
-        (acc, component) => ({ ...acc, [component]: { component } }),
-        {}
-      ) as RenderRuntime['extensions']
+      extensions = componentsNames.reduce((acc, component) => {
+        acc[component] = { component }
+        return acc
+      }, {} as RenderRuntime['extensions'])
     }
     const componentsToDownload = Object.values(extensions).reduce<string[]>(
       (acc, extension) => {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -126,6 +126,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     ensureSession: PropTypes.func,
     extensions: PropTypes.object,
     fetchComponent: PropTypes.func,
+    fetchComponents: PropTypes.func,
     getSettings: PropTypes.func,
     goBack: PropTypes.func,
     hints: PropTypes.object,
@@ -379,6 +380,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       ensureSession: this.ensureSession,
       extensions,
       fetchComponent: this.fetchComponent,
+      fetchComponents: this.fetchComponents,
       getSettings: this.getSettings,
       goBack: this.goBack,
       hints,
@@ -762,9 +764,16 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
   public fetchComponents = async (
     components: RenderRuntime['components'],
-    extensions: RenderRuntime['extensions']
+    extensions?: RenderRuntime['extensions']
   ) => {
     const { runtime } = this.props
+    if (!extensions) {
+      const componentsNames = Object.keys(components)
+      extensions = componentsNames.reduce(
+        (acc, component) => ({ ...acc, [component]: { component } }),
+        {}
+      ) as RenderRuntime['extensions']
+    }
     const componentsToDownload = Object.values(extensions).reduce<string[]>(
       (acc, extension) => {
         if (extension.render === 'lazy') {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -207,6 +207,10 @@ declare global {
     ensureSession: () => Promise<void>
     extensions: RenderRuntime['extensions']
     fetchComponent: (component: string) => Promise<void>
+    fetchComponents: (
+      components: RenderRuntime['components'],
+      extensions?: RenderRuntime['extensions']
+    ) => Promise<void>
     getSettings: (app: string) => any
     goBack: () => void
     hints: RenderHints


### PR DESCRIPTION
Related to [this PR on pages-graphql](https://github.com/vtex/pages-graphql/pull/336).

**Big Picture**: Tech Solutions Internship project by Júlia Rocha to automatically generate documentation for Store Framework components

- **exposes the `fetchComponents`:** For her project to fetch some component implementation, we have to expose the `fetchComponents` functions to the `RenderProvider`, so she can import it from `useRuntime()`.
- **`extensions` argument to be optional:** The `fetchComponents` function has on its interface two arguments: _components_ and _extensions_. We only care about fetching a specific set of components, and those are not coupled with _extensions_, so, if only components are provided, I "mock" an `extensions` object that will match all provided components. I've chosen this approach to avoid entropy on the method implementation.