### PR TITLE
Add replace prop to the Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `replace` prop to the `Link` component.
 
 ## [8.90.1] - 2020-01-24
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ You can pass a handful of configuration props to navigate:
 | params | `object`      |   `{}`  | Map of _parameters_ names in the path for the page and the values that should replace them. Example: `{slug: 'shirt'}`
 | query | `string`  | `''`   | String representation of the query params that will be appended to the path. Example: `skuId=231`.
 | scrollOptions | `RenderScrollOptions` | -- | After the navigation, if the page should be scrolled to a specific position, or should stay still (use `false`)
+| replace | `boolean` | `undefined` | If it should call the replace function to navigate or not
 #### Example
 ```javascript
 navigate({
@@ -107,6 +108,7 @@ Link is a custom React component that renders an `a` HTML element that, when cli
 | params | `object`      |   `{}`  | Map of _param_ names in the path for the page and the values that should replace them. Example: `{slug: 'shirt'}`
 | query | `string`  | `''`   | String representation of the query params that will be appended to the path. Example: `skuId=231`.
 | onClick | `function` | -- | Callback that will be fired when the user click on the Component. Example: `() => alert('Salut')`
+| replace | `boolean` | `undefined` | If it should call the replace function to navigate or not
 
 Other props you pass will be forwarded to the `a` component and can be used for customisation.
 

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -30,6 +30,7 @@ const Link: React.FunctionComponent<Props> = ({
   query,
   children,
   modifiers,
+  replace,
   ...linkProps
 }) => {
   const {
@@ -60,6 +61,7 @@ const Link: React.FunctionComponent<Props> = ({
         scrollOptions,
         to,
         modifiers,
+        replace,
       }
       if (navigate(options)) {
         event.preventDefault()
@@ -75,6 +77,7 @@ const Link: React.FunctionComponent<Props> = ({
       scrollOptions,
       modifiers,
       navigate,
+      replace,
     ]
   )
 


### PR DESCRIPTION
The `Link` component could receive that prop already because his props extend the `NavigationOptions`, but it wasn't doing anything with it.