### PR TITLE
Feature/prevent replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prevent running `history.replace` on hydration if it's not needed, improving performance slightly.
 
 ## [8.90.3] - 2020-02-03
 ### Added

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -56,6 +56,7 @@ import { RenderContextProvider } from './RenderContext'
 import RenderPage from './RenderPage'
 import { appendLocationSearch } from '../utils/location'
 import { setCookie } from '../utils/cookie'
+import { isEqual } from 'apollo-utilities'
 
 interface Props {
   children: ReactElement<any> | null
@@ -241,7 +242,9 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           renderRouting: true,
         },
       }
-      history.replace(renderLocation)
+      if (!isEqual(history.location, renderLocation)) {
+        history.replace(renderLocation)
+      }
       // backwards compatibility
       window.browserHistory = global.browserHistory = history
     }

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -241,7 +241,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           renderRouting: true,
         },
       }
-      if (!equals(history.location, renderLocation)) {
+      if (!equals(history.location as RenderHistoryLocation, renderLocation)) {
         history.replace(renderLocation)
       }
       // backwards compatibility

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -56,7 +56,6 @@ import { RenderContextProvider } from './RenderContext'
 import RenderPage from './RenderPage'
 import { appendLocationSearch } from '../utils/location'
 import { setCookie } from '../utils/cookie'
-import { isEqual } from 'apollo-utilities'
 
 interface Props {
   children: ReactElement<any> | null
@@ -242,7 +241,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           renderRouting: true,
         },
       }
-      if (!isEqual(history.location, renderLocation)) {
+      if (!equals(history.location, renderLocation)) {
         history.replace(renderLocation)
       }
       // backwards compatibility

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -241,6 +241,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           renderRouting: true,
         },
       }
+      // TODO: use something with better performance than equals
       if (!equals(history.location as RenderHistoryLocation, renderLocation)) {
         history.replace(renderLocation)
       }


### PR DESCRIPTION
Prevent running `history.replace` on hydration if it's not needed, improving performance slightly.

Before
<img width="440" alt="Screen Shot 2020-01-31 at 16 19 43" src="https://user-images.githubusercontent.com/5691711/73567934-25280280-4446-11ea-91f1-4b4a615d103f.png">


After:
<img width="305" alt="Screen Shot 2020-01-31 at 16 21 19" src="https://user-images.githubusercontent.com/5691711/73567915-1fcab800-4446-11ea-83df-57b4cf4bb89c.png">
