### PR TITLE
Remove ReactDOMServer from client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lazy loads ReactDOMServer on server only, preventing from being loaded on the client.
 
 ## [8.91.0] - 2020-02-06
 

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -138,8 +138,9 @@ const render = async (
     return (renderFn(root, elem) as unknown) as Element
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { renderToStaticMarkup, renderToString } = require('react-dom/server')
+  const ReactDOMServer = await import('react-dom/server')
+
+  const { renderToStaticMarkup, renderToString } = ReactDOMServer.default
 
   const commonRenderResult = {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/react/externals.json
+++ b/react/externals.json
@@ -48,6 +48,10 @@
       },
       {
         "clientOnly": true,
+        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
+      },
+      {
+        "clientOnly": true,
         "path": "npm:fg-loadcss@2.1.0/dist/cssrelpreload.min.js"
       },
       {
@@ -111,6 +115,10 @@
       {
         "path": "npm:intl@1.2.5/dist/Intl.min.js",
         "serverOnly": true
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
       },
       {
         "clientOnly": true,

--- a/react/externals.json
+++ b/react/externals.json
@@ -28,11 +28,6 @@
         "path": "npm:react-dom@16.9.0/umd/react-dom.development.js"
       },
       {
-        "global": "ReactDOMServer",
-        "import": "react-dom/server",
-        "path": "npm:react-dom@16.9.0/umd/react-dom-server.browser.development.js"
-      },
-      {
         "global": "ReactIntl",
         "import": "react-intl",
         "path": "npm:react-intl@3.9.1/dist/react-intl.js"
@@ -43,11 +38,6 @@
         "path": "npm:history@4.7.2/umd/history.js"
       },
       {
-        "global": "Sentry",
-        "import": "@sentry/browser",
-        "path": "npm:@sentry/browser@4.4.1/build/bundle.js"
-      },
-      {
         "global": "R",
         "import": "ramda",
         "path": "npm:ramda@0.26.1/dist/ramda.js"
@@ -55,10 +45,6 @@
       {
         "path": "npm:intl@1.2.5/dist/Intl.js",
         "serverOnly": true
-      },
-      {
-        "clientOnly": true,
-        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
       },
       {
         "clientOnly": true,
@@ -108,11 +94,6 @@
         "path": "npm:react-dom@16.9.0/umd/react-dom.production.min.js"
       },
       {
-        "global": "ReactDOMServer",
-        "import": "react-dom/server",
-        "path": "npm:react-dom@16.9.0/umd/react-dom-server.browser.production.min.js"
-      },
-      {
         "global": "ReactIntl",
         "import": "react-intl",
         "path": "npm:react-intl@3.9.1/dist/react-intl.min.js"
@@ -123,11 +104,6 @@
         "path": "npm:history@4.7.2/umd/history.min.js"
       },
       {
-        "global": "Sentry",
-        "import": "@sentry/browser",
-        "path": "npm:@sentry/browser@4.4.1/build/bundle.min.js"
-      },
-      {
         "global": "R",
         "import": "ramda",
         "path": "npm:ramda@0.26.1/dist/ramda.min.js"
@@ -135,10 +111,6 @@
       {
         "path": "npm:intl@1.2.5/dist/Intl.min.js",
         "serverOnly": true
-      },
-      {
-        "clientOnly": true,
-        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
       },
       {
         "clientOnly": true,

--- a/react/package.json
+++ b/react/package.json
@@ -29,6 +29,7 @@
     "ramda": "^0.26.1",
     "react-amphtml": "^4.0.2",
     "react-apollo": "^3.1.2",
+    "react-dom": "16.9.0",
     "react-helmet": "^5.2.0",
     "react-json-view": "^1.19.1",
     "route-parser": "^0.0.5"
@@ -70,7 +71,6 @@
     "lint-staged": "^8.0.4",
     "prettier": "^1.19.1",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-hot-loader": "^4.3.12",
     "react-intl": "^3.9.1",
     "react-no-ssr": "^1.1.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6853,15 +6853,15 @@ react-base16-styling@^0.6.0:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-dom@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+react-dom@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.15.0"
 
 react-dom@^16.9.0:
   version "16.12.0"
@@ -7397,6 +7397,14 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Lazy-loads ReactDOMServer when necessary, instead of always loading it on the client

Depends on https://github.com/vtex/builder-hub/pull/889

https://domserver--storecomponents.myvtex.com/