### PR TITLE
Enable registering components lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Enable registering components lazily.
 
 ## [8.111.0] - 2020-07-08
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -9,6 +9,7 @@ import { createReactIntl } from './utils/reactIntl'
 import { createCustomReactApollo } from './utils/reactApollo'
 import { fetchUncriticalStyles, UncriticalStyle } from './utils/assets'
 
+window.__RENDER_LAZY__ = true
 window.__RENDER_8_RUNTIME__ = { ...runtimeGlobals }
 
 // compatibility

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -9,7 +9,6 @@ import { createReactIntl } from './utils/reactIntl'
 import { createCustomReactApollo } from './utils/reactApollo'
 import { fetchUncriticalStyles, UncriticalStyle } from './utils/assets'
 
-window.__RENDER_LAZY__ = true
 window.__RENDER_8_RUNTIME__ = { ...runtimeGlobals }
 
 // compatibility

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -176,8 +176,14 @@ if (window.__RUNTIME__.start && !window.__ERROR__) {
       window.addEventListener('DOMContentLoaded', resolve)
     )
 
+    const asyncReadyPromise = window.__ASYNC_READY__ || Promise.resolve()
+
     const resolveUncriticalPromise = createUncriticalPromise()
-    Promise.all([contentLoadedPromise, intlPolyfillPromise]).then(() => {
+    Promise.all([
+      asyncReadyPromise,
+      contentLoadedPromise,
+      intlPolyfillPromise,
+    ]).then(() => {
       setTimeout(() => {
         window?.performance?.mark?.('render-start')
         window.__RENDER_8_RUNTIME__.start()

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -567,8 +567,6 @@ declare global {
     __RENDER_8_HOT__: HotEmitterRegistry
     __RENDER_8_RUNTIME__: RuntimeExports
     __RENDER_8_SESSION__: RenderSession
-    __RENDER_LAZY__: boolean
-
     __REQUEST_ID__: string
     __RUNTIME__: RenderRuntime
     __STATE__: NormalizedCacheObject

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -563,6 +563,7 @@ declare global {
       shouldUpdateRuntime: boolean,
       setMessages: (messages: RenderRuntime['messages']) => void
     ) => Promise<void>
+    __ASYNC_READY__: Promise<void>
     __RENDER_8_COMPONENTS__: ComponentsRegistry
     __RENDER_8_HOT__: HotEmitterRegistry
     __RENDER_8_RUNTIME__: RuntimeExports

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -567,6 +567,8 @@ declare global {
     __RENDER_8_HOT__: HotEmitterRegistry
     __RENDER_8_RUNTIME__: RuntimeExports
     __RENDER_8_SESSION__: RenderSession
+    __RENDER_LAZY__: boolean
+
     __REQUEST_ID__: string
     __RUNTIME__: RenderRuntime
     __STATE__: NormalizedCacheObject

--- a/react/utils/registerComponent.tsx
+++ b/react/utils/registerComponent.tsx
@@ -71,7 +71,7 @@ export default (
     implementer = maybeWrapWithHMR(module, evaluatedImplementer)
   }
 
-  locators.forEach(locator => {
+  locators.forEach((locator) => {
     if (window.__RENDER_8_COMPONENTS__[locator]) {
       return
     }
@@ -87,7 +87,7 @@ export default (
           }
 
           const evaluatedImplementer = implementer()
-          locators.forEach(eachLocator => {
+          locators.forEach((eachLocator) => {
             loadedComponents[eachLocator] = {
               implementer: evaluatedImplementer,
             }


### PR DESCRIPTION
Currently, when registering a component depending on another one by importing it, like `import { AnotherComp } from 'vendor.anotherApp'`, the `AnotherComp` assets must come and run synchronously before the dependant one. Otherwise everything explodes. 💥 

With this PR (and some render-server magic ✨ ) we can have async scripts.