### PR TITLE
Feature/lazy images fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ExperimentalLazyImages` component
+- Support for `__fold__.experimentalLazyImages` block.
 
 ## [8.92.0] - 2020-02-19
 ### Added

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -4,6 +4,7 @@ import { useTreePath } from '../utils/treePath'
 import ExtensionPoint from './ExtensionPoint'
 import { useRuntime } from './RenderContext'
 import { LoadingWrapper } from './LoadingContext'
+import { LazyImages } from './LazyImages'
 
 type Element = string | ElementArray
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -96,13 +97,17 @@ class Container extends Component<ContainerProps, ContainerState> {
     const hasFold = foldIndex > -1
 
     if (hasFold && !shouldRenderBelowTheFold) {
-      elementsToRender = foldIndex + 1
+      elementsToRender = foldIndex
     }
+
+    const lazyImagesFoldPosition = elements.indexOf(
+      '__fold__.experimentalLazyImages'
+    )
 
     const returnValue: JSX.Element[] = elements
       .slice(0, elementsToRender)
-      .map((element: Element) => {
-        return (
+      .map((element: Element, i: number) => {
+        const container = (
           <Container
             key={element.toString()}
             elements={element}
@@ -113,6 +118,12 @@ class Container extends Component<ContainerProps, ContainerState> {
             {children}
           </Container>
         )
+
+        if (i < lazyImagesFoldPosition) {
+          return container
+        }
+
+        return <LazyImages key={element.toString()}>{container}</LazyImages>
       })
 
     return (

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -104,6 +104,8 @@ class Container extends Component<ContainerProps, ContainerState> {
       '__fold__.experimentalLazyImages'
     )
 
+    const hasLazyImagesFold = lazyImagesFoldPosition > -1
+
     const returnValue: JSX.Element[] = elements
       .slice(0, elementsToRender)
       .map((element: Element, i: number) => {
@@ -119,7 +121,7 @@ class Container extends Component<ContainerProps, ContainerState> {
           </Container>
         )
 
-        if (i < lazyImagesFoldPosition) {
+        if (!hasLazyImagesFold || i < lazyImagesFoldPosition) {
           return container
         }
 

--- a/react/components/LazyImages.css
+++ b/react/components/LazyImages.css
@@ -1,0 +1,3 @@
+.lazyload:global(.lazyload) {
+  opacity: 0;
+}

--- a/react/components/LazyImages.tsx
+++ b/react/components/LazyImages.tsx
@@ -1,0 +1,85 @@
+import React, { useContext, FC } from 'react'
+import styles from './LazyImages.css'
+
+interface LazyImagesContext {
+  lazyLoad: boolean
+  /** "native" uses the attribute "loading=lazy", which is good but only works
+   * on Chrome. lazysizes is a JS plugin already provided by render-runtime,
+   * with broader support, but the behaviour might be a little worse at times */
+  method: 'native' | 'lazysizes'
+}
+
+const LazyImagesContext = React.createContext<LazyImagesContext>({
+  lazyLoad: false,
+  method: 'native',
+})
+
+interface LazyImagesProps {
+  lazyLoad?: boolean
+  experimentalMethod?: LazyImagesContext['method']
+}
+
+const LazyImages: FC<LazyImagesProps> = ({
+  children,
+  lazyLoad = true,
+  experimentalMethod = 'native',
+}) => {
+  return (
+    <LazyImagesContext.Provider
+      value={{ lazyLoad, method: experimentalMethod }}
+    >
+      {children}
+    </LazyImagesContext.Provider>
+  )
+}
+
+const useLazyImages = () => {
+  const value = useContext(LazyImagesContext)
+
+  return value
+}
+
+interface MaybeLazyImageProps {
+  createElement: typeof React.createElement
+  imageProps: Record<string, any>
+}
+
+const MaybeLazyImage: FC<MaybeLazyImageProps> = ({
+  createElement = React.createElement,
+  imageProps,
+}) => {
+  const { lazyLoad, method } = useLazyImages()
+
+  if (lazyLoad) {
+    let newImageProps = imageProps
+
+    switch (method) {
+      case 'native':
+        newImageProps = {
+          ...imageProps,
+          loading: 'lazy',
+        }
+        break
+      case 'lazysizes':
+        /** adds `lazyload` class to enable lazysizes, and moves the image URI
+         * from src to data-src. `styles.lazyload` is used to hide the "broken image"
+         * symbol while the image hasn't been loaded */
+        newImageProps = {
+          ...imageProps,
+          className: `lazyload ${imageProps.className ?? ''} ${
+            styles.lazyload
+          }`,
+          src: undefined,
+          'data-src': imageProps.src,
+          loading: 'lazy',
+        }
+        break
+    }
+    return createElement.apply(React, ['img', newImageProps])
+  }
+
+  // Otherwise, just render the image
+  return createElement.apply(React, ['img', imageProps])
+}
+
+export { LazyImages, MaybeLazyImage }

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -15,8 +15,9 @@ import { getDataFromTree } from 'react-apollo'
 import { hydrate, render as renderDOM } from 'react-dom'
 import { Helmet } from 'react-helmet'
 import NoSSR, { useSSR } from '../components/NoSSR'
-import { isEmpty, prop } from 'ramda'
+import { isEmpty } from 'ramda'
 import Loading from '../components/Loading'
+import { MaybeLazyImage, LazyImages } from '../components/LazyImages'
 import { LoadingContextProvider } from '../components/LoadingContext'
 
 import { ChildBlock, useChildBlock } from '../components/ChildBlock'
@@ -243,13 +244,18 @@ function start() {
       }
 
       if (type === 'img') {
-        props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
-        if (
-          typeof props.src === 'string' &&
-          props.src.startsWith(vtexImgHost)
-        ) {
+        const { src } = props
+        props.src = optimizeSrcForVtexImg(vtexImgHost, src)
+        if (typeof src === 'string' && src.startsWith(vtexImgHost)) {
           props.crossOrigin = props.crossOrigin || 'anonymous'
         }
+        return ReactCreateElement.apply(React, [
+          MaybeLazyImage,
+          {
+            createElement: ReactCreateElement,
+            imageProps: props,
+          },
+        ])
       }
 
       if (props && props.style && isStyleWritable(props)) {
@@ -309,6 +315,7 @@ export {
   useSSR,
   RenderContextConsumer,
   TreePathContextConsumer,
+  LazyImages as ExperimentalLazyImages,
   canUseDOM,
   render,
   start,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -244,9 +244,11 @@ function start() {
       }
 
       if (type === 'img') {
-        const { src } = props
-        props.src = optimizeSrcForVtexImg(vtexImgHost, src)
-        if (typeof src === 'string' && src.startsWith(vtexImgHost)) {
+        props.src = optimizeSrcForVtexImg(vtexImgHost, props.src)
+        if (
+          typeof props.src === 'string' &&
+          props.src.startsWith(vtexImgHost)
+        ) {
           props.crossOrigin = props.crossOrigin || 'anonymous'
         }
         return ReactCreateElement.apply(React, [


### PR DESCRIPTION
Adds:
- `ExperimentalLazyImages` component
- Support for `__fold__.experimentalLazyImages` block.

Relies on https://github.com/vtex-apps/store/pull/424 for the block support

Workspace incoming