### PR TITLE
Fix prop target of link not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Link not working with `target` different from the default value.
+
 ## [8.91.3] - 2020-02-18 [YANKED]
 ### Fixed
 - Issue where page wouldn't remount if params changed within the same page.

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -19,6 +19,7 @@ const isMailToUrl = (url: string) => mailToRegex.test(url)
 interface Props extends NavigateOptions {
   onClick?: (event: React.MouseEvent) => void
   className?: string
+  target?: string
 }
 
 const Link: React.FunctionComponent<Props> = ({
@@ -32,6 +33,7 @@ const Link: React.FunctionComponent<Props> = ({
   modifiers,
   replace,
   modifiersOptions,
+  target,
   ...linkProps
 }) => {
   const {
@@ -65,7 +67,10 @@ const Link: React.FunctionComponent<Props> = ({
         replace,
         modifiersOptions,
       }
-      if (navigate(options)) {
+
+      // If you pass a target different from "_self" the component
+      // will behave just like a normal anchor element
+      if ((target === '_self' || !target) && navigate(options)) {
         event.preventDefault()
       }
     },
@@ -81,6 +86,7 @@ const Link: React.FunctionComponent<Props> = ({
       navigate,
       replace,
       modifiersOptions,
+      target,
     ]
   )
 
@@ -117,7 +123,12 @@ const Link: React.FunctionComponent<Props> = ({
       : href
 
   return (
-    <a href={hrefWithoutIframePrefix} {...linkProps} onClick={handleClick}>
+    <a
+      target={target}
+      href={hrefWithoutIframePrefix}
+      {...linkProps}
+      onClick={handleClick}
+    >
       {children}
     </a>
   )


### PR DESCRIPTION
The  `Link` component wasn't working properly when you try to use it with `target="_blank"`.

To test this you have to follow the steps:
1. Go to the [workspace](https://klynger--storecomponents.myvtex.com/)
2. Click on the `Quickview` text inside the `ProductSummary` to open the modal
3. Click on the `Mais Detalhes >` in the modal

To see the bug [access this workspace](https://linkbug--storecomponents.myvtex.com/) that doesn't have the changes and do the same steps
