### PR TITLE
Revert "Merge pull request #470 from vtex-apps/fix/page-remount"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [8.91.3] - 2020-02-18
+## [8.91.3] - 2020-02-18 [YANKED]
 ### Fixed
 - Issue where page wouldn't remount if params changed within the same page.
 

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -15,17 +15,6 @@ const RenderPage: FC<Props> = props => {
     route: { params },
   } = runtime
 
-  let paramsString = ''
-
-  try {
-    paramsString = JSON.stringify(params)
-  } catch (e) {
-    console.warn(
-      "Unable to stringify params for page. This shouldn't be much of a problem, but might prevent components from being reset on page change. The params object is as follows:",
-      params
-    )
-  }
-
   return (
     <MaybeContext
       nestedPage={page}
@@ -33,13 +22,7 @@ const RenderPage: FC<Props> = props => {
       params={params}
       runtime={runtime}
     >
-      <ExtensionPoint
-        key={`${page}/${paramsString}`}
-        id={page}
-        query={query}
-        params={params}
-        {...props}
-      />
+      <ExtensionPoint id={page} query={query} params={params} {...props} />
     </MaybeContext>
   )
 }


### PR DESCRIPTION
Reverts https://github.com/vtex-apps/render-runtime/pull/470, which was deprecated due to a bug on the admin.

A PR with the proper fix is incoming