### PR TITLE
Fix/page remount 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue caused by the page remount fix on admin pages, where it wouldn't update properly on client side rendering.
 
 ## [8.91.4] - 2020-02-19
 ### Fixed

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -15,6 +15,26 @@ const RenderPage: FC<Props> = props => {
     route: { params },
   } = runtime
 
+  /** Will use the params of the page as a key for the component, so React will
+   * unmount and remount it on page change. This is used to reset components
+   * to their initial state on page change, to better simulate how regular
+   * web pages work. */
+  let paramsString = ''
+
+  /** TODO: This is a quick fix--the admin, which runs on an iframe, doesn't play
+   * nice with unmounting/remounting. Should perhaps try and find a better solution
+   * for this issue. */
+  if (!page?.startsWith('admin.')) {
+    try {
+      paramsString = JSON.stringify(params)
+    } catch (e) {
+      console.warn(
+        "Unable to stringify params for page. This shouldn't be much of a problem, but might prevent components from being reset on page change. The params object is as follows:",
+        params
+      )
+    }
+  }
+
   return (
     <MaybeContext
       nestedPage={page}
@@ -22,7 +42,14 @@ const RenderPage: FC<Props> = props => {
       params={params}
       runtime={runtime}
     >
-      <ExtensionPoint id={page} query={query} params={params} {...props} />
+      <ExtensionPoint
+        // Key used to unmount/remount the component on page change.
+        key={`${page}/${paramsString}`}
+        id={page}
+        query={query}
+        params={params}
+        {...props}
+      />
     </MaybeContext>
   )
 }


### PR DESCRIPTION
Fixes issue caused by the page remount fix.

Previously it was causing issues when navigating on the admin. This makes an exception for the admin pages, preventing them from being remounted on navigation.

Continuation of https://github.com/vtex-apps/render-runtime/pull/470

https://remountdev--joythestore.myvtex.com/
https://remountdev--joythestore.myvtex.com/admin
https://remount--gc-lea7269.mygocommerce.com/admin

.