### PR TITLE
Fix/revert unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Revert page remounting temporarily (introduced in versions 8.91.3 and 8.91.5) due to bugs in edge cases.
 
 ## [8.93.0] - 2020-02-20
 ### Added

--- a/react/components/RenderPage.tsx
+++ b/react/components/RenderPage.tsx
@@ -15,26 +15,6 @@ const RenderPage: FC<Props> = props => {
     route: { params },
   } = runtime
 
-  /** Will use the params of the page as a key for the component, so React will
-   * unmount and remount it on page change. This is used to reset components
-   * to their initial state on page change, to better simulate how regular
-   * web pages work. */
-  let paramsString = ''
-
-  /** TODO: This is a quick fix--the admin, which runs on an iframe, doesn't play
-   * nice with unmounting/remounting. Should perhaps try and find a better solution
-   * for this issue. */
-  if (!page?.startsWith('admin.')) {
-    try {
-      paramsString = JSON.stringify(params)
-    } catch (e) {
-      console.warn(
-        "Unable to stringify params for page. This shouldn't be much of a problem, but might prevent components from being reset on page change. The params object is as follows:",
-        params
-      )
-    }
-  }
-
   return (
     <MaybeContext
       nestedPage={page}
@@ -42,14 +22,7 @@ const RenderPage: FC<Props> = props => {
       params={params}
       runtime={runtime}
     >
-      <ExtensionPoint
-        // Key used to unmount/remount the component on page change.
-        key={`${page}/${paramsString}`}
-        id={page}
-        query={query}
-        params={params}
-        {...props}
-      />
+      <ExtensionPoint id={page} query={query} params={params} {...props} />
     </MaybeContext>
   )
 }


### PR DESCRIPTION
Reverts page remounting, due to bugs on certain edge cases/third party components.

[The specific issue](https://github.com/vtex-apps/render-runtime/pull/470) this change was intended to fix should be solved by https://github.com/vtex-apps/drawer/pull/16