### PR TITLE
Update prop-types version

### DIFF
--- a/react/externals.json
+++ b/react/externals.json
@@ -15,7 +15,7 @@
       {
         "global": "PropTypes",
         "import": "prop-types",
-        "path": "npm:prop-types@15.6.2/prop-types.js"
+        "path": "npm:prop-types@15.7.2/prop-types.js"
       },
       {
         "global": "React",
@@ -95,7 +95,7 @@
       {
         "global": "PropTypes",
         "import": "prop-types",
-        "path": "npm:prop-types@15.6.2/prop-types.min.js"
+        "path": "npm:prop-types@15.7.2/prop-types.min.js"
       },
       {
         "global": "React",

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "hoist-non-react-statics": "^2.5.0",
     "js-base64": "^2.4.9",
     "myvtex-sse": "^1.2.0",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.7.2",
     "query-string": "^5.1.1",
     "ramda": "^0.26.1",
     "react-amphtml": "^4.0.2",


### PR DESCRIPTION
Update `prop-types` package so `material-ui@4.x` works, otherwise it crashes with an error:

<img width="1240" alt="Screen Shot 2020-03-02 at 14 43 55" src="https://user-images.githubusercontent.com/10400340/75702446-458cec00-5c94-11ea-92f6-6a3a8e967ded.png">

It crashes because it uses a new validator, `elementType`, added in [`15.7.0`](https://github.com/facebook/prop-types/blob/master/CHANGELOG.md#1570).