### PR TITLE
Adding preventRemount prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `preventRemount` on navigation.
 
 ## [8.93.2] - 2020-03-02
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,19 +2,6 @@
 
 This app handles runtime execution of React apps in the VTEX IO Platform.
 
-## Table of Contents
-
-- [Exported Components](#exported-components)
-	- [Link](#link-1)
-	- [NoSSR](#nossr)
-- [Navigation](#navigation)
-  - [navigate](#navigate)
-    - [Navigate options](#navigate-options)
-    - [Example](#example)
-  - [Link](#link-1)
-  - [Other methods](#other-methods)
-     - [goBack](#goback)
-     - [setQuery](#setQuery)
 ## Exported Components
 
 ### Link
@@ -74,7 +61,7 @@ export withRuntimeContext(MyOtherComponent)
 
 You can pass a handful of configuration props to navigate:
 
-#### Navigate options
+#### Navigate Options
 
 | Name      | Type          | Default  | Description |
 | :------------- |:-------------| :-----|:-----|
@@ -86,6 +73,9 @@ You can pass a handful of configuration props to navigate:
 | query | `string`  | `''`   | String representation of the query params that will be appended to the path. Example: `skuId=231`.
 | scrollOptions | `RenderScrollOptions` | -- | After the navigation, if the page should be scrolled to a specific position, or should stay still (use `false`)
 | replace | `boolean` | `undefined` | If it should call the replace function to navigate or not
+| preventRemount | `boolean` | `false` | If `true`, only the URL will change, but not the components :exclamation: **Use with caution!**
+
+
 #### Example
 ```javascript
 navigate({

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -613,8 +613,8 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     } = this.state
     const { state } = location
 
-    // Make sure this is our navigation
-    if (!state || !state.renderRouting) {
+    // In case of other router's navigation, or when preventRemount is true, do nothing
+    if (!state || !state.renderRouting || state.preventRemount) {
       return
     }
 

--- a/react/components/useRuntime.ts
+++ b/react/components/useRuntime.ts
@@ -1,3 +1,0 @@
-export default () => {
-  return {} as RenderContext
-}

--- a/react/components/useRuntime.ts
+++ b/react/components/useRuntime.ts
@@ -1,0 +1,3 @@
+export default () => {
+  return {} as RenderContext
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -159,6 +159,7 @@ declare global {
       renderRouting?: true
       scrollOptions?: RenderScrollOptions
       fetchPage?: boolean
+      preventRemount?: boolean
     }
   }
 

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -45,13 +45,15 @@ function createLocationDescriptor(
     query,
     scrollOptions,
     fetchPage,
-  }: Pick<NavigateOptions, 'hash' | 'query' | 'scrollOptions' | 'fetchPage'>
+    preventRemount,
+  }: Partial<NavigateOptions>
 ): LocationDescriptorObject {
   return {
     pathname: navigationRoute.path,
     state: {
       fetchPage,
       navigationRoute,
+      preventRemount,
       renderRouting: true,
       scrollOptions,
     },
@@ -241,6 +243,7 @@ export function navigate(
     rootPath,
     replace,
     fetchPage = true,
+    preventRemount,
     modifiers,
     modifiersOptions,
   } = options
@@ -312,6 +315,7 @@ export function navigate(
     const nextQuery = mergePersistingQueries(history.location.search, query)
     const location = createLocationDescriptor(navigationRoute, {
       fetchPage,
+      preventRemount,
       query: nextQuery,
       scrollOptions,
       hash: realHash,
@@ -488,6 +492,7 @@ export interface NavigateOptions {
   fallbackToWindowLocation?: boolean
   replace?: boolean
   fetchPage?: boolean
+  preventRemount?: boolean
   rootPath?: string
   modifiers?: Set<NavigationRouteModifier>
   modifiersOptions?: Record<string, any>


### PR DESCRIPTION
To be used mostly on our _CRUDly_ admin apps, so they don't need to [hack](https://github.com/vtex/admin-collections/blob/f4f9270e848154bba4cf52e9968f9c2a13cf9e91/react/components/CollectionView/index.tsx#L107) when needing to only change the URL.

- [x] Add a `preventRemount` prop and use it so we don't remount our _comps_ 

- [x] Clearly state on docs the implications of using it

**How to test**
1. Go https://templo--storecomponents.myvtex.com/
2. Inspect a component `usingRuntime()` with React Dev Tools
3. `$r.props.runtime.navigate({ page: 'store.product', params: { slug: 'my-product' }, preventRemount: true })`

**P.S:** I've also removed the **Table of Contents** from README.md, since it gets messed up in VTEX IO Docs.