### PR TITLE
Fix/partial hydration on site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where components optimised for partial hydration wouldn't appear on the CMS.
 
 ## [8.97.1] - 2020-03-24
 ### Fixed

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -80,7 +80,7 @@ const ComponentLoader: FunctionComponent<Props> = props => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (!shouldHydrate) {
+  if (!isSiteEditorIframe && !shouldHydrate) {
     content = (
       <Hydration treePath={treePath} hydration={hydration}>
         {content}


### PR DESCRIPTION
Fixes issue where components optimised for partial hydration wouldn't appear on the CMS.

To test, go to https://lbebber--storecomponents.myvtex.com/admin/cms/site-editor, scroll down to the Info Card, click on the select button on the header (on the right of the "url" field), and try to select it. It should work.

Compare with https://storecomponents.myvtex.com/admin/cms/site-editor, where doing the same should do nothing.