### PR TITLE
Fix/hydration details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where partial hydration content below regular `__fold__` would be loaded immediately.
 
 ## [8.98.1] - 2020-04-02
 ### Fixed

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -6,6 +6,7 @@ import { TreePathContextProvider } from '../../utils/treePath'
 import { isSiteEditorIframe } from '../../utils/dom'
 import SiteEditorWrapper from './SiteEditorWrapper'
 import Hydration from '../Hydration'
+import { LazyImages } from '../LazyImages'
 
 const componentPromiseMap: any = {}
 const componentPromiseResolvedMap: any = {}
@@ -82,9 +83,11 @@ const ComponentLoader: FunctionComponent<Props> = props => {
 
   if (!isSiteEditorIframe && !shouldHydrate) {
     content = (
-      <Hydration treePath={treePath} hydration={hydration}>
-        {content}
-      </Hydration>
+      <LazyImages>
+        <Hydration treePath={treePath} hydration={hydration}>
+          {content}
+        </Hydration>
+      </LazyImages>
     )
   }
 

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -105,11 +105,6 @@ class Container extends Component<ContainerProps, ContainerState> {
     )
     const hasLazyImagesFold = lazyImagesFoldPosition > -1
 
-    const lazyAssetsFoldPosition = elements.indexOf(
-      '__fold__.experimentalLazyAssets'
-    )
-    const hasLazyAssetsFold = lazyAssetsFoldPosition > -1
-
     const returnValue: JSX.Element[] = elements
       .slice(0, elementsToRender)
       .map((element: Element, i: number) => {
@@ -125,10 +120,7 @@ class Container extends Component<ContainerProps, ContainerState> {
           </Container>
         )
 
-        if (
-          (hasLazyImagesFold && i > lazyImagesFoldPosition) ||
-          (hasLazyAssetsFold && i > lazyAssetsFoldPosition)
-        ) {
+        if (hasLazyImagesFold && i > lazyImagesFoldPosition) {
           container = (
             <LazyImages key={element.toString()}>{container}</LazyImages>
           )

--- a/react/hooks/hydration.tsx
+++ b/react/hooks/hydration.tsx
@@ -12,12 +12,13 @@ export const useDehydratedContent = (hydrationId: string) => {
     window?.document?.querySelector?.(`[data-hydration-id="${hydrationId}"]`)
   )
 
-  const [hasRenderedOnServer] = useState(
+  const [hasDehydratedContent] = useState(
     !!dehydratedElement && dehydratedElement.childElementCount > 0
   )
 
   return {
-    hasRenderedOnServer,
+    hasRenderedOnServer: !!dehydratedElement,
+    hasDehydratedContent,
     dehydratedElement,
   }
 }


### PR DESCRIPTION
Fixes issue where partial hydration content below regular `__fold__` would be loaded immediately.

To test, go to https://www.als.com/?workspace=lbebberprod1 with the Network tab on Devtools open. Around 126 files, give or take, should be loaded in total.
Filter for 'footer', and there shouldn't appear any file with that name (provided you didn't scroll the page)

![Screen Shot 2020-03-30 at 13 07 27](https://user-images.githubusercontent.com/5691711/77938104-a0156a00-728b-11ea-8f95-8a70ca318a20.png)

![Screen Shot 2020-03-30 at 13 39 10](https://user-images.githubusercontent.com/5691711/77938260-dc48ca80-728b-11ea-93a8-c9ece64cd41d.png)


Compare with https://www.als.com/, where doing the same loads some 134 files, including files from the footer.
![Screen Shot 2020-03-30 at 13 07 16](https://user-images.githubusercontent.com/5691711/77938216-caffbe00-728b-11ea-97ba-ef1d950c546e.png)

![Screen Shot 2020-03-30 at 13 39 34](https://user-images.githubusercontent.com/5691711/77938296-e9fe5000-728b-11ea-8c59-28febbbfd2d2.png)


