### PR TITLE
Fix persisted query not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- PersistedQueryNotFoundError
+  - Adds query to request when persisted query is not found to avoid PersistedQueryNotFoundError from graphql-server
+  - Uses POST on those requests
+  - Throws error in development when persisted query is not found
 
 ## [8.99.1] - 2020-04-24
 ### Fixed

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -98,8 +98,15 @@ export const createUriSwitchLink = (
         binding,
         workspace,
         route: { domain },
+        production,
       } = initialRuntime
       const hash = generateHash(operation.query)
+
+      if (!production && !hash) {
+        throw new Error(
+          'Could not generate hash from query. Are you using graphql-tag ? Split your graphql queries in .graphql files and import them instead'
+        )
+      }
 
       const includeQuery = (oldContext as any).http?.includeQuery || !hash
       const { maxAge, scope, version, provider, sender } = extractHints(

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -100,6 +100,8 @@ export const createUriSwitchLink = (
         route: { domain },
       } = initialRuntime
       const hash = generateHash(operation.query)
+
+      const includeQuery = (oldContext as any).http?.includeQuery || !hash
       const { maxAge, scope, version, provider, sender } = extractHints(
         operation.query,
         cacheHints[hash]
@@ -109,7 +111,7 @@ export const createUriSwitchLink = (
         initialRuntime
       )
       const customScope = requiresAuthorization ? 'private' : scope
-      const oldMethod = fetchOptions.method || 'POST'
+      const oldMethod = includeQuery ? 'POST' : fetchOptions.method || 'POST'
       const protocol = canUseDOM ? 'https:' : 'http:'
       const method =
         customScope?.toLowerCase() === 'private' ? 'POST' : oldMethod
@@ -126,6 +128,10 @@ export const createUriSwitchLink = (
 
       return {
         ...oldContext,
+        http: {
+          ...(oldContext as any).http,
+          includeQuery,
+        },
         scope: customScope,
         fetchOptions: { ...fetchOptions, method },
         uri: `${protocol}//${baseURI}/_v/${customScope}/graphql/v${version}${query}`,


### PR DESCRIPTION
Fixes PersistedQueryNotFoundError. This fix includes:
  - Adds query to request when persisted query is not found to avoid PersistedQueryNotFoundError from graphql-server
  - Uses POST on those requests
  - Throws error in development when persisted query is not found