### PR TITLE
fix: isSiteEditorIframe verification raising error on iframe consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Let runtime to be used inside an iframe.
 
 ## [8.100.1] - 2020-04-29
 ### Fixed

--- a/react/utils/dom.tsx
+++ b/react/utils/dom.tsx
@@ -79,12 +79,21 @@ export const getMarkups = (
   return markups
 }
 
-export const isSiteEditorIframe =
-  canUseDOM &&
-  window.top !== window.self &&
-  window.top.__provideRuntime &&
-  !!window.top.__provideRuntime &&
-  window.__RUNTIME__.route.domain === 'store'
+const checkIsSiteEditorIframe = () => {
+  try {
+    return (
+      canUseDOM &&
+      window.top !== window.self &&
+      window.top.__provideRuntime &&
+      !!window.top.__provideRuntime &&
+      window.__RUNTIME__.route.domain === 'store'
+    )
+  } catch {
+    return false
+  }
+}
+
+export const isSiteEditorIframe = checkIsSiteEditorIframe()
 
 export const getContainer = () => {
   return canUseDOM


### PR DESCRIPTION
**What does this PR do?**

We need to make an app available for any costumer (VTEX and/or Indeva) to consume it through an iframe.
The variable `isSiteEditorIframe` is raising error when any vtex-app is consumed by an iframe using the render-runtime with react apps.

Examples:
- fixed iframe: https://ivan--indevasetup.myvtex.com/rihappy
- raising error: https://developers.vtex.com/docs/teste

```
Uncaught Error: An error happened while requiring the app vtex.render-runtime@8.100.1/index, please check your app's code.\nError: Blocked a frame with origin "https://vtex.io" from accessing a cross-origin frame.
https://vtexpages.vtexassets.com/_v/public/assets/v1/published/vtex.render-runtime@8.100.1/public/react/common.min.js?workspace=master
```