### PR TITLE
Fix/navigate 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where an infinite loading would happen when navigating to 404 pages.
 
 ## [8.104.2] - 2020-06-05
 ### Fixed

--- a/react/utils/fetch.ts
+++ b/react/utils/fetch.ts
@@ -23,6 +23,7 @@ const RETRY_STATUSES = [
 const canRetry = (status: number) => RETRY_STATUSES.includes(status)
 
 const ok = (status: number) => 200 <= status && status < 300
+const isNotFound = (status: number) => status === 404
 
 export const fetchWithRetry = (
   url: string,
@@ -37,7 +38,7 @@ export const fetchWithRetry = (
     fetcher(url, init)
       .then(response => {
         status = response.status
-        return ok(status)
+        return ok(status) || isNotFound(status)
           ? { response, error: null }
           : response
               .json()


### PR DESCRIPTION
Fixes infinite loading that would happen when navigating to 404 pages.

### How to test

Before:
Go to https://www.als.com/; on the menu, go to "Kids > Girls > Shirts". The loading bar should stay on indefinitely.

If you try to refresh, a "Page not found" page should appear.

After:
Doing the same navigation on https://fixnotfound--alssports.myvtex.com/ should display the "Page not found" page right away.

