### PR TITLE
Fix/apollo devtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue with Apollo Devtools turning up blank.
 
 ## [8.100.4] - 2020-05-07
 ### Fixed

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -146,7 +146,7 @@ export const getClient = (
        * Should look into why it is needed in the first place.
        * https://github.com/apollographql/apollo-client-devtools/issues/238
        */
-      typeDefs: {} as any,
+      typeDefs: [],
     })
   }
 

--- a/react/utils/client/index.ts
+++ b/react/utils/client/index.ts
@@ -142,6 +142,11 @@ export const getClient = (
       link,
       resolvers: {},
       ssrMode: !canUseDOM,
+      /** TODO: The empty typedefs below fixes an issue with Apollo Devtools.
+       * Should look into why it is needed in the first place.
+       * https://github.com/apollographql/apollo-client-devtools/issues/238
+       */
+      typeDefs: {} as any,
     })
   }
 


### PR DESCRIPTION
Fixes error with apollo devtools turning up blank.

To test, open https://apollofix--storecomponents.myvtex.com/, go to the "Apollo" devtools tab (considering of course that you have it installed) and notice that it works. Doing the same on another dev workspace should turn it blank.