### PR TITLE
Feat/prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prefetch: Save query data in memory and only hydrate apollo cache before navigating.
 
 ## [8.102.1] - 2020-05-20
 ### Changed

--- a/react/components/Prefetch/PrefetchContext.tsx
+++ b/react/components/Prefetch/PrefetchContext.tsx
@@ -31,6 +31,7 @@ interface PrefetchCacheObject {
   routeId: string
   matchingPage: RenderRuntime['route']
   contentResponse: ContentResponse | null
+  queryData: RenderRuntime['queryData']
 }
 
 export interface PrefetchState {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -669,6 +669,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       const routeId = destinationRouteId
       const matchingPage = prefetchedPathData.matchingPage
       const contentResponse = prefetchedPathData.contentResponse
+      const queryData = prefetchedPathData.queryData
       let extensions = routeData.extensions
       let messages = routeData.messages
       if (contentResponse) {
@@ -687,6 +688,10 @@ class RenderProvider extends Component<Props, RenderProviderState> {
           }
           extensions[treePath]!.contentIds = contentIds
         }
+      }
+
+      if (queryData) {
+        this.hydrateApolloCache(queryData)
       }
 
       this.setState(

--- a/react/hooks/prefetch.ts
+++ b/react/hooks/prefetch.ts
@@ -49,7 +49,6 @@ interface MaybeUpdatePathArgs {
     routeValid: boolean
   }
   page?: string
-  client: ApolloClientType
 }
 
 const maybeUpdatePathCache = async ({
@@ -57,7 +56,6 @@ const maybeUpdatePathCache = async ({
   navigationRoute,
   validCache,
   page,
-  client,
 }: MaybeUpdatePathArgs) => {
   const { pathsState } = prefetchState
   if (validCache.pathValid) {
@@ -73,14 +71,12 @@ const maybeUpdatePathCache = async ({
   if (navigationData == null || navigationPage == null) {
     return null
   }
-  if (navigationData?.queryData) {
-    hydrateApolloCache(navigationData.queryData, client)
-  }
 
   const cacheObj = {
     routeId: navigationPage,
     matchingPage: navigationData.route,
     contentResponse: navigationData.contentResponse,
+    queryData: navigationData.queryData,
   }
 
   const cache = getCacheForPage(navigationPage)
@@ -109,7 +105,6 @@ const prefetchRequests = async ({
     navigationRoute,
     validCache,
     page,
-    client,
   })
 
   pathsState[navigationRoute.path] = { fetching: false, page: navigationPage }

--- a/react/utils/flags.ts
+++ b/react/utils/flags.ts
@@ -1,7 +1,7 @@
 const flags = {
   RENDER_NAVIGATION: true,
   VTEX_ASSETS_URL: true,
-  PREFETCH: false,
+  PREFETCH: true,
 }
 
 window.flags = flags


### PR DESCRIPTION
#### What does this PR do? \*

Before, as soon as we downloaded the query data for each path, we would hydrate the apollo cache.

This lead to problems, probably bugs in react-apollo, that made the vtex.search (biggy search) to lose its content when doing the prefetch of products inside a search page.

#### How to test it? \*

www.exito.com/search?_query=tv&workspace=pref
https://www.als.com/?workspace=pref

confirm there are prefetch happening and that everything works as expected

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
