### PR TITLE
Replace node URL module with window.URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace `url` module import with native `window.URL` imeplementation.
 
 ## [8.102.1] - 2020-05-20
 ### Changed

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -119,7 +119,7 @@ function getRelativeURLWithQuery({
   urlObj.search = ''
 
   Object.entries(query).forEach(([key, value]) => {
-    urlObj.searchParams.set(key, value as any)
+    urlObj.searchParams.set(key, value)
   })
 
   return urlObj.href.slice(baseUrl.length)

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -1,6 +1,5 @@
 import { stringify } from 'query-string'
 import { isEmpty } from 'ramda'
-import { parse, format } from 'url'
 
 import navigationPageQuery from '../queries/navigationPage.graphql'
 import routePreviews from '../queries/routePreviews.graphql'
@@ -105,6 +104,27 @@ const runtimeFields = [
   'settings',
 ].join(',')
 
+function getRelativeURLWithQuery({
+  path,
+  query,
+}: {
+  path: string
+  query: Record<string, any>
+}) {
+  // we don't need to have the rootPath here because only
+  // the relative path matters
+  const baseUrl = window.location.origin
+  const urlObj = new URL(path, baseUrl)
+
+  urlObj.search = ''
+
+  Object.entries(query).forEach(([key, value]) => {
+    urlObj.searchParams.set(key, value as any)
+  })
+
+  return urlObj.href.slice(baseUrl.length)
+}
+
 export const fetchServerPage = async ({
   fetcher,
   path,
@@ -114,13 +134,13 @@ export const fetchServerPage = async ({
   query?: Record<string, string>
   fetcher: GlobalFetch['fetch']
 }): Promise<ParsedServerPageResponse> => {
-  const parsedUrl = parse(path)
-  parsedUrl.search = undefined
-  parsedUrl.query = {
-    ...rawQuery,
-    __pickRuntime: runtimeFields,
-  } as any
-  const url = format(parsedUrl)
+  const url = getRelativeURLWithQuery({
+    path,
+    query: {
+      ...rawQuery,
+      __pickRuntime: runtimeFields,
+    },
+  })
   const page: ServerPageResponse = await fetchWithRetry(
     url,
     {
@@ -205,13 +225,14 @@ export const getPrefetchForPath = async ({
   query?: Record<string, string>
   fetcher: GlobalFetch['fetch']
 }): Promise<PrefetchPageResponse | null> => {
-  const parsedUrl = parse(path)
-  parsedUrl.search = undefined
-  parsedUrl.query = {
-    ...rawQuery,
-    __pickRuntime: 'page,queryData,contentResponse,route',
-  } as any
-  const url = format(parsedUrl)
+  const url = getRelativeURLWithQuery({
+    path,
+    query: {
+      ...rawQuery,
+      __pickRuntime: 'page,queryData,contentResponse,route',
+    },
+  })
+
   const pageResponsePromise = fetchWithRetry(
     url,
     {


### PR DESCRIPTION
#### What does this PR do? \*

The url module used by the routes.ts is a node module. This means that only by just importing it, our builder-hub's webpack adds 1580+- lines of code (or 5kb gzipped) of unneeded code to our stores javascript payload. We can easily replace it with the native window.URL constructor.

Note: IE 11 doesn't have the `URL` and `URLSearchParams` constructors, but we're already polyfilling it [here](https://github.com/vtex/render-server/blob/master/node/utils/assetLoader.ts#L56).

Story: https://app.clubhouse.io/vtex/story/38530/remove-url-module-from-render-runtime

![image](https://user-images.githubusercontent.com/12702016/83275941-40adda80-a1a6-11ea-811a-2facf8e8117e.png)

#### How to test it? \*

1) Go to https://kiwi--storecomponents.myvtex.com
2) Navigate to your heart's desire



Also tested the IE 11 polyfill via browserstack.

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

n/a
