### PR TITLE
add sales channel to queryString on graphql queries

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -82,6 +82,7 @@ export interface RenderProviderState {
   cacheHints: RenderRuntime['cacheHints']
   components: RenderRuntime['components']
   culture: RenderRuntime['culture']
+  salesChannel: RenderRuntime['salesChannel']
   defaultExtensions: RenderRuntime['defaultExtensions']
   device: ConfigurationDevice
   extensions: RenderRuntime['extensions']
@@ -138,6 +139,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
     contentMap: PropTypes.object,
     components: PropTypes.object,
     culture: PropTypes.object,
+    salesChannel: PropTypes.string,
     defaultExtensions: PropTypes.object,
     device: PropTypes.string,
     emitter: PropTypes.object,
@@ -218,6 +220,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       cacheHints,
       contentMap,
       culture,
+      salesChannel,
       messages,
       components,
       exposeBindingAddress,
@@ -295,6 +298,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       contentMap,
       components,
       culture,
+      salesChannel,
       defaultExtensions: {},
       device: 'any',
       extensions,
@@ -381,6 +385,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       pages,
       preview,
       culture,
+      salesChannel,
       device,
       route,
       query,
@@ -409,6 +414,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       components,
       contentMap,
       culture,
+      salesChannel,
       defaultExtensions,
       device,
       emitter,
@@ -979,6 +985,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
         cacheHints,
         components,
         culture,
+        salesChannel,
         extensions,
         messages,
         pages,
@@ -992,6 +999,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
               cacheHints,
               components,
               culture,
+              salesChannel,
               extensions,
               messages,
               pages,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -203,6 +203,7 @@ declare global {
     components: RenderRuntime['components']
     contentMap: RenderRuntime['contentMap']
     culture: RenderRuntime['culture']
+    salesChannel: RenderRuntime['salesChannel']
     defaultExtensions: RenderRuntime['defaultExtensions']
     device: ConfigurationDevice
     emitter: RenderRuntime['emitter']
@@ -449,6 +450,7 @@ declare global {
     route: Route
     version: string
     culture: Culture
+    salesChannel?: string
     pages: Pages
     extensions: Extensions
     platform: string

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -45,6 +45,7 @@ export interface OperationContext {
     | 'cacheHints'
     | 'components'
     | 'culture'
+    | 'salesChannel'
     | 'extensions'
     | 'messages'
     | 'pages'
@@ -91,6 +92,7 @@ export const createUriSwitchLink = (
           appsEtag,
           cacheHints,
           culture: { locale },
+          salesChannel,
         },
       } = oldContext
       const { extensions } = operation
@@ -128,7 +130,26 @@ export const createUriSwitchLink = (
         provider,
       }
 
-      let query = `?workspace=${workspace}&maxAge=${maxAge}&appsEtag=${appsEtag}&domain=${domain}&locale=${locale}`
+      const queryObj: Record<string, string> = {
+        workspace,
+        maxAge,
+        appsEtag,
+        domain,
+        locale,
+        sc: String(salesChannel),
+      }
+
+      let query = Object.keys(queryObj).reduce(
+        (queryString: string, objKey: string, index: number) => {
+          let nextKeyPrefix = ''
+          if (index < Object.keys(queryObj).length - 1) {
+            nextKeyPrefix = '&'
+          }
+          return `${queryString}${objKey}=${queryObj[objKey]}${nextKeyPrefix}`
+        },
+        '?'
+      )
+
       if (binding && binding.id) {
         query = appendLocationSearch(query, { __bindingId: binding.id })
       }


### PR DESCRIPTION
#### What does this PR do? \*
Add sales channel info in the querystring of graphql queries.

#### How to test it? \*
Enter on https://sconquerystring--storecomponents.myvtex.com and see that each graphql request now have the query param `sc=<sales channel value>`

Example:
`https://sconquerystring--storecomponents.myvtex.com/_v/private/graphql/v1?workspace=sconquerystring&maxAge=long&appsEtag=remove&domain=store&locale=en-US&`**sc=1**`&__bindingId=aacb06b3-a8fa-4bab-b5bd-2d654d20dcd8`

#### Related to / Depends on \*
depends on: https://github.com/vtex/render-server/pull/623

<!--- Optional -->
