### PR TITLE
prevent change path when set query is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent setQuery method from ever changing the current path when calling navigate.
 
 ## [8.103.1] - 2020-06-01
 ### Changed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -526,6 +526,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
 
     return pageNavigate(history, pages, {
       fetchPage: false,
+      skipSetPath: true,
       page,
       params,
       query: nextQuery,

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -46,10 +46,10 @@ function createLocationDescriptor(
     scrollOptions,
     fetchPage,
     preventRemount,
+    skipSetPath,
   }: Partial<NavigateOptions>
 ): LocationDescriptorObject {
   return {
-    pathname: navigationRoute.path,
     state: {
       fetchPage,
       navigationRoute,
@@ -57,6 +57,7 @@ function createLocationDescriptor(
       renderRouting: true,
       scrollOptions,
     },
+    ...(skipSetPath ? {} : { pathname: navigationRoute.path }),
     ...(query && { search: query }),
     ...(hash && { hash }),
   }
@@ -323,6 +324,7 @@ export function navigate(
     replace,
     fetchPage = true,
     preventRemount,
+    skipSetPath = false,
   } = options
 
   const navigationRoute = getNavigationRouteToNavigate(pages, options, true)
@@ -346,6 +348,7 @@ export function navigate(
       query: nextQuery,
       scrollOptions,
       hash: navigationRoute.realHash,
+      skipSetPath,
     })
     const method = replace ? 'replace' : 'push'
     window.setTimeout(() => history[method](location), 0)
@@ -523,6 +526,7 @@ export interface NavigateOptions {
   rootPath?: string
   modifiers?: Set<NavigationRouteModifier>
   modifiersOptions?: Record<string, any>
+  skipSetPath?: boolean
 }
 
 export interface NavigationRouteChange {


### PR DESCRIPTION
#### What does this PR do? \*

- Prevents setQuery method to change the path when calling navigate.
The problem:

without this, when we try to call setQuery in a store with bindings, like powerplanet, the path will change. Example:
You are in binding pt-BR and the catalog language is es-ES.
you are seeing url: '/sapato-pt', that is the url for the pt-BR binding.

After doing a setQUery to change a query param, you will be navigated to: `/sapato-es`. Because the current architecture still keeps the params in the tenant language

I propose that a `setQuuery` should never attempt to change the path.
#### How to test it? \*

https://teste--powerplanet.myvtex.com/smartwatch/smartband?__bindingAddress=www.powerplanetonline.com/pt

go here and click on the xiaomi filter, see it work as expected

https://setquery--motorolaus.myvtex.com/
https://setquery--boticario.myvtex.com/
https://setquery--worldwidegolf.myvtex.com/
https://setquery--exitocol.myvtex.com/

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
