### PR TITLE
Stop overriding native Intl now we have full-icu on nodejs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop overriding native Intl now we have full-icu on nodejs.
 
 ## [8.103.1] - 2020-06-01
 ### Changed

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -22,9 +22,6 @@ if (window.IntlPolyfill) {
   window.IntlPolyfill.__disableRegExpRestore()
   if (!window.Intl) {
     window.Intl = window.IntlPolyfill
-  } else if (!canUseDOM) {
-    window.Intl.NumberFormat = window.IntlPolyfill.NumberFormat
-    window.Intl.DateTimeFormat = window.IntlPolyfill.DateTimeFormat
   }
 }
 if (
@@ -85,7 +82,7 @@ if (
   canUseDOM &&
   document.querySelector('style#critical')
 ) {
-  window.__UNCRITICAL_PROMISE__ = new Promise(resolve => {
+  window.__UNCRITICAL_PROMISE__ = new Promise((resolve) => {
     window.addEventListener('load', () => {
       const base = document.querySelector('noscript#styles_base')
       if (base) {
@@ -104,7 +101,7 @@ if (
 
 if (window.__RUNTIME__.start && !window.__ERROR__) {
   if (canUseDOM) {
-    const contentLoadedPromise = new Promise(resolve =>
+    const contentLoadedPromise = new Promise((resolve) =>
       window.addEventListener('DOMContentLoaded', resolve)
     )
     Promise.all([contentLoadedPromise, intlPolyfillPromise]).then(() => {


### PR DESCRIPTION
#### What does this PR do?
Stop using `Intl` from polyfill on SSR. Now we have node with full ICU data 🎉 

The polyfill does not cover some cases.

If you go here: https://npm.runkit.com/intl
and try: 
```js
var intl = require("intl")
console.log(new intl.NumberFormat('ro-RO', {style: 'currency', currency: 'RON', currencyDisplay: 'name'}).format(100))
```

You will get "100,00 RON", but it should be "100,00 lei românești".

#### How to test it? \*
It is linked and working here: https://breno--melimeloparis.myvtex.com/?__bindingAddress=www.melimeloparis.ro/&utm_source=fobar