### PR TITLE
fix rootpath unneeded prepend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- On navigation, don't preprend rootpath if destination is to a path that already starts with rootpath.
 
 ## [8.104.0] - 2020-06-03
 ### Changed

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -362,7 +362,11 @@ export function navigate(
 
 function navigationRootPath(path: string, rootPath?: string) {
   // Prefix any non-absolute paths (e.g. http:// or https://) with runtime.rootPath
-  if (rootPath && !path.startsWith('http')) {
+  if (
+    rootPath &&
+    !path.startsWith('http') &&
+    !path.startsWith(`${rootPath}/`)
+  ) {
     return rootPath + path
   }
 


### PR DESCRIPTION
#### What does this PR do? \*
- Do not prepend root path if the destination path already has the root path.

We test if the destination path starts with `${rootPath}/`. So the result is:
For rootpath == `/br`
/brasil/fogao => will append and result in => /br/brasil/fogao
/shoes => will append and result in => /br/shoes
/br/shoes => will not append and will remain => /br/shoes

#### How to test it? \*
https://shop.samsung.com/br/eletrodomesticos/Geladeiras?map=c,c&workspace=teste
Click on a filter

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
