### PR TITLE
Feature/app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Adds `appSettings` prop to blocks that have their settings exposed on `__RUNTIME__`.
 
 ## [8.104.3] - 2020-06-09
 ### Fixed

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -13,8 +13,8 @@ import LoadingBar from '../LoadingBar'
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
   () =>
-    new Promise<{ default: any }>(resolve => {
-      import('@vtex/blocks-inspector').then(BlocksInspector => {
+    new Promise<{ default: any }>((resolve) => {
+      import('@vtex/blocks-inspector').then((BlocksInspector) => {
         resolve({ default: BlocksInspector.default.ExtensionPointWrapper })
       })
     })
@@ -47,7 +47,7 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     return
   }
 
-  const childBlocks = extension.blocks.filter(block => {
+  const childBlocks = extension.blocks.filter((block) => {
     /* This weird conditional check is for backwards compatibility.
      * Blocks that were built prior to https://github.com/vtex/builder-hub/pull/856
      * would not have the 'children' property (block.children === undefined).
@@ -90,7 +90,7 @@ function withOuterExtensions(
     return element
   }
 
-  const beforeElements = before.map(beforeId => (
+  const beforeElements = before.map((beforeId) => (
     <ExtensionPoint
       id={beforeId}
       key={beforeId}
@@ -100,7 +100,7 @@ function withOuterExtensions(
     />
   ))
 
-  const afterElements = after.map(afterId => (
+  const afterElements = after.map((afterId) => (
     <ExtensionPoint
       id={afterId}
       key={afterId}
@@ -137,7 +137,7 @@ function withOuterExtensions(
   }, wrapped)
 }
 
-const ExtensionPoint: FC<Props> = props => {
+const ExtensionPoint: FC<Props> = (props) => {
   const runtime = useRuntime()
 
   const { inspect, getSettings } = runtime

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -140,7 +140,7 @@ function withOuterExtensions(
 const ExtensionPoint: FC<Props> = props => {
   const runtime = useRuntime()
 
-  const { inspect } = runtime
+  const { inspect, getSettings } = runtime
 
   const treePathFromHook = useTreePath()
 
@@ -164,8 +164,12 @@ const ExtensionPoint: FC<Props> = props => {
     props: extensionProps = {},
   } = extension || {}
 
+  const appName = component?.substr(0, component.indexOf('@'))
+  const appSettings = appName ? getSettings(appName) : {}
+
   const mergedProps = React.useMemo(() => {
     return reduce(mergeDeepRight, {} as any, [
+      appSettings ? { appSettings } : {},
       /** Extra props passed to the ExtensionPoint component
        * e.g. <ExtensionPoint foo="bar" />
        */
@@ -180,7 +184,15 @@ const ExtensionPoint: FC<Props> = props => {
       content,
       { params, query },
     ])
-  }, [parentProps, extensionProps, blockProps, content, params, query])
+  }, [
+    parentProps,
+    extensionProps,
+    blockProps,
+    content,
+    params,
+    query,
+    appSettings,
+  ])
 
   if (
     /* Stops rendering if the extension is not found. Useful for optional ExtensionPoints */


### PR DESCRIPTION
#### What does this PR do? \*
Adds `appSettings` prop to ExtensionPoints that have settings exposed on `__RUNTIME__`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Some pixel apps need access to some settings to be rendered on SSR. Failure to SSR causes issues with Google etc
Example of usage: https://github.com/vtex-apps/yotpo/pull/10/files

Running on https://www.worldwidegolfshops.com/bushnell-hybrid-rangefinder-10143757/p?workspace=yotposeo5&v=1
Related PRs:
https://github.com/vtex/render-server/pull/629
https://github.com/vtex-apps/render-runtime/pull/533
https://github.com/vtex/pixel-server/pull/35
#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
