### PR TITLE
Update graphql from 0.x to 15.x

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "eventemitter3": "^3.0.0",
     "eventsource-polyfill": "^0.9.6",
     "exenv": "^1.2.2",
-    "graphql": "^0.13.2",
+    "graphql": "^15.1.0",
     "hoist-non-react-statics": "^2.5.0",
     "js-base64": "^2.4.9",
     "myvtex-sse": "^1.2.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4611,7 +4611,12 @@ graphql-tag@~2.8.0:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
   integrity sha1-Us3qB6hCFU7BGi6EDBG5d/m4Nc4=
 
-graphql@^0.13.2, graphql@~0.13.2:
+graphql@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.1.0.tgz#b93e28de805294ec08e1630d901db550cb8960a1"
+  integrity sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==
+
+graphql@~0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==


### PR DESCRIPTION
#### What does this PR do? \*

It bumps our `graphql` dependency from `0.x` to `15.x` (yeah, i know, but gotta test it a lot). The reason behind this update is to have the correct `process.env.NODE_ENV` checks (`0.x` env checks are wrong).

#### How to test it? \*

Link it and use any store

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

https://github.com/vtex/builder-hub/pull/1033