### PR TITLE
Feature/lazy header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Images on `before` and `after` (i.e. header and footer) are loaded lazily.
 
 ## [8.107.0] - 2020-06-17
 ### Fixed

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -9,6 +9,7 @@ import NoSSR from '../NoSSR'
 import { withErrorBoundary } from '../ErrorBoundary'
 import GenericPreview from '../Preview/GenericPreview'
 import LoadingBar from '../LoadingBar'
+import { LazyImages } from '../LazyImages'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
@@ -114,10 +115,10 @@ function withOuterExtensions(
 
   const wrapped = (
     <Fragment key={`wrapped-${treePath}`}>
-      {beforeElements}
+      <LazyImages>{beforeElements}</LazyImages>
       {element}
       {isRootTreePath && <div className="flex flex-grow-1" />}
-      {afterElements}
+      <LazyImages>{afterElements}</LazyImages>
     </Fragment>
   )
 


### PR DESCRIPTION
#### What does this PR do? \*
Makes images on the header and footer load lazily.

#### How to test it? \*
This PR is running on https://www.motorola.co.uk/?workspace=lbebberprod2

Verify that the header and footer work correctly, comparing with https://www.motorola.co.uk

In the Network panel on devtools, filter by Img and reload the page
It should load fewer images than the current published version.

Before (:cry-blood:):
<img width="172" alt="Screen Shot 2020-06-24 at 15 42 42" src="https://user-images.githubusercontent.com/5691711/85614553-61e0da00-b631-11ea-9a01-493f858ff0bb.png">

After (still huge, mind you, but better):
<img width="174" alt="Screen Shot 2020-06-24 at 15 41 02" src="https://user-images.githubusercontent.com/5691711/85614444-4544a200-b631-11ea-8f59-78c147c4d63a.png">


#### Describe alternatives you've considered, if any. \*
Doing this on the header and footer is safer than doing on the entire page, which should be considered in the future.

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
