### PR TITLE
Feature/unveilhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `unveilhooks` lazysizes plugin, which allows lazyloading background images.
+
+### Changed
+- Upgraded lazysizes.
 
 ## [8.109.0] - 2020-06-25
 ### Changed

--- a/react/externals.json
+++ b/react/externals.json
@@ -53,7 +53,11 @@
       },
       {
         "clientOnly": true,
-        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
+        "path": "npm:lazysizes@5.2.2/plugins/unveilhooks/ls.unveilhooks.min.js"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:lazysizes@5.2.2/lazysizes.min.js"
       },
       {
         "clientOnly": true,
@@ -133,7 +137,11 @@
       },
       {
         "clientOnly": true,
-        "path": "npm:lazysizes@5.1.0/lazysizes.min.js"
+        "path": "npm:lazysizes@5.2.2/plugins/unveilhooks/ls.unveilhooks.min.js"
+      },
+      {
+        "clientOnly": true,
+        "path": "npm:lazysizes@5.2.2/lazysizes.min.js"
       },
       {
         "clientOnly": true,


### PR DESCRIPTION
#### What does this PR do? \*

Upgrades lazysizes plugin and adds unveilhooks plugin, which allows lazyloading background images.
(Takes up 1.4kb in size)

Can be seen working here https://lbebber--worldwidegolf.myvtex.com/

In order to see it in action, hover any item on the header menu, and notice that its images are loaded lazily.

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
