### PR TITLE
Check channelPrivacy to decide on query scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Check channelPrivacy to decide on query scope.
 
 ## [8.110.0] - 2020-07-01
 ### Added

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -461,6 +461,7 @@ declare global {
     binding?: BindingInfo
     blocks?: Blocks
     blocksTree?: BlockContentTree
+    channelPrivacy?: 'private' | 'public'
     contentMap?: ContentMap
     customRouting?: boolean
     emitter: EventEmitter

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -1,5 +1,4 @@
 import { ApolloLink, NextLink, Operation } from 'apollo-link'
-import { path } from 'ramda'
 import { canUseDOM } from 'exenv'
 import {
   ASTNode,
@@ -24,7 +23,7 @@ const assetsFromQuery = (query: ASTNode) => {
       if (node.name.value === 'context') {
         const scopeArg =
           node.arguments &&
-          node.arguments.find(argNode => argNode.name.value === 'scope')
+          node.arguments.find((argNode) => argNode.name.value === 'scope')
         if (scopeArg) {
           assets.queryScope = (scopeArg.value as StringValueNode).value
         }
@@ -113,11 +112,14 @@ export const createUriSwitchLink = (
         operation.query,
         cacheHints[hash]
       )
-      const requiresAuthorization = path(
-        ['settings', `vtex.${domain}`, 'requiresAuthorization'],
-        initialRuntime
-      )
-      const customScope = requiresAuthorization ? 'private' : scope
+
+      const requiresAuthorization =
+        initialRuntime.settings?.[`vtex.${domain}`]?.requiresAuthorization
+
+      const isPrivateChannel = initialRuntime.channelPrivacy === 'private'
+
+      const customScope =
+        requiresAuthorization || isPrivateChannel ? 'private' : scope
       const oldMethod = includeQuery ? 'POST' : fetchOptions.method || 'POST'
       const protocol = canUseDOM ? 'https:' : 'http:'
       const method =


### PR DESCRIPTION
#### What does this PR do? \*
Check channelPrivacy to decide on query scope.

#### How to test it? \*

Open https://brunoh--motorolaus.myvtex.com/admin

Click on "use beta" at the end of the left menu.

Go to https://brunoh--motorolaus.myvtex.com

When browsing anonymously you will see product query requests with `/_v/segment/graphql`.
If you log in as a B2B consumer, those requests will be under `/_v/private/graphql`.

#### Related to / Depends on \*

This feature will only work with `vtex.store-session@1.0.1-beta.0`, session service beta (vtexcommercebeta) and https://github.com/vtex/render-server/pull/642

In order to access session service beta, you will need a rewriter version that forwards the `vtex-commerce-env` cookie: https://github.com/vtex/rewriter/pull/159

In order to test it in a workspace, you will need the latest version of `@vtex/api` which can be yarn linked with render-server. There is a PR to release a service-runtime-node version with this new `@vtex/api`: https://github.com/vtex/service-runtime-node/pull/302

Although it has a lot of dependencies, it is safe to release this version as it won't break if `channelPrivacy` is undefined.