### PR TITLE
Check for hasContentSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Look for `hasContentSchema` to check if a block has a content schema.
 
 ## [8.123.0] - 2020-10-13
 

--- a/react/components/ExtensionPoint/SiteEditorWrapper.tsx
+++ b/react/components/ExtensionPoint/SiteEditorWrapper.tsx
@@ -2,8 +2,15 @@ import ReactDOM from 'react-dom'
 import React from 'react'
 import { getImplementation } from '../../utils/assets'
 import { isSiteEditorIframe } from '../../utils/dom'
+interface Props {
+  component: string | null
+  props: Record<string, any>
+  treePath: string
+  runtime: RenderContext
+  hydration: Hydration
+}
 
-class SiteEditorWrapper extends React.Component<any> {
+class SiteEditorWrapper extends React.Component<Props> {
   public componentDidMount() {
     this.addDataToElementIfEditable()
   }
@@ -17,13 +24,20 @@ class SiteEditorWrapper extends React.Component<any> {
   }
 
   private addDataToElementIfEditable = () => {
-    const ComponentImpl =
-      this.props.component && getImplementation(this.props.component)
+    const {
+      component,
+      treePath,
+      runtime: {
+        extensions: { [treePath]: extension },
+      },
+    } = this.props
+
+    const ComponentImpl = component && getImplementation(component)
 
     const isEditable =
-      ComponentImpl &&
-      (ComponentImpl.hasOwnProperty('schema') ||
-        ComponentImpl.hasOwnProperty('getSchema'))
+      extension?.hasContentSchema ||
+      ComponentImpl?.hasOwnProperty('schema') ||
+      ComponentImpl?.hasOwnProperty('getSchema')
 
     if (!isEditable) {
       return
@@ -33,7 +47,7 @@ class SiteEditorWrapper extends React.Component<any> {
     const element = ReactDOM.findDOMNode(this) as Element
 
     if (element && element.setAttribute) {
-      element.setAttribute('data-extension-point', this.props.treePath)
+      element.setAttribute('data-extension-point', treePath)
     }
   }
 


### PR DESCRIPTION
#### What does this PR do? \*

Uses an extension point's `hasContentChema` to check if the block used has a content schema.

#### How to test it? \*

It was tested in #526 😳 

(incoming test workspace)


#### Related to / Depends on \*

<!--- Optional -->
https://github.com/vtex/pages-graphql/pull/375