### PR TITLE
Fix/product context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fallback to server-side navigation when the new page components conflict with the loaded components.
 
 ## [8.111.0] - 2020-07-08
 ### Added

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -25,6 +25,7 @@ import {
   traverseComponent,
   traverseListOfComponents,
   fetchComponents,
+  isConflictingLoadedComponents,
 } from '../utils/components'
 import { setCookie } from '../utils/cookie'
 import {
@@ -739,6 +740,13 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             settings,
             queryData,
           }: ParsedServerPageResponse) => {
+            if (
+              isConflictingLoadedComponents(components, this.state.components)
+            ) {
+              window.location.reload()
+              return new Promise(() => {})
+            }
+
             if (queryData) {
               this.hydrateApolloCache(queryData)
             }

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -743,6 +743,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
             if (
               isConflictingLoadedComponents(components, this.state.components)
             ) {
+              this.scrollTo({ top: 0, left: 0 })
               window.location.reload()
               return new Promise(() => {})
             }

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -6,6 +6,31 @@ const FILE_EXT_REX = /(\.min)?(\.js|\.css)/ // https://regex101.com/r/8vmjes/1
 
 const uniqAsset = uniqWith<AssetEntry, AssetEntry>((a, b) => a.path === b.path)
 
+const getAppAndVersion = (locator: string) => {
+  const [appAtVersion] = locator.split('/')
+  const [app, version] = appAtVersion.split('@')
+  return { app, version }
+}
+
+export const isConflictingLoadedComponents = (
+  navigatedComponents: Components,
+  loadedComponents: Components
+) => {
+  const loadedVersionByApp = Object.keys(loadedComponents).reduce(
+    (acc, locator) => {
+      const { app, version } = getAppAndVersion(locator)
+      acc[app] = version
+      return acc
+    },
+    {} as Record<string, string>
+  )
+
+  return Object.keys(navigatedComponents).some((locator) => {
+    const { app, version } = getAppAndVersion(locator)
+    return loadedVersionByApp[app] && loadedVersionByApp[app] !== version
+  })
+}
+
 export const fetchComponents = async (
   components: RenderRuntime['components'],
   runtime: RenderRuntime,


### PR DESCRIPTION
#### What does this PR do? \*

It fixes errors occurring when a new version of a component is released and the user navigates from a pages with the older version to a page with the new version.

One known case is when a new version of the `vtex.product-context` is deployed.

The user receives a cached homepage HTML with the older `ProductContext` (some components in the shelf depend on it). Then after navigating to a product they must see an endless loading page, like this:

![image](https://user-images.githubusercontent.com/2726345/88343907-db471780-cd18-11ea-8149-10de2b06bd17.png)

That happens because those components were already evaluated and they are using the react context from the older `ProductContext`, which will not be populated in the product page because it is using the react context from the new `ProductContext` version.

#### How to test it? \*

Reproducing the error:
- Go to the storetheme homepage.
- Scroll down to the shelf to make sure the product context is loaded (do not hover any product).
- Install a different version of the `vtex.product-context` app.
- Click to navigate to some product page and you will see a page the endless loading page.

Try this process again after linking this render-runtime and the error will not happen.