### PR TITLE
add bindingaddress qs on pickruntime request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prefetch not working on myvtex on stores that have multiple bindings.
 
 ## [8.111.1] - 2020-07-24
 ### Changed


### PR DESCRIPTION
#### What does this PR do? \*

On myvtex, there is no rootpath, a lot of the requests base themselves on `__bindingAddress` querystring.

The pickruntime for prefetch was not being done with this qs and so what resulting in errors.

This pr fixes it and does not break what should keep working

#### How to test it? \*

Navigate here: https://fidelis--powerplanet.myvtex.com/?__bindingAddress=b2c.powerplanet.com/pt

And here: https://storetheme.vtex.com/?workspace=fidelis

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
