### PR TITLE
Feature/simpler blink fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Simplified image-blinking prevention on partial hydration.
 
 ## [8.111.1] - 2020-07-24
 ### Changed

--- a/react/components/Hydration/PreventHydration.tsx
+++ b/react/components/Hydration/PreventHydration.tsx
@@ -130,14 +130,13 @@ const useEagerImages = (treePath: string, shouldMakeImagesEager?: boolean) => {
       safeQuerySelector<HTMLImageElement>(`img[data-src="${image.src}"]`)
     )
 
-    // Just a sanity check
     if (!images) {
       return
     }
 
     for (const image of images) {
       if (!image) {
-        return
+        continue
       }
       image.classList.remove('lazyload')
       image.setAttribute('loading', 'eager')


### PR DESCRIPTION
#### What does this PR do? \*
Simplifies the logic that prevents blinking images on partial hydration.

The intention is to prevent weird react bugs that may happen.

Instead of reusing the previous already-loaded image elements, it just disables lazyloading from the newly rendered ones.

To test, go to this page (without "Disable cache" turned on), and scroll down to the shelf. The images shouldn't blink
(this is the current behaviour already, this PR just simplifies the logic)

https://storetheme.vtex.com/?workspace=lbebberblink1&v=01

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
