### PR TITLE
Update render-session to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Updates render-session to 1.9.1, which calls VTEX ID refresh token route before Session.
 
 ## [8.111.3] - 2020-08-20
 ### Changed

--- a/react/externals.json
+++ b/react/externals.json
@@ -3,7 +3,7 @@
     "dev": [
       {
         "clientOnly": true,
-        "path": "npm:vtex-render-session@1.8.1/dist/index.js"
+        "path": "npm:vtex-render-session@1.9.1/dist/index.js"
       },
       {
         "path": "npm:bluebird@3.5.1/js/browser/bluebird.js",

--- a/react/externals.json
+++ b/react/externals.json
@@ -82,7 +82,7 @@
     "prod": [
       {
         "clientOnly": true,
-        "path": "npm:vtex-render-session@1.8.1/dist/index.min.js"
+        "path": "npm:vtex-render-session@1.9.1/dist/index.min.js"
       },
       {
         "path": "npm:bluebird@3.5.1/js/browser/bluebird.min.js",


### PR DESCRIPTION
#### What does this PR do? \*

Updates render-session to 1.9.1 ([this PR](https://github.com/vtex-apps/render-session/pull/28)).

#### How to test it? \*


#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
