### PR TITLE
Add memo to blocks children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Memoize blocks children so they only re-render when props change.
 
 ## [8.114.0] - 2020-09-06
 ### Changed

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -1,5 +1,5 @@
 import { mergeDeepRight, reduce } from 'ramda'
-import React, { FC, Fragment, Suspense } from 'react'
+import React, { FC, Fragment, Suspense, useMemo } from 'react'
 
 import ComponentLoader from './ComponentLoader'
 import Loading from '../Loading'
@@ -195,20 +195,21 @@ const ExtensionPoint: FC<Props> = (props) => {
     appSettings,
   ])
 
+  const componentChildren = useMemo(() => {
+    const isCompositionChildren =
+      extension && extension.composition === 'children'
+
+    return isCompositionChildren && extension?.blocks
+      ? getChildExtensions(runtime, newTreePath)
+      : children
+  }, [children, extension, newTreePath, runtime])
+
   if (
     /* Stops rendering if the extension is not found. Useful for optional ExtensionPoints */
     !extension
   ) {
     return null
   }
-
-  const isCompositionChildren =
-    extension && extension.composition === 'children'
-
-  const componentChildren =
-    isCompositionChildren && extension.blocks
-      ? getChildExtensions(runtime, newTreePath)
-      : children
 
   const isRootTreePath = newTreePath.indexOf('/') === -1
 


### PR DESCRIPTION
#### What does this PR do? \*

Adds a simple memoization to the `children` object passed down to blocks in order to enable memoization solely on the props, which can benefit components that render a lot of stuff to partially memoize some of the tree.

#### How to test it? \*

Use the same testing plan as vtex-apps/checkout-cart#61. The product list component has been memoized (and it wouldn't work without this PR because the children would change every render, making the memoization useless) in order to avoid rendering all of the products in the orderForm when you alter the quantity of only one of them.

#### Describe alternatives you've considered, if any. \*

One alternative would require a change in the product-list component itself, where it wouldn't depend on the children but would tigh the implementation of the product list item to the component itself and make any customizations the agencies have done thrown away.

#### Related to / Depends on \*

N/A