### PR TITLE
Better fold + lazy footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for lazy rendering the page footer via `enableLazyFooter` setting.
 
 ### Changed
-- Fold inserts an empty div inside the page for spacing, instead of stretching the overall page.
+- Fold inserts empty divs inside the page for spacing, instead of stretching the overall page.
+- Fold uses view detection on each concealed block, instead of showing them all at once on scroll.
 
 ## [8.121.0] - 2020-09-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for lazy rendering the page footer via `enableLazyFooter` setting.
+
+### Changed
+- Fold inserts an empty div inside the page for spacing, instead of stretching the overall page.
 
 ## [8.121.0] - 2020-09-21
 ### Added

--- a/react/components/LazyRender.tsx
+++ b/react/components/LazyRender.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const LazyRender: FunctionComponent<Props> = ({
   children,
-  height = 300,
+  height = 400,
   offset = 300,
   debug = false,
 }) => {

--- a/react/components/LazyRender.tsx
+++ b/react/components/LazyRender.tsx
@@ -11,7 +11,6 @@ const LazyRender: FunctionComponent<Props> = ({
   children,
   height = 400,
   offset = 300,
-  debug = false,
 }) => {
   const ref = useRef(null)
   const [hasBeenViewed, setHasBeenViewed] = useState(false)
@@ -20,9 +19,6 @@ const LazyRender: FunctionComponent<Props> = ({
     ref,
     onView: () => {
       setHasBeenViewed(true)
-      if (debug) {
-        console.log('ViewDetector has been viewed')
-      }
     },
     once: true,
     initializeOnInteraction: true,
@@ -38,7 +34,6 @@ const LazyRender: FunctionComponent<Props> = ({
         position: 'relative',
         width: '100%',
         height,
-        border: debug ? '1px solid red' : undefined,
       }}
     >
       <div
@@ -50,7 +45,6 @@ const LazyRender: FunctionComponent<Props> = ({
           height: '100%',
           paddingBottom: offset * 2,
           boxSizing: 'content-box',
-          border: debug ? '1px dotted red' : undefined,
         }}
       />
     </div>

--- a/react/components/LazyRender.tsx
+++ b/react/components/LazyRender.tsx
@@ -1,0 +1,58 @@
+import React, { FunctionComponent, useRef, useState } from 'react'
+import { useOnView } from '../hooks/viewDetection'
+
+interface Props {
+  height?: number
+  offset?: number
+  debug?: boolean
+}
+
+const LazyRender: FunctionComponent<Props> = ({
+  children,
+  height = 300,
+  offset = 300,
+  debug = false,
+}) => {
+  const ref = useRef(null)
+  const [hasBeenViewed, setHasBeenViewed] = useState(false)
+
+  useOnView({
+    ref,
+    onView: () => {
+      setHasBeenViewed(true)
+      if (debug) {
+        console.log('ViewDetector has been viewed')
+      }
+    },
+    once: true,
+    initializeOnInteraction: true,
+  })
+
+  if (hasBeenViewed) {
+    return <>{children}</>
+  }
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height,
+        border: debug ? '1px solid red' : undefined,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          width: '100%',
+          top: -offset,
+          bottom: -offset,
+          border: debug ? '1px dotted red' : undefined,
+        }}
+      />
+    </div>
+  )
+}
+
+export default LazyRender

--- a/react/components/LazyRender.tsx
+++ b/react/components/LazyRender.tsx
@@ -34,7 +34,6 @@ const LazyRender: FunctionComponent<Props> = ({
 
   return (
     <div
-      ref={ref}
       style={{
         position: 'relative',
         width: '100%',
@@ -43,11 +42,14 @@ const LazyRender: FunctionComponent<Props> = ({
       }}
     >
       <div
+        ref={ref}
         style={{
-          position: 'absolute',
+          position: 'relative',
           width: '100%',
           top: -offset,
-          bottom: -offset,
+          height: '100%',
+          paddingBottom: offset * 2,
+          boxSizing: 'content-box',
           border: debug ? '1px dotted red' : undefined,
         }}
       />


### PR DESCRIPTION
#### What does this PR do? \*
Improves fold implementation and functionality, and adds support for lazy footer rendering, enabled via `enableLazyFooter` setting.

This PR also refactors the `LayoutContainer` class into a Function Component, and also simplifies its implementation a bit.

Before, if the user scrolled reasonably quickly, they would stumble upon the footer, which would promptly blink away, and then the whole rest of the page would render
![before-als](https://user-images.githubusercontent.com/5691711/94059282-942cdf80-fdb8-11ea-9f60-112056ef2615.gif)
![before-footer](https://user-images.githubusercontent.com/5691711/94059414-bf173380-fdb8-11ea-8767-5e992d79eb59.gif)

With this PR, each concealed row adds its own empty spacer div, which brings the scroll area closer to the actual value. It also adds spacing between the above-the-fold content and the footer, which prevents the user from seeing it in most cases.

![after-als-quick](https://user-images.githubusercontent.com/5691711/94059626-11585480-fdb9-11ea-8a45-456607156079.gif)
![after-quick](https://user-images.githubusercontent.com/5691711/94059645-174e3580-fdb9-11ea-8f63-0bc3b31b2d45.gif)

Also, since it renders the rows one by one, instead of the whole page in a single blow, the rendering should be much smoother, which is more noticeable if the user scrolls more slowly.
![after-als-smooth](https://user-images.githubusercontent.com/5691711/94059460-d1916d00-fdb8-11ea-8288-8fd6a2a2e3b4.gif)
![after-smooth](https://user-images.githubusercontent.com/5691711/94059577-04d3fc00-fdb9-11ea-8c7e-382c5b93d47b.gif)

This PR also adds lazy rendering of the footer, if `enableLazyFooter`  is enabled (via `vtex settings set vtex.store enableLazyFooter true`)

In the example below, JS is disabled. Notice via the scrollbar that the user is scrolling to the bottom of the page, with no footer in sight. This should improve the initial rendering performance.
![carrefour-empty](https://user-images.githubusercontent.com/5691711/94059830-64320c00-fdb9-11ea-9557-a69746282243.gif)

After and before, throttled 4x
<img width="473" alt="Screen Shot 2020-09-23 at 16 32 31" src="https://user-images.githubusercontent.com/5691711/94060513-75c7e380-fdba-11ea-9323-bbe4ab92f077.png">


#### How to test it? \*

Can be tested in the following workspaces:
https://www.als.com/?workspace=lbebberfold1&v=01
https://www.exito.com/?workspace=lbebberfold1
https://www.carrefour.com.br/?ak-testab=vtex&workspace=lbebberfold1&v=01

Just refresh and scroll around a few times, with varying speed.

Compare with their respective master workspaces:
https://www.als.com/
https://www.exito.com/
https://www.carrefour.com.br/?ak-testab=vtex

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
