### PR TITLE
Fix: Styles update event not being emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fix
+### Fixed
 - Styles update event not being emitted.
 
 ## [8.123.1] - 2020-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Styles update event not being emitted.
 
 ## [8.123.1] - 2020-10-14
 ### Fixed

--- a/react/package.json
+++ b/react/package.json
@@ -79,7 +79,7 @@
     "react-no-ssr": "^1.1.0",
     "regenerator-runtime": "^0.13.1",
     "ts-jest": "^24.0.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "husky": {
     "hooks": {

--- a/react/utils/events.ts
+++ b/react/utils/events.ts
@@ -128,12 +128,12 @@ const initSSE = (
         break
       case 'styles':
         console.log('[styles] Styles changed.')
-        if (updated.indexOf('style.json') > -1) {
+        if (updated.some((filePath) => /style\.json/gi.test(filePath))) {
           emittersByWorkspace[`${account}/${workspace}`].forEach((e) =>
             e.emit('styleTachyonsUpdate')
           )
         }
-        if (updated.indexOf('overrides.css') > -1) {
+        if (updated.some((filePath) => /overrides\.css/gi.test(filePath))) {
           emittersByWorkspace[`${account}/${workspace}`].forEach((e) =>
             e.emit('styleOverrides')
           )

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -8056,10 +8056,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.4"


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug where updating styles would no emit events thus not hot-reloading styles.

[Issue on Store Discussion](https://github.com/vtex-apps/store-discussion/issues/435).

#### How to test it? \*

- Go to [Workspace](https://styles--beightoneagency.myvtex.com/pao?_q=pao&map=ft)
- Link an app or theme that has styles.json or css overrides.
- Make changes on any styles files.
- Observe that hot-reloading now works.

#### Describe alternatives you've considered, if any. \*

N/A

#### Related to / Depends on \*

N/A
