### PR TITLE
Remount lazy loaded images when src changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `src` of lazy images not being updated when the `src` prop changes.
 
 ## [8.123.1] - 2020-10-14
 ### Fixed

--- a/react/components/LazyImages.tsx
+++ b/react/components/LazyImages.tsx
@@ -67,6 +67,9 @@ const MaybeLazyImage: FC<MaybeLazyImageProps> = ({
          * symbol while the image hasn't been loaded */
         newImageProps = {
           ...imageProps,
+          // explicity key because we need react to re-render the whole img element
+          // in case the src changes (i.e: product-summary + sku)
+          key: imageProps.src,
           className: `lazyload ${imageProps.className ?? ''} ${
             styles.lazyload
           }`,


### PR DESCRIPTION
#### What does this PR do? \*

Currently, if a lazyloaded `img` tag has its `src` attribute changed, our monkey patched `img`s are not changing the `src` attribute, only the `data-src`. This PR adds a `key` based on the passed `src` so `React` is re-renders the whole tag when the src changes. 

#### How to test it? \*

**Compare:**
https://kiwi--celsia.myvtex.com/
https://celsia.myvtex.com/

**Flow:**
1) Focus on search bar
2) Type `samsung`
3) Change the sku variation and see if the image changes

![image](https://user-images.githubusercontent.com/12702016/96294375-a7e7f200-0fc2-11eb-842e-f08a56489730.png)



#### Describe alternatives you've considered, if any. \*

n/a

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
