### PR TITLE
Fix exported type of canUseDOM and culture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Exported type of `canUseDOM`.
+- Add missing fields to type `culture`.
 
 ## [8.124.0] - 2020-10-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Exported type of `canUseDOM`.
 
 ## [8.124.0] - 2020-10-21
 ### Fixed

--- a/react/components/canUseDOM.ts
+++ b/react/components/canUseDOM.ts
@@ -1,1 +1,3 @@
-export { canUseDOM } from 'exenv'
+import { canUseDOM } from 'exenv'
+
+export default canUseDOM

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -40,7 +40,7 @@ import { RenderContext, withRuntimeContext } from '../components/RenderContext'
  * So `useRuntime` should be imported from `../components/useRuntime` rather than
  * being imported along with the other functions from `RenderContext` */
 import useRuntime from '../components/useRuntime'
-import { canUseDOM } from '../components/canUseDOM'
+import canUseDOM from '../components/canUseDOM'
 import RenderProvider from '../components/RenderProvider'
 import { getVTEXImgHost } from '../utils/assets'
 import PageCacheControl from '../utils/cacheControl'

--- a/react/typings/runtime.ts
+++ b/react/typings/runtime.ts
@@ -96,11 +96,13 @@ interface RenderHints {
 }
 
 interface Culture {
-  availableLocales: string[]
-  locale: string
-  language: string
   country: string
+  availableLocales: string[]
   currency: string
+  customCurrencyDecimalDigits: number | null
+  customCurrencySymbol: string | null
+  language: string
+  locale: string
 }
 
 export interface Pages {


### PR DESCRIPTION
#### What does this PR do? \*

canUseDOM was not being exported as a type

![image](https://user-images.githubusercontent.com/284515/96759969-1fe15e00-13af-11eb-9335-d7a9dc983acf.png)

#### How to test it? \*

Link this and then link an app after running `vtex setup --typings`

You can see in this workspace that I have the vtex.format-currency app linked:
https://breno--storecomponents.myvtex.com/

I rendered null if canUseDOM is true
![image](https://user-images.githubusercontent.com/284515/96766280-37b9e180-13b1-11eb-980d-e608f58029e9.png)

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

n/a
