### PR TITLE
Fix fold issue - user scrolling the page before JS being initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Trigger interaction event on `viewDetection` if the user has scrolled the page before JS being initialized.
 
 ## [8.124.3] - 2020-10-30
 ### Fixed

--- a/react/hooks/viewDetection.tsx
+++ b/react/hooks/viewDetection.tsx
@@ -93,6 +93,12 @@ const useOnView = ({
       window?.document?.addEventListener('scroll', handleInteraction)
       window?.document?.addEventListener('mouseover', handleInteraction)
 
+      /** Triggers interaction event if the user has scrolled the
+       * page before JS being initialized */
+      if (window?.scrollY > 0) {
+        handleInteraction()
+      }
+
       return unobserve
     }
 


### PR DESCRIPTION
#### What does this PR do? \*
As the title says

If the user scrolls the page before JS being initialized, the user interaction detection is not triggered until the user scrolls again. This PR checks if the page scroll is >0 and triggers the event right away if that's the case

#### How to test it? \*

Workspace:
https://mercado.carrefour.com.br/?workspace=lbebberfixfold5&v=04

Basically just open the page and interact with it to see if it breaks.
Then, scroll down to about the middle of the page, and refresh the page, and *keep the mouse still*. The page content should appear without user interaction.

After/Before demonstration (note the red bar on the header appearing--that's when the page has been hydrated in this case)
![carrefourfood-hydrate](https://user-images.githubusercontent.com/5691711/99863454-06cdf780-2b7d-11eb-865e-335fecb836ec.gif)

Related with https://github.com/vtex/render-server/pull/695

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
