### PR TITLE
Feature/inner fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `__fold__` blocks inside other blocks.
 
 ## [8.124.4] - 2020-11-21
 ### Fixed

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -12,6 +12,7 @@ import GenericPreview from '../Preview/GenericPreview'
 import LoadingBar from '../LoadingBar'
 import { LazyImages } from '../LazyImages'
 import LazyRender from '../LazyRender'
+import FoldableContainer from '../FoldableContainer'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
@@ -65,7 +66,15 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     return isChild && isNotSlot
   })
 
-  return childBlocks.map((child, i) => {
+  /** Rudimentary detection of __fold__ blocks. Shouldn't be a problem
+   * because other types of fold blocks aren't used inside other blocks
+   * anyway. Could be improved if necessary.
+   */
+  const foldIndex = childBlocks.findIndex((child) =>
+    child.extensionPointId.includes('_fold_')
+  )
+
+  const childExtensions = childBlocks.map((child, i) => {
     const childTreePath = mountTreePath(child.extensionPointId, treePath)
 
     const childExtension = runtime?.extensions[childTreePath]
@@ -80,6 +89,15 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
       />
     )
   })
+
+  if (foldIndex > -1) {
+    return (
+      <FoldableContainer foldIndex={foldIndex}>
+        {childExtensions}
+      </FoldableContainer>
+    )
+  }
+  return childExtensions
 }
 
 function withOuterExtensions(

--- a/react/components/FoldableContainer.tsx
+++ b/react/components/FoldableContainer.tsx
@@ -1,0 +1,28 @@
+import React, { FunctionComponent } from 'react'
+import LazyRender from './LazyRender'
+
+interface Props {
+  foldIndex?: number
+}
+const FoldableContainer: FunctionComponent<Props> = ({
+  children,
+  foldIndex,
+}) => {
+  if (foldIndex == null || foldIndex === -1) {
+    return <>{children}</>
+  }
+  const childrenArray = React.Children.toArray(children)
+  const aboveTheFold = childrenArray.slice(0, foldIndex)
+  const belowTheFold = childrenArray.slice(foldIndex).map((element, i) => {
+    return <LazyRender key={i}>{element}</LazyRender>
+  })
+
+  return (
+    <>
+      {aboveTheFold}
+      {belowTheFold}
+    </>
+  )
+}
+
+export default FoldableContainer

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -4,7 +4,7 @@ import ExtensionPoint from './ExtensionPoint'
 import { useRuntime } from './RenderContext'
 import { LoadingWrapper } from './LoadingContext'
 import { LazyImages } from './LazyImages'
-import LazyRender from './LazyRender'
+import FoldableContainer from './FoldableContainer'
 
 type Element = string | ElementArray
 type ElementArray = Element[]
@@ -85,16 +85,20 @@ const Container: FunctionComponent<ContainerProps> = ({
         )
       }
 
-      if (hasFold && i > foldIndex) {
-        container = (
-          <LazyRender key={element.toString()}>{container}</LazyRender>
-        )
-      }
-
       return container
     })
 
-  return <div className={className}>{wrappedElements}</div>
+  if (!hasFold) {
+    return <div className={className}>{wrappedElements}</div>
+  }
+
+  return (
+    <div className={className}>
+      <FoldableContainer foldIndex={foldIndex}>
+        {wrappedElements}
+      </FoldableContainer>
+    </div>
+  )
 }
 
 const LayoutContainer: React.FunctionComponent<LayoutContainerProps> = (

--- a/react/hooks/prefetch.ts
+++ b/react/hooks/prefetch.ts
@@ -322,6 +322,7 @@ export const usePrefetchAttempt = ({
       }, 1)
     },
     bailOut: !hints.mobile,
+    initializeOnInteraction: true,
     threshold: 0.75,
   })
 


### PR DESCRIPTION
#### What does this PR do? \*
Adds support for `__fold__` blocks inside other blocks.



#### How to test it? \*
https://www.carrefour.com.br/notebook-samsung-intel-core-i7-9750h-16gb-1tb-256gb-15-6-windows-10-home-odyssey-np850xbd-xg2br-5923425/p?workspace=lbebberinnerfold1

If you scroll down very quickly, you should see the lazy rendered blocks appearing as they cross into the viewport. This is to confirm that the feature is working properly.
![carrefour-innerfould-scrollquick](https://user-images.githubusercontent.com/5691711/99886427-303d6080-2c1b-11eb-8c96-9653166fb1be.gif)


Compare with the version currently in production, where the content is already rendered by the time you would scroll down (which is nicer lol, but heavier)
![carrefour-innerfold-off](https://user-images.githubusercontent.com/5691711/99886452-6bd82a80-2c1b-11eb-9b6b-04f6c741281a.gif)


If you scroll down a little slower there shouldn't be much shifting around though.
![carrefour-innerfold-scrollsmooth](https://user-images.githubusercontent.com/5691711/99886399-f0767900-2c1a-11eb-9ccd-72f32de9a33a.gif)

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
