### PR TITLE
Fix/lazy footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where `after` pixels would be "lazy rendered" if `enableLazyFooter` was enabled, which would cause both functional and layout issues.
 
 ## [8.125.0] - 2020-11-21
 ### Added

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -124,26 +124,33 @@ function withOuterExtensions(
     />
   ))
 
-  const afterElements = after.map((afterId) => (
-    <ExtensionPoint
-      id={afterId}
-      key={afterId}
-      treePath={treePath}
-      params={props.params}
-      query={props.query}
-    />
-  ))
+  const afterElements = after.map((afterId) => {
+    const extension = (
+      <ExtensionPoint
+        id={afterId}
+        key={afterId}
+        treePath={treePath}
+        params={props.params}
+        query={props.query}
+      />
+    )
+
+    const shouldLazyRender = lazyFooter && afterId === '$after_footer'
+    return shouldLazyRender ? (
+      <LazyRender key={afterId}>{extension}</LazyRender>
+    ) : (
+      extension
+    )
+  })
 
   const isRootTreePath = treePath.indexOf('/') === -1
-
-  const wrappedFooter = <LazyImages>{afterElements}</LazyImages>
 
   const wrapped = (
     <Fragment key={`wrapped-${treePath}`}>
       <LazyImages>{beforeElements}</LazyImages>
       {element}
       {isRootTreePath && <div className="flex flex-grow-1" />}
-      {lazyFooter ? <LazyRender>{wrappedFooter}</LazyRender> : wrappedFooter}
+      <LazyImages>{afterElements}</LazyImages>
     </Fragment>
   )
 


### PR DESCRIPTION
#### What does this PR do? \*

Fixes issue with `enableLazyFooter` setting

#### How to test it? \*

Before:
https://www.carrefour.com.br/refrigerador-frost-free-1-porta-322l-branco-rfe39-electrolux-110v-mp15274896/p?idsku=1322062&workspace=lazyfooternotworking&v=02
![lazyfooter-no](https://user-images.githubusercontent.com/5691711/99923338-0451d600-2d14-11eb-9933-e873637b8c90.gif)

You can see that there's a big empty space at the top; this is the `pixels` which are `after` elements but are not being rendered.

After:
https://www.carrefour.com.br/refrigerador-frost-free-1-porta-322l-branco-rfe39-electrolux-110v-mp15274896/p?idsku=1322062&workspace=lazyfooterworking&v=01
![lazyfooter-yes](https://user-images.githubusercontent.com/5691711/99923342-06b43000-2d14-11eb-84d2-9848ee9163db.gif)

This issue is not happening in this workspace.

You can see that the footer is being lazy rendered by opening the "Network" tab on devtools, and searching for the string `5b00`, which refers to an image at the footer. The search should turn empy....
<img width="465" alt="Screen Shot 2020-11-22 at 22 44 16" src="https://user-images.githubusercontent.com/5691711/99923409-69a5c700-2d14-11eb-84ab-c5d25e696efb.png">

...until you scroll to the bottom of the page
<img width="504" alt="Screen Shot 2020-11-22 at 22 44 27" src="https://user-images.githubusercontent.com/5691711/99923417-73c7c580-2d14-11eb-861e-461c1f24f63c.png">




#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
