### PR TITLE
Switching fallback to scope: private on GraphQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fallbacking to `scope: private` on GraphQL queries whenever we miss the queries's map cache.
 
 ## [8.126.2] - 2020-12-02 [YANKED]
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.126.2",
+  "version": "8.126.3-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/utils/client/links/uriSwitchLink.ts
+++ b/react/utils/client/links/uriSwitchLink.ts
@@ -63,7 +63,7 @@ const extractHints = (query: ASTNode, meta: CacheHints) => {
 
   const {
     maxAge = 'long',
-    scope = 'public',
+    scope = 'private',
     version = 1,
     provider,
     sender,


### PR DESCRIPTION
On our Splunk logs, we've identified several `orderForm`-like queries that were coming as `GET /_v/public/graphql`. This is erratic as these queries should always be private. Coming like that, there's a chance that some of these requests get a cache hit on some layer.

We've tried forcing the private scope on the queries itself but later realized that such work would need to be replicated on other queries/apps. Since this is a critical issue for us, we've agreed that the downside of sometimes (the unusual scenario of query-map changing on an user's session) using our private routes to "public" queries is worth.

Test [here](https://lucis--storecomponents.myvtex.com)