### PR TITLE
Make render8 pages work for stores running on portal 2, Return of the Jedi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- GraphQL client link and assets for pages served through Janus.
 
 ## [8.126.3] - 2020-12-03
 ### Changed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -243,6 +243,7 @@ export class RenderProvider extends Component<
       components,
       exposeBindingAddress,
       extensions,
+      isJanusProxied,
       pages,
       page,
       query,
@@ -253,7 +254,7 @@ export class RenderProvider extends Component<
       loadedDevices,
     } = props.runtime
     const { apollo, history, deviceInfo, sessionPromise } = props
-    const ignoreCanonicalReplacement = query && query.map
+    const ignoreCanonicalReplacement = isJanusProxied || (query && query.map)
     this.fetcher = fetch
 
     if (binding && canUseDOM) {
@@ -581,13 +582,22 @@ export class RenderProvider extends Component<
   }
 
   private updateDeviceBlocks = async (deviceInfo: DeviceInfo) => {
+    const {
+      runtime: { isJanusProxied },
+    } = this.props
+
+    const {
+      route: { path },
+    } = this.state
+
     const query = queryStringToMap(location.search) as RenderRuntime['query']
 
     const { components, extensions, messages } = await fetchServerPage({
       fetcher: this.fetcher,
-      path: this.state.route.path,
+      path,
       query,
       deviceInfo,
+      isJanusProxied,
     })
 
     await this.fetchComponents(components, extensions)
@@ -647,7 +657,7 @@ export class RenderProvider extends Component<
 
   public onPageChanged = (location: RenderHistoryLocation) => {
     const {
-      runtime: { renderMajor, query: queryFromRuntime },
+      runtime: { renderMajor, query: queryFromRuntime, isJanusProxied },
     } = this.props
 
     const {
@@ -765,6 +775,7 @@ export class RenderProvider extends Component<
           query,
           workspace: workspaceFromQuery,
           deviceInfo,
+          isJanusProxied,
         }).then(
           async ({
             appsEtag,
@@ -971,7 +982,7 @@ export class RenderProvider extends Component<
 
   public updateRuntime = async (options?: PageContextOptions) => {
     const {
-      runtime: { renderMajor, query: queryFromRuntime },
+      runtime: { renderMajor, query: queryFromRuntime, isJanusProxied },
     } = this.props
     const {
       page,
@@ -1004,6 +1015,7 @@ export class RenderProvider extends Component<
           fetcher: this.fetcher,
           workspace: workspaceFromQuery,
           deviceInfo,
+          isJanusProxied,
         })
       : await fetchNavigationPage({
           apolloClient: this.apolloClient,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -297,7 +297,9 @@ function start() {
       window.__RUNTIME__.query = { ...serverQuery, ...browserQuery }
     }
 
-    const runtime = window.__RUNTIME__
+    const runtime: RenderRuntime = window.__RUNTIME__
+    runtime.isJanusProxied =
+      canUseDOM && window.location.pathname.startsWith('/api/io/')
     const rootName = runtime.page
     validateRootComponent(rootName, runtime.extensions)
 

--- a/react/typings/runtime.ts
+++ b/react/typings/runtime.ts
@@ -59,6 +59,7 @@ export interface RenderRuntime {
     data: string
   }>
   uncriticalStyleRefs?: StyleRefs
+  isJanusProxied?: boolean
 }
 
 interface Route {

--- a/react/utils/host.ts
+++ b/react/utils/host.ts
@@ -1,22 +1,35 @@
 import { canUseDOM } from 'exenv'
+
 import { RenderRuntime } from '../typings/runtime'
 
-const isRenderServedPage = () => {
+function isRenderServedPage() {
   const generatorMetaTag = document.querySelector(`meta[name='generator']`)
   const generator = generatorMetaTag && generatorMetaTag.getAttribute('content')
   return generator && generator.startsWith('vtex.render-server')
 }
 
-export const getBaseURI = (runtime: RenderRuntime) => {
-  const { account, workspace, publicEndpoint, rootPath = '' } = runtime
+export function getBaseURI(runtime: RenderRuntime) {
+  const {
+    account,
+    workspace,
+    publicEndpoint,
+    isJanusProxied,
+    rootPath = '',
+  } = runtime
+
   if (!canUseDOM) {
     return `${workspace}--${account}.${publicEndpoint}`
-  } else {
-    const {
-      location: { hostname },
-    } = window
-    return hostname.endsWith(`.${publicEndpoint}`) || isRenderServedPage()
-      ? hostname + rootPath
-      : `${hostname}/api/io`
   }
+
+  const {
+    location: { hostname },
+  } = window
+
+  if (isJanusProxied) {
+    return `${hostname}/api/io`
+  }
+
+  return hostname.endsWith(`.${publicEndpoint}`) || isRenderServedPage()
+    ? hostname + rootPath
+    : `${hostname}/api/io`
 }

--- a/react/utils/routes.ts
+++ b/react/utils/routes.ts
@@ -105,6 +105,16 @@ const parseDefaultPagesQueryResponse = (
   }
 }
 
+function prependIOProxy(path: string) {
+  if (!path) {
+    return '/api/io'
+  }
+
+  const joiner = path.startsWith('/') ? '' : '/'
+
+  return `/api/io${joiner}${path}`
+}
+
 const runtimeFields = [
   'appsEtag',
   'blocks',
@@ -148,17 +158,20 @@ function getRelativeURLWithQuery({
 
 export const fetchServerPage = async ({
   fetcher,
-  path,
+  path: rawPath,
   query: rawQuery,
   workspace,
   deviceInfo,
+  isJanusProxied,
 }: {
   path: string
   query?: Record<string, string>
   fetcher: GlobalFetch['fetch']
   workspace?: string
   deviceInfo?: DeviceInfo
+  isJanusProxied?: boolean
 }): Promise<ParsedServerPageResponse> => {
+  const path = isJanusProxied ? prependIOProxy(rawPath) : rawPath
   const url = getRelativeURLWithQuery({
     path,
     query: {
@@ -191,7 +204,9 @@ export const fetchServerPage = async ({
     queryData,
   } = page
   if (routeId === 'redirect') {
-    window.location.href = route.path
+    window.location.href = isJanusProxied
+      ? prependIOProxy(route.path)
+      : route.path
   }
 
   const queryString = stringify(rawQuery || {})


### PR DESCRIPTION
#### What does this PR do? \*

<img width="1279" alt="Screen Shot 2020-12-03 at 6 17 35 PM" src="https://user-images.githubusercontent.com/3926634/101089412-e1d17f80-3593-11eb-8e72-7a21759626b6.png">

<img width="1280" alt="Screen Shot 2020-12-03 at 6 11 38 PM" src="https://user-images.githubusercontent.com/3926634/101089426-e6963380-3593-11eb-803a-787cbe21fb62.png">

#### How to test it? \*

- visit: https://ioqa.myvtexprod.com/?workspace=felipe2
- or: https://ioqa.vtexcommercestable.com.br/?workspace=felipe2


#### Related to / Depends on \*

- Agora vai: https://github.com/vtex-apps/render-runtime/pull/580