### PR TITLE
Extend prefetch scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Prefetch does not work when the document has already been loaded.
+
 ## [8.128.0] - 2021-03-12
 
 ### Added

--- a/react/components/Prefetch/PrefetchContext.tsx
+++ b/react/components/Prefetch/PrefetchContext.tsx
@@ -105,17 +105,25 @@ export const PrefetchContextProvider: FC<{ history: History<any> | null }> = ({
     if (history) {
       unlistenRef.current = history.listen(onPageChanged)
     }
-    window.addEventListener(
-      'load',
-      () => {
-        if (isPrefetchEnabled(storeSettings)) {
-          setTimeout(() => {
-            state.queue.start()
-          }, getTimeout(hints.mobile))
-        }
-      },
-      { once: true }
-    )
+
+    if (isPrefetchEnabled(storeSettings)) {
+      if (window?.document?.readyState === 'complete') {
+        setTimeout(() => {
+          state.queue.start()
+        }, getTimeout(hints.mobile))
+      } else {
+        window?.document?.addEventListener(
+          'load',
+          () => {
+            setTimeout(() => {
+              state.queue.start()
+            }, getTimeout(hints.mobile))
+          },
+          { once: true }
+        )
+      }
+    }
+
     return () => {
       if (unlistenRef.current) {
         unlistenRef.current()


### PR DESCRIPTION
#### What does this PR do? *

The prefetch queue listener is not triggered when the document has already been loaded. So, in this case, instead of adding a listener, we could just start the queue to make prefetch work in all scenarios.

#### How to test it? \*

https://vitorflg--storecomponents.myvtex.com/

Prefetch should work in all scenarios.

#### Describe alternatives you've considered if any. \*

X

#### Related to / Depends on \*

X
