### PR TITLE
Fix/update device blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix wrong request when trying to update device blocks with rootPath.
 
 ## [8.126.6] - 2021-01-11
 ### Fixed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -1,6 +1,6 @@
 import debounce from 'debounce'
 import { canUseDOM } from 'exenv'
-import { equals, merge, mergeWith, difference } from 'ramda'
+import { equals, merge, mergeWith, difference, path } from 'ramda'
 import { History, UnregisterCallback, LocationListener } from 'history'
 import PropTypes from 'prop-types'
 import React, { Component, Fragment, ReactElement, Suspense } from 'react'
@@ -128,6 +128,15 @@ const areOptionsDifferent = (a: NavigateOptions, b: NavigateOptions) => {
     a.rootPath !== b.rootPath ||
     !equals(a.params, b.params)
   )
+}
+
+const prependRootPath = (path: string, rootPath?: string) => {
+  if (!rootPath) {
+    return path
+  }
+
+  const maybeSlash = path.startsWith('/') ? '' : '/'
+  return `${rootPath}${maybeSlash}${path}`
 }
 
 interface NavigationState {
@@ -583,7 +592,7 @@ export class RenderProvider extends Component<
 
   private updateDeviceBlocks = async (deviceInfo: DeviceInfo) => {
     const {
-      runtime: { isJanusProxied },
+      runtime: { isJanusProxied, rootPath },
     } = this.props
 
     const {
@@ -594,7 +603,7 @@ export class RenderProvider extends Component<
 
     const { components, extensions, messages } = await fetchServerPage({
       fetcher: this.fetcher,
-      path,
+      path: prependRootPath(path, rootPath),
       query,
       deviceInfo,
       isJanusProxied,


### PR DESCRIPTION
#### What does this PR do? \*
Fix wrong request when trying to update device blocks with rootPath.

#### How to test it? \*

The error can be seen in any store with `rootPath`. Go to http://motorola.com/us/ and try to resize the window to a mobile size. It won't work because the request to _pickRuntime_ is going out without the `rootPath`.

The fix is already installed (beta) in the `sbdsef` account.
Resizing the window works here: https://www.stanleyengineeredfastening.com/en-US/catalog-global/