### PR TITLE
Disable folding on the site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [8.95.1] - 2020-03-11
 
 ## [8.95.0] - 2020-03-10
+### Fixed
+- Site editor is not rendering some blocks due to the fold block.
 ### Removed
 - Removes sentry from externals.json so this asset isn't rendered to the browser
 

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -13,6 +13,8 @@ import LoadingBar from '../LoadingBar'
 import { LazyImages } from '../LazyImages'
 import LazyRender from '../LazyRender'
 import FoldableContainer from '../FoldableContainer'
+import { isSiteEditorIframe } from '../../utils/dom'
+import canUseDOM from '../canUseDOM'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
@@ -90,7 +92,11 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     )
   })
 
-  if (foldIndex > -1) {
+  if (!canUseDOM) {
+    return childExtensions
+  }
+
+  if (foldIndex > -1 && !isSiteEditorIframe) {
     return (
       <FoldableContainer foldIndex={foldIndex}>
         {childExtensions}

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -92,7 +92,8 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     )
   })
 
-  if (!canUseDOM) {
+  if (runtime?.route?.path.includes('__siteEditor')) {
+    console.log('SERVER OR CLIENT')
     return childExtensions
   }
 

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -14,7 +14,7 @@ import { LazyImages } from '../LazyImages'
 import LazyRender from '../LazyRender'
 import FoldableContainer from '../FoldableContainer'
 import { isSiteEditorIframe } from '../../utils/dom'
-import canUseDOM from '../canUseDOM'
+import { Route } from '../../typings/runtime'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
@@ -114,7 +114,8 @@ function withOuterExtensions(
   props: any,
   element: JSX.Element,
   // TODO: these args are getting ridiculous, maybe group them in an object
-  lazyFooter: boolean
+  lazyFooter: boolean,
+  route: Route
 ) {
   if (before.length === 0 && after.length === 0 && around.length === 0) {
     return element
@@ -141,7 +142,11 @@ function withOuterExtensions(
       />
     )
 
-    const shouldLazyRender = lazyFooter && afterId === '$after_footer'
+    const shouldLazyRender =
+      lazyFooter &&
+      afterId === '$after_footer' &&
+      !route?.path.includes('__siteEditor')
+
     return shouldLazyRender ? (
       <LazyRender key={afterId}>{extension}</LazyRender>
     ) : (
@@ -280,7 +285,8 @@ const ExtensionPoint: FC<Props> = (props) => {
     newTreePath,
     mergedProps,
     componentLoader,
-    isLazyFooterEnabled
+    isLazyFooterEnabled,
+    runtime?.route
   )
 
   /**

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -93,7 +93,6 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
   })
 
   if (runtime?.route?.path.includes('__siteEditor')) {
-    console.log('SERVER OR CLIENT')
     return childExtensions
   }
 

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -6,10 +6,7 @@ import { LoadingWrapper } from './LoadingContext'
 import { LazyImages } from './LazyImages'
 import FoldableContainer from './FoldableContainer'
 import { isSiteEditorIframe } from '../utils/dom'
-import canUseDOM from './canUseDOM'
 import { Route } from '../typings/runtime'
-
-canUseDOM
 
 type Element = string | ElementArray
 type ElementArray = Element[]

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -6,7 +6,9 @@ import { LoadingWrapper } from './LoadingContext'
 import { LazyImages } from './LazyImages'
 import FoldableContainer from './FoldableContainer'
 import { isSiteEditorIframe } from '../utils/dom'
-import { canUseDOM } from '..'
+import canUseDOM from './canUseDOM'
+
+canUseDOM
 
 type Element = string | ElementArray
 type ElementArray = Element[]

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -7,6 +7,7 @@ import { LazyImages } from './LazyImages'
 import FoldableContainer from './FoldableContainer'
 import { isSiteEditorIframe } from '../utils/dom'
 import canUseDOM from './canUseDOM'
+import { Route } from '../typings/runtime'
 
 canUseDOM
 
@@ -24,6 +25,7 @@ interface ContainerProps {
   isRow: boolean
   isMobile?: boolean
   preview?: boolean
+  route?: Route
 }
 
 const Container: FunctionComponent<ContainerProps> = ({
@@ -33,6 +35,7 @@ const Container: FunctionComponent<ContainerProps> = ({
   isMobile,
   preview,
   children,
+  route,
   ...props
 }) => {
   const className = `flex flex-grow-1 w-100 ${
@@ -92,7 +95,7 @@ const Container: FunctionComponent<ContainerProps> = ({
       return container
     })
 
-  if (!hasFold || (canUseDOM && isSiteEditorIframe)) {
+  if (!hasFold || isSiteEditorIframe || route?.path?.includes('__siteEditor')) {
     return <div className={className}>{wrappedElements}</div>
   }
 
@@ -108,7 +111,7 @@ const Container: FunctionComponent<ContainerProps> = ({
 const LayoutContainer: React.FunctionComponent<LayoutContainerProps> = (
   props
 ) => {
-  const { extensions, preview, hints } = useRuntime()
+  const { extensions, preview, hints, route } = useRuntime()
   const { treePath } = useTreePath()
 
   const extension = extensions[treePath]
@@ -123,6 +126,7 @@ const LayoutContainer: React.FunctionComponent<LayoutContainerProps> = (
       preview={preview}
       isRow={false}
       isMobile={hints.mobile}
+      route={route}
     />
   )
 

--- a/react/components/LayoutContainer.tsx
+++ b/react/components/LayoutContainer.tsx
@@ -5,6 +5,8 @@ import { useRuntime } from './RenderContext'
 import { LoadingWrapper } from './LoadingContext'
 import { LazyImages } from './LazyImages'
 import FoldableContainer from './FoldableContainer'
+import { isSiteEditorIframe } from '../utils/dom'
+import { canUseDOM } from '..'
 
 type Element = string | ElementArray
 type ElementArray = Element[]
@@ -88,7 +90,7 @@ const Container: FunctionComponent<ContainerProps> = ({
       return container
     })
 
-  if (!hasFold) {
+  if (!hasFold || (canUseDOM && isSiteEditorIframe)) {
     return <div className={className}>{wrappedElements}</div>
   }
 

--- a/react/typings/runtime.ts
+++ b/react/typings/runtime.ts
@@ -62,7 +62,7 @@ export interface RenderRuntime {
   isJanusProxied?: boolean
 }
 
-interface Route {
+export interface Route {
   domain: string
   blockId: string
   canonicalPath?: string

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -222,7 +222,7 @@ export function getRouteFromPathOld(
 }
 
 const mergePersistingQueries = (currentQuery: string, query: string) => {
-  const KEYS = ['disableUserLand', '__bindingAddress']
+  const KEYS = ['disableUserLand', '__bindingAddress', '__siteEditor']
   const current = queryStringToMap(currentQuery)
   const next = queryStringToMap(query)
   const has = (value?: string) => !!value || value === null


### PR DESCRIPTION
#### What does this PR do? \*

Blocks that are under fold block sometimes not render in the blocks list of the site editor. It disables that performance feature in this scenario.

#### How to test it? \*

https://vitorflg--muji.myvtex.com/admin/cms/site-editor

#### Describe alternatives you've considered, if any. \*

Create a different component/logic flow for the site editor and the end-client render, but it would need a big refactoring.

#### Related to / Depends on \*

X
