### PR TITLE
CHK-480: Fix locale update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Legacy extension components not re-rendering when the `locale` is updated.
 
 ## [7.42.0] - 2020-06-23
 ### Added

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -657,7 +657,7 @@ class RenderProvider extends Component<Props, RenderProviderState> {
       <RenderContext.Provider value={context}>
         <TreePathContext.Provider value={{ treePath: '' }}>
           <ApolloProvider client={this.apolloClient}>
-            <IntlProvider locale={locale} messages={mergedMessages}>
+            <IntlProvider key={locale} locale={locale} messages={mergedMessages}>
               <Fragment>
                 {!production && !isStorefrontIframe && <BuildStatus />}
                 {component}

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -75,7 +75,7 @@ const render = (name: string, runtime: RenderRuntime, element?: HTMLElement): Re
   )
 
   return canUseDOM
-    ? (disableSSR || created ? renderDOM<HTMLDivElement>(root, elem) : hydrate(root, elem)) as Element
+    ? (disableSSR || created ? renderDOM(root, elem) : hydrate(root, elem)) as Element
     : renderToStringWithData(root).then(({ markup, renderTimeMetric }) => ({
       markups: getMarkups(name, markup),
       maxAge: cacheControl!.maxAge,

--- a/react/package.json
+++ b/react/package.json
@@ -57,6 +57,6 @@
     "tslint": "^5.2.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.1.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1088,10 +1088,10 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
#### What does this PR do? \*

The aim of this PR is to make legacy extension components reflect `locale` changes. To do that, we are making of `locale`   a `key` to `IntlProvider`, so all of its childs will be properly re-rendered.

#### How to test it? \*

- Use this [workspace](https://jeff--muji.vtexcommercebeta.com.br/checkout/cart/add/?sku=20362&qty=1&seller=1&sc=7)
- Check if `shipping-preview` and `omnishipping` are properly translated to Finnish.

#### Describe alternatives you've considered, if any. \*

N/A

#### Related to / Depends on \*

This depends on and will only be effective after https://github.com/vtex/vcs.checkout-ui/pull/966 is merged. 

<!--- Optional -->
