### PR TITLE
Fix/prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix wrong binding content being loaded with prefetch enabled.
 
 ## [8.126.7] - 2021-01-15
 ### Fixed

--- a/react/hooks/prefetch.ts
+++ b/react/hooks/prefetch.ts
@@ -240,15 +240,15 @@ export const usePrefetchAttempt = ({
   }, [canPrefetch, waitToPrefetch])
 
   const {
-    binding,
     pages,
     navigationRouteModifiers,
     hints,
+    query,
     renderMajor,
     getSettings,
   } = runtime
 
-  const canonicalBaseAddress = binding?.canonicalBaseAddress
+  const canonicalBaseAddress = query?.__bindingAddress
   const storeSettings = getSettings('vtex.store')
 
   const attemptPrefetch = useCallback(() => {


### PR DESCRIPTION
#### What does this PR do? \*
Fix wrong binding content being loaded with prefetch enabled.

#### How to test it? \*

Go to https://brunoh2--muji.myvtex.com/storage/storage-boxes-and-baskets/natural-storage?__bindingAddress=www.muji.eu/fr

Click on "Rangement"
> ![rangement](https://user-images.githubusercontent.com/2726345/105084259-dd462500-5a74-11eb-976d-803f3485b6d0.png)

Then hover your mouse cursor over the "See all products" link in the "Natural Storage" carousel
> ![seeall](https://user-images.githubusercontent.com/2726345/105084725-8725b180-5a75-11eb-85dc-640f8f40eedc.png)


It should trigger a prefetch:
> <img width="1176" alt="trigger" src="https://user-images.githubusercontent.com/2726345/105084771-9a388180-5a75-11eb-90bc-47532ec7fb6e.png">

Then click on "See all products" and you will enter a page with the content in english despite the `__bindingAddress` query string.
> ![uk](https://user-images.githubusercontent.com/2726345/105085335-5eea8280-5a76-11eb-97e6-145c33413c84.png)

Linking this PR and repeating this process will show the problem is fixed.