### PR TITLE
Disable hydrate-on-view on the site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Disable hydrate-on-view in the site editor. 
+
 ## [8.126.9] - 2021-01-21
+### Fixed
+- Disable folding in the site editor. 
 
 ## [8.126.8] - 2021-01-21
 ### Fixed

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -129,8 +129,10 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     <AsyncComponent {...asyncComponentProps}>{children}</AsyncComponent>
   )
 
-  const shouldHydrate =
-    hydration ||
+  const isSiteEditor = !runtime?.route?.path.includes('__siteEditor')
+
+  const shouldLazyHydrate =
+    !hydration ||
     hydration === 'always' ||
     /** TODO: Currently it only applies partial hydration on top level components
      * Nested partial hydration should be supported in the future */
@@ -138,7 +140,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (!runtime?.route?.path.includes('__siteEditor') && shouldHydrate) {
+  if (!isSiteEditor && !shouldLazyHydrate) {
     content = (
       <LazyImages>
         <Hydration treePath={treePath} hydration={hydration}>

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -138,7 +138,11 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (!runtime?.route?.path.includes('__siteEditor') || !shouldHydrate) {
+  if (
+    !runtime?.route?.path.includes('__siteEditor') ||
+    !shouldHydrate ||
+    !isSiteEditorIframe
+  ) {
     content = (
       <LazyImages>
         <Hydration treePath={treePath} hydration={hydration}>

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -130,7 +130,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
   )
 
   const shouldHydrate =
-    !hydration ||
+    hydration ||
     hydration === 'always' ||
     /** TODO: Currently it only applies partial hydration on top level components
      * Nested partial hydration should be supported in the future */
@@ -138,11 +138,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (
-    !runtime?.route?.path.includes('__siteEditor') ||
-    !shouldHydrate ||
-    !isSiteEditorIframe
-  ) {
+  if (!runtime?.route?.path.includes('__siteEditor') && shouldHydrate) {
     content = (
       <LazyImages>
         <Hydration treePath={treePath} hydration={hydration}>

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -67,6 +67,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     children,
     treePath,
     props: componentProps,
+    runtime,
     hydration,
   } = props
 
@@ -137,7 +138,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (!isSiteEditorIframe && !shouldHydrate) {
+  if (!runtime?.route?.path.includes('__siteEditor') || !shouldHydrate) {
     content = (
       <LazyImages>
         <Hydration treePath={treePath} hydration={hydration}>

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -129,9 +129,11 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     <AsyncComponent {...asyncComponentProps}>{children}</AsyncComponent>
   )
 
-  const isSiteEditor = runtime?.route?.queryString?.__siteEditor
+  const isSiteEditor =
+    runtime?.route?.queryString &&
+    Object.keys(runtime.route.queryString).includes('__siteEditor')
 
-  const shouldLazyHydrate =
+  const shouldHydrateEagerly =
     !hydration ||
     hydration === 'always' ||
     /** TODO: Currently it only applies partial hydration on top level components
@@ -140,7 +142,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
      * https://jsperf.com/js-regex-match-vs-substring) */
     treePath?.substring(treePath?.indexOf('/') + 1).indexOf('/') > -1
 
-  if (!isSiteEditor && !shouldLazyHydrate) {
+  if (!isSiteEditor && !shouldHydrateEagerly) {
     content = (
       <LazyImages>
         <Hydration treePath={treePath} hydration={hydration}>

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -129,9 +129,9 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     <AsyncComponent {...asyncComponentProps}>{children}</AsyncComponent>
   )
 
-  const isSiteEditor =
-    runtime?.route?.queryString &&
-    Object.keys(runtime.route.queryString).includes('__siteEditor')
+  const queryString = runtime?.route?.queryString ?? {}
+
+  const isSiteEditor = Object.keys(queryString).includes('__siteEditor')
 
   const shouldHydrateEagerly =
     !hydration ||

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -129,7 +129,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     <AsyncComponent {...asyncComponentProps}>{children}</AsyncComponent>
   )
 
-  const isSiteEditor = !runtime?.route?.path.includes('__siteEditor')
+  const isSiteEditor = runtime?.route?.path.includes('__siteEditor')
 
   const shouldLazyHydrate =
     !hydration ||

--- a/react/components/ExtensionPoint/ComponentLoader.tsx
+++ b/react/components/ExtensionPoint/ComponentLoader.tsx
@@ -129,7 +129,7 @@ const ComponentLoader: FunctionComponent<Props> = (props) => {
     <AsyncComponent {...asyncComponentProps}>{children}</AsyncComponent>
   )
 
-  const isSiteEditor = runtime?.route?.path.includes('__siteEditor')
+  const isSiteEditor = runtime?.route?.queryString?.__siteEditor
 
   const shouldLazyHydrate =
     !hydration ||

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -13,7 +13,6 @@ import LoadingBar from '../LoadingBar'
 import { LazyImages } from '../LazyImages'
 import LazyRender from '../LazyRender'
 import FoldableContainer from '../FoldableContainer'
-import { isSiteEditorIframe } from '../../utils/dom'
 import { Route } from '../../typings/runtime'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
@@ -92,11 +91,11 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     )
   })
 
-  if (runtime?.route?.path.includes('__siteEditor')) {
+  if (runtime?.route?.queryString?.__siteEditor) {
     return childExtensions
   }
 
-  if (foldIndex > -1 && !isSiteEditorIframe) {
+  if (foldIndex > -1) {
     return (
       <FoldableContainer foldIndex={foldIndex}>
         {childExtensions}

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -91,10 +91,9 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
     )
   })
 
-  if (
-    runtime?.route?.queryString &&
-    Object.keys(runtime.route.queryString).includes('__siteEditor')
-  ) {
+  const queryString = runtime?.route?.queryString ?? {}
+
+  if (Object.keys(queryString).includes('__siteEditor')) {
     return childExtensions
   }
 

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -90,8 +90,15 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
       />
     )
   })
+  console.log(
+    '🚀 ~ file: index.tsx ~ line 98 ~ getChildExtensions ~ runtime?.route?.queryString',
+    runtime?.route?.queryString
+  )
 
-  if (runtime?.route?.queryString?.__siteEditor) {
+  if (
+    runtime?.route?.queryString &&
+    Object.keys(runtime.route.queryString).includes('__siteEditor')
+  ) {
     return childExtensions
   }
 

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -90,10 +90,6 @@ export function getChildExtensions(runtime: RenderContext, treePath: string) {
       />
     )
   })
-  console.log(
-    '🚀 ~ file: index.tsx ~ line 98 ~ getChildExtensions ~ runtime?.route?.queryString',
-    runtime?.route?.queryString
-  )
 
   if (
     runtime?.route?.queryString &&

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -174,6 +174,7 @@ interface MatchingServerPage {
   title?: string
   routeId: string
   params: Record<string, string>
+  queryString?: Record<string, any>
   id: string
   path: string
   domain: string

--- a/react/typings/runtime.ts
+++ b/react/typings/runtime.ts
@@ -70,6 +70,7 @@ export interface Route {
   metaTags?: RouteMetaTags
   pageContext: PageDataContext
   params: Record<string, any>
+  queryString?: Record<string, any>
   path: string
   title?: string
 }


### PR DESCRIPTION
#### What does this PR do? \*

Change the site editor identifier. A flag added to the admin-pages now permits us to better recognize if a page is being requested in the admin or not.

#### How to test it? \*

https://vitorflg--muji.myvtex.com/admin/cms/site-editor

#### Describe alternatives you've considered, if any. \*

X

#### Related to / Depends on \*

X