### PR TITLE
Use props children in slots if their slot children prop is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use props `children` in slots if slot children is empty.
+
 ## [8.126.10] - 2021-01-26
 
 ### Fixed

--- a/react/utils/slots.tsx
+++ b/react/utils/slots.tsx
@@ -52,7 +52,11 @@ export function generateSlot({
         runtime={runtime}
         hydration={hydration}
       >
-        {slotChildren}
+        {Array.isArray(slotChildren) &&
+        slotChildren.length === 0 &&
+        componentLoaderPropsWithContent.children
+          ? componentLoaderPropsWithContent.children
+          : slotChildren}
       </ComponentLoader>
     )
   }


### PR DESCRIPTION
#### What does this PR do? \*

#### Context

1. A component with `composition: "children"`
```json
{
  "my-custom-context": {
    "component": "MyContextProvider",
    "composition": "children"
  }
}
```

2. A component that uses slots:

```json
{
  "productWrapper#custompdpcontext": {
    "props": {
      "CustomContext": "my-custom-context"
    }
  }
}
```

3. In the `productWrapper` React component we have:

```tsx
function ProductWrapper({ children, CustomContext }) {
  const CustomContextElement = CustomContext || Fragment
  
  return (
    <CustomContextElement>
      {children}
    </CustomContextElement>
  )
}
```

#### Issue

The block `my-custom-context` doesn't have any blocks in it's block definition (which will be used as children):

![image](https://user-images.githubusercontent.com/284515/106058808-87a2f580-60d0-11eb-8448-714ebca5476a.png)

The current code in master considers the empty blocks array as a value, overriding the prop `children` used in the React code.

This PR checks if the blocks array is empty and if a children prop is passed and uses it instead.

#### How to test it? \*

https://context--storecomponents.myvtex.com/blouse-with-knot/p?skuId=2000544

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
