### PR TITLE
Add a custom callback param to the localesChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+-  Custom callback param to the localesChanged event.
+
 ## [8.127.0] - 2021-03-10
 
 ### Added

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -964,9 +964,14 @@ export class RenderProvider extends Component<
     return assetsPromise
   }
 
-  public onLocaleSelected = (locale: string, domain?: string) => {
+  public onLocaleSelected = (
+    locale: string,
+    domain?: string,
+    callback?: () => unknown
+  ) => {
     if (locale !== this.state.culture.locale) {
       const sessionData = { public: {} }
+
       if (domain && domain === 'admin') {
         sessionData.public = {
           admin_cultureInfo: {
@@ -980,13 +985,20 @@ export class RenderProvider extends Component<
           },
         }
       }
-      this.patchSession(sessionData)
-        .then(() => window.location.reload())
+
+      return this.patchSession(sessionData)
+        .then(() => {
+          if (callback) return callback()
+
+          return window.location.reload()
+        })
         .catch((e) => {
           console.log('Failed to fetch new locale file.')
           console.error(e)
         })
     }
+
+    return undefined
   }
 
   public updateRuntime = async (options?: PageContextOptions) => {


### PR DESCRIPTION
The context for this change is in the [#prod-muji-eu](https://vtex.slack.com/archives/C01619D8146/p1614199934018700) channel.

#### What does this PR do? \*

As the title says, it adds a new param to the localesChanged event handler for a custom callback, considering that could be other options besides a page reload.

#### How to test it? \*

https://www.loom.com/share/0ea28c9573754baeb8d7d96e3ded5156

https://vitorflg--muji.myvtex.com/admin/cms/site-editor

#### Describe alternatives you've considered, if any. \*

X

#### Related to / Depends on \*

It's a PR that support another one -> https://github.com/vtex-apps/admin-pages/pull/374