### PR TITLE
Fix/avoid css conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `RenderContext` and `withRuntimeContext` exported types definition.
 
-### Fixed
-- CSS conflicts after a hot reaload.
-
 ## [8.126.11] - 2021-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- CSS conflicts after a hot reload.
+- CSS conflicts after a hot reload. 
 
 ## [8.128.1] - 2021-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- CSS conflicts after a hot reaload.
+
 ## [8.128.1] - 2021-03-17
 
 ### Fixed
@@ -24,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `RenderContext` and `withRuntimeContext` exported types definition.
+
+### Fixed
+- CSS conflicts after a hot reaload.
 
 ## [8.126.11] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- CSS conflicts after a hot reaload.
+- CSS conflicts after a hot reload.
 
 ## [8.128.1] - 2021-03-17
 

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -964,14 +964,9 @@ export class RenderProvider extends Component<
     return assetsPromise
   }
 
-  public onLocaleSelected = (
-    locale: string,
-    domain?: string,
-    callback?: () => unknown
-  ) => {
+  public onLocaleSelected = (locale: string, domain?: string) => {
     if (locale !== this.state.culture.locale) {
       const sessionData = { public: {} }
-
       if (domain && domain === 'admin') {
         sessionData.public = {
           admin_cultureInfo: {
@@ -985,20 +980,13 @@ export class RenderProvider extends Component<
           },
         }
       }
-
-      return this.patchSession(sessionData)
-        .then(() => {
-          if (callback) return callback()
-
-          return window.location.reload()
-        })
+      this.patchSession(sessionData)
+        .then(() => window.location.reload())
         .catch((e) => {
           console.log('Failed to fetch new locale file.')
           console.error(e)
         })
     }
-
-    return undefined
   }
 
   public updateRuntime = async (options?: PageContextOptions) => {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -964,9 +964,14 @@ export class RenderProvider extends Component<
     return assetsPromise
   }
 
-  public onLocaleSelected = (locale: string, domain?: string) => {
+  public onLocaleSelected = (
+    locale: string,
+    domain?: string,
+    callback?: () => unknown
+  ) => {
     if (locale !== this.state.culture.locale) {
       const sessionData = { public: {} }
+
       if (domain && domain === 'admin') {
         sessionData.public = {
           admin_cultureInfo: {
@@ -980,13 +985,20 @@ export class RenderProvider extends Component<
           },
         }
       }
-      this.patchSession(sessionData)
-        .then(() => window.location.reload())
+
+      return this.patchSession(sessionData)
+        .then(() => {
+          if (callback) return callback()
+
+          return window.location.reload()
+        })
         .catch((e) => {
           console.log('Failed to fetch new locale file.')
           console.error(e)
         })
     }
+
+    return undefined
   }
 
   public updateRuntime = async (options?: PageContextOptions) => {

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -85,7 +85,7 @@ function addStyleToPage(href: string) {
   }
 }
 
-const updateHref = (linkElement: Element) => {
+const updateHref = (linkElement: HTMLLinkElement) => {
   const href = linkElement && linkElement.getAttribute('href')
 
   if (href) {
@@ -109,6 +109,8 @@ const updateHref = (linkElement: Element) => {
           nextElementSibling.id.indexOf(idPrefix) > -1
         ) {
           linkElement.parentNode.removeChild(nextElementSibling)
+
+          linkElement.disabled = true
         }
       })
     }
@@ -120,12 +122,16 @@ const updateHref = (linkElement: Element) => {
 }
 
 export const hotReloadOverrides = () => {
-  const linkElements = Array.from(document.querySelectorAll('.override_link'))
+  const linkElements: HTMLLinkElement[] = Array.from(
+    document.querySelectorAll('.override_link')
+  )
   linkElements.forEach(updateHref)
 }
 
 export const hotReloadTachyons = () => {
-  const linkElements = Array.from(document.querySelectorAll('.style_link'))
+  const linkElements: HTMLLinkElement[] = Array.from(
+    document.querySelectorAll('.style_link')
+  )
   linkElements.forEach(updateHref)
 }
 

--- a/react/utils/assets.ts
+++ b/react/utils/assets.ts
@@ -109,9 +109,9 @@ const updateHref = (linkElement: HTMLLinkElement) => {
           nextElementSibling.id.indexOf(idPrefix) > -1
         ) {
           linkElement.parentNode.removeChild(nextElementSibling)
-
-          linkElement.disabled = true
         }
+
+        linkElement.disabled = true
       })
     }
 


### PR DESCRIPTION
#### What does this PR do? \*

**Disable original CSS when new hot reload CSS's is being created to avoid rule conflicts.

#### How to test it? \*

1. Link store theme and try to make a change in a CSS rule(It will create another CSS with the changed rule, and ****disable the original one**).
2. Delete the rule(It will create another CSS, and remove the created above).
3. The result should be a UI without the rule.

Currently, at production, the result is a UI with the original rule.

#### Describe alternatives you've considered, if any. \*

X

#### Related to / Depends on \*

X