### PR TITLE
Pass locale as arg to the localesChanged event callback

### DIFF
--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -967,7 +967,7 @@ export class RenderProvider extends Component<
   public onLocaleSelected = (
     locale: string,
     domain?: string,
-    callback?: () => unknown
+    callback?: (locale: string) => unknown
   ) => {
     if (locale !== this.state.culture.locale) {
       const sessionData = { public: {} }
@@ -988,7 +988,7 @@ export class RenderProvider extends Component<
 
       return this.patchSession(sessionData)
         .then(() => {
-          if (callback) return callback()
+          if (callback) return callback(locale)
 
           return window.location.reload()
         })


### PR DESCRIPTION
#### What does this PR do? \*

 The `locale` is not being passed to the `localesChanged` event callback, it's a need for a custom logic on admin-pages.

#### How to test it? \*

[WIP]

#### Describe alternatives you've considered, if any. \*

X

<!--- Optional -->

#### Related to / Depends on \*

[WIP]

<!--- Optional -->
