### PR TITLE
Decoding parameters to avoid double encoding while using route-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Double encoding while generating paths
 
 ## [8.128.2] - 2021-03-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.128.2",
+  "version": "8.128.3-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.128.3-beta.0",
+  "version": "8.128.2",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/utils/pages.test.ts
+++ b/react/utils/pages.test.ts
@@ -1,4 +1,46 @@
-import { getComparablePrecedence } from './pages'
+import { formatPathParameters, getComparablePrecedence } from './pages'
+import RouteParser from 'route-parser'
+
+describe('#formatPathParameters', () => {
+  it('should remove any encoding', () => {
+    const params = [
+      {
+        term: 'a%2520b%2520c',
+      },
+      {
+        term: 'a%20b%20c',
+      },
+    ]
+
+    const results = params.map((param) => formatPathParameters(param))
+
+    expect(results).toEqual([{ term: 'a%20b%20c' }, { term: 'a b c' }])
+  })
+})
+
+describe('#routeParser', () => {
+  it('should not add double enconding', () => {
+    const params = [
+      {
+        term: 'a',
+      },
+      {
+        term: 'b',
+      },
+      {
+        term: 'a%20b%20c',
+      },
+    ]
+
+    const validTemplate = ['/:term', '/:term', '/:term']
+
+    const results = params.map((param, index) =>
+      new RouteParser(validTemplate[index]).reverse(param)
+    )
+
+    expect(results).toEqual(['/a', '/b', '/a%20b%20c'])
+  })
+})
 
 describe('#getPrecedence', () => {
   it('should set precedence as expected', () => {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -235,6 +235,15 @@ const mergePersistingQueries = (currentQuery: string, query: string) => {
   return mapToQueryString({ ...persisting, ...next })
 }
 
+export const formatPathParameters = (params: Record<string, string>) => {
+  const obj: Record<string, string> = {}
+  for (const key in params) {
+    obj[key] = decodeURI(params[key])
+  }
+
+  return obj
+}
+
 export function getNavigationRouteToNavigate(
   pages: Pages,
   options: NavigateOptions,
@@ -279,16 +288,19 @@ export function getNavigationRouteToNavigate(
   const realHash = is(String, hash) ? `#${hash}` : ''
   let query = inputQuery || realQuery
 
+  const decodedParams = formatPathParameters(params)
+
   let navigationRoute: any = {}
 
   if (isEnabled('RENDER_NAVIGATION')) {
     const fallbackPage = { path: to, params: {}, id: '' }
-    const routeFromPage = page && getRouteFromPageName(page, pages, params)
+    const routeFromPage =
+      page && getRouteFromPageName(page, pages, decodedParams)
     const routeFromPath = getRouteFromPath(to, pages)
     navigationRoute = routeFromPage || routeFromPath || fallbackPage
   } else {
     navigationRoute = page
-      ? getRouteFromPageName(page, pages, params)
+      ? getRouteFromPageName(page, pages, decodedParams)
       : getRouteFromPathOld(to, pages, query, realHash)
   }
 


### PR DESCRIPTION
#### What does this PR do? \*
It fixes a bug in basically every production store when searching three terms. The requests were being blocked by the WAF that we have on Azion, because they contained double encoded strings. You can simulate the behavior, for example, going to polishop.com.br and trying to search for "fritadeira air fryer". Once you go to the Network tab, you'll see that you receive a `400`, as the image below:
![image](https://user-images.githubusercontent.com/19495917/115255256-759b8680-a104-11eb-8ffe-1be10689e1e7.png)

You can check in the following image that, instead of having `fritadeira%20air%20fryer` in the path, you will find `fritadeira%2520air%2520fryer`. This is due to the fact that the package that we use to join the path using the terms object already encodes the string. However, the strings were already reaching the RouteParser's method encoded.

![image](https://user-images.githubusercontent.com/19495917/115255347-8c41dd80-a104-11eb-8d09-ec2c3965a299.png)

In order for us to fix the problem without removing the usage of the `route-parser` package, we decided to implement a util function that decodes the string before using it in the method. 

> It's important to emphasize that the behavior of blocking the requests only affects searches with three terms or more because it's based on a score and if it goes above the threshold, it will block the request

#### How to test it? \*
In the Store Theme public domain ([storetheme.vtex.com](storetheme.vtex.com)), you can check that the problem is "solved". In this account, there is a beta version of render-runtime installed. If you install the most recent stable version (`vtex.render-runtime@8.128.2`), you'll be able to reproduce the problem that was mentioned below.

I've also created some unit tests in order to reproduce the double encoding and to test the function that I've implemented.

#### Describe alternatives you've considered, if any. \*
As a temporary solution to the client that reported the problem, we deactivated the WAF, but this is not the best scenario, because it disables every protection that the client's public domain has.
