### PR TITLE
Adding internal params identifiable via __ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Link `params` that starts with `__` are no longer considered during path transformations. They can be used as alternatives to query params.
 
 ## [8.128.4] - 2021-04-22
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -621,7 +621,7 @@ The `Link` React component is responsible for rendering an `a` HTML element that
 | :------------- |:-------------| :-----|:-----|
 | `page`     | `string`  | The name of the page that the user will be redirected to. Maps to a `blocks.json` block (e.g., `'store.product'`)||
 | `to`     | `string`    |The URL of the page that the user will be redirected to (e.g., `/shirt/p?skuId=1`). Notice that `to` is an **alternative** to `page` and it contains the whole URL instead of the page name. | |
-| `params` | `object`      | The `param` values of the page path in a key-value format (e.g, `{slug: 'shirt'}`). | `{}`|
+| `params` | `object`      | The `param` values of the page path in a key-value format (e.g, `{slug: 'shirt'}`). Params that starts with `__` are not considered on path transformations, and can be generaly be used as an alternative to query params | `{}`|
 | `query` | `string`  | The representation of the query params that are appended to the page path (e.g., `skuId=231`.) | `''` |
 | `onClick` | `function` | A callback that is fired when the user clicks on a component (e.g., `() => alert('Salut')`) | |
 | `replace` | `boolean` | The boolean value used to indicate if it should call (`true`) the replace function to navigate or not (`false`) | |

--- a/docs/README.md
+++ b/docs/README.md
@@ -628,7 +628,7 @@ The `Link` React component is responsible for rendering an `a` HTML element that
 
 Other props you pass will be forwarded to the `a` component and can be used for customization.
 
-Take the following usage example:
+Take the following usage examples:
 
 ```tsx
 import React from 'react'
@@ -636,6 +636,23 @@ import { Link } from 'vtex.render-runtime'
 
 function MyComponent() {
   return <Link to="/otherpage" classname="c-on-base">Hello</Link>
+}
+
+export default MyComponent
+```
+
+```tsx
+import React from 'react'
+import { Link } from 'vtex.render-runtime'
+
+function MyComponent() {
+  const params = {
+    slug: PRODUCT_SLUG, // Considered on path transformations (/{slug}/p)
+    __listName: 'List of products' // Ignored on path transformations
+    __yourProductPageParam: YOUR_PARAM // Ignored on path transformations
+  }
+
+  return <Link to="/productpage" params={params}>Hello</Link>
 }
 
 export default MyComponent

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -654,6 +654,19 @@ export class RenderProvider extends Component<
     }
   }
 
+  private mergeRouteParams<T extends { params: any }>(
+    matchingPage: T,
+    transientRoute: { params: any }
+  ): T {
+    return {
+      ...matchingPage,
+      params: {
+        ...transientRoute.params,
+        ...matchingPage.params,
+      },
+    }
+  }
+
   public afterPageChanged = (
     route: string,
     scrollOptions?: RenderScrollOptions
@@ -754,7 +767,7 @@ export class RenderProvider extends Component<
             page: routeId,
             preview: false,
             query,
-            route: matchingPage,
+            route: this.mergeRouteParams(matchingPage, transientRoute),
           }),
           () => {
             this.navigationState = { isNavigating: false }
@@ -822,7 +835,7 @@ export class RenderProvider extends Component<
                 pages,
                 preview: false,
                 query,
-                route: matchingPage,
+                route: this.mergeRouteParams(matchingPage, transientRoute),
                 settings,
               }),
               () => {
@@ -870,7 +883,7 @@ export class RenderProvider extends Component<
                 pages,
                 preview: false,
                 query,
-                route: updatedRoute,
+                route: this.mergeRouteParams(updatedRoute, transientRoute),
                 settings,
               },
               () => {

--- a/react/utils/pages.ts
+++ b/react/utils/pages.ts
@@ -155,8 +155,16 @@ function getRouteFromPageName(
   pages: Pages,
   params: any
 ): NavigationRoute | null {
-  const path = pathFromPageName(id, pages, params) || ''
-  checkValidParams(id, pages, path, params)
+  const pathParams = Object.keys(params)
+    .filter((key) => !key.startsWith('__'))
+    .reduce((acc, key) => {
+      acc[key] = params[key]
+      return acc
+    }, {} as any)
+
+  const path = pathFromPageName(id, pages, pathParams) || ''
+  checkValidParams(id, pages, path, pathParams)
+
   return path ? { id, path, params } : null
 }
 


### PR DESCRIPTION
#### What does this PR do? \*
This PR adds a filter to Link params. This filter prevents all params that start with `__` from being considered during path transformations. This was added to safely allow the usage of params that are sent between pages but shouldn't be added to the query params due to user experience compromises.

#### How to test it? \*
[Workspace](http://icarorender--storecomponents.myvtex.com)
[Workspace 2](http://icarogtm--storecomponents.myvtex.com)
