### PR TITLE
added rel prop for better SEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `rel` prop for better SEO
+- `rel` prop to `Link` component for better SEO.
 
 ## [8.128.4] - 2021-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `rel` prop for better SEO
 
 ## [8.128.4] - 2021-04-22
 

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -23,6 +23,7 @@ interface Props extends NavigateOptions {
   className?: string
   target?: string
   waitToPrefetch?: number
+  rel?: HTMLAnchorElement['rel']
 }
 
 const appendWorkspaceToURL = (
@@ -55,6 +56,7 @@ const Link: React.FunctionComponent<Props> = ({
   modifiersOptions,
   target,
   waitToPrefetch,
+  rel,
   ...linkProps
 }) => {
   const {


### PR DESCRIPTION
#### What does this PR do? \*

This PR adds the `rel` prop to the `Link` component, allowing it to declare the relationship between the link and the current document

#### How to test it? \*

By updating the render-runtime app, the `rel` prop should be available to use whenever the `Link` component is declared

#### Describe alternatives you've considered, if any. \*

It was a suggestion made by the reviewers/contributors of another PR, I'll post the link in the section below

#### Related to / Depends on \*

https://github.com/vtex-apps/store-link/pull/29

