### PR TITLE
Rel prop passed down in the return statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `rel` prop passed down in the `return` statement
 
 ## [8.131.0] - 2021-08-02
 ### Added

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -156,6 +156,7 @@ const Link: React.FunctionComponent<Props> = ({
   const linkElementProps = {
     target,
     href: hrefWithoutIframePrefix,
+    rel,
     ...linkProps,
     onClick: handleClick,
   }

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -56,7 +56,6 @@ const Link: React.FunctionComponent<Props> = ({
   modifiersOptions,
   target,
   waitToPrefetch,
-  rel,
   ...linkProps
 }) => {
   const {

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -156,7 +156,6 @@ const Link: React.FunctionComponent<Props> = ({
   const linkElementProps = {
     target,
     href: hrefWithoutIframePrefix,
-    rel,
     ...linkProps,
     onClick: handleClick,
   }


### PR DESCRIPTION
#### What does this PR do? \*

This PR fixes a previous implementation where the `rel` prop is added, but it isn't passed down to the child component, resulting in a prop that is accepted and doesn't give errors, but it doesn't do anything.

#### How to test it? \*

Wherever a store-link is added to the theme, adding the "rel" prop actually makes use of said prop.

#### Related to / Depends on \*

https://github.com/vtex-apps/render-runtime/pull/618
