### PR TITLE
Feature/perf measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Performance measurements on Splunk for 0.05% of views.
 
 ## [8.131.1] - 2021-09-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Performance measurements on Splunk for 0.05% of views.
+- Performance measurements on Splunk for 0.5% of views.
 
 ## [8.131.1] - 2021-09-06
 ### Fixed

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -147,7 +147,7 @@ const prependRootPath = (path: string, rootPath?: string) => {
 function performanceMeasure(...args: Parameters<typeof window.performance.measure>): PerformanceMeasure | null | undefined | void {
   try {
     const measure = window?.performance?.measure?.(...args)
-    if (measure) {
+    if (measure as PerformanceMeasure | undefined) {
       return measure
     }
     // Fix for Firefox. Performance.measure doesn't return anything it seems,

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -159,7 +159,7 @@ function logMeasures({ measures, account, device, page }: {
   page: string
 }) {
   // Log 0.5% of the views, for now
-  if (Math.random() > 0.005) {
+  if (Math.random() > 0.005 && !(window?.location?.search?.includes?.('__debugLogMeasures'))) {
     return
   }
 

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -71,6 +71,8 @@ import {
 } from '../typings/global'
 import { RenderRuntime, Components, Extension } from '../typings/runtime'
 
+import { logEvent } from '../utils/splunkLogger'
+
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectorPopover = React.lazy(
   () =>
@@ -80,18 +82,6 @@ const InspectorPopover = React.lazy(
       })
     })
 )
-
-import SplunkEvents from 'splunk-events'
-
-const SPLUNK_ENDPOINT = 'https://splunk72-heavyforwarder-public.vtex.com:8088'
-const SPLUNK_TOKEN = 'cce4a8e7-6e7a-40a0-aafb-ac45b0e271ba'
-const splunkLogger = new SplunkEvents()
-
-splunkLogger.config({
-  endpoint: SPLUNK_ENDPOINT,
-  token: SPLUNK_TOKEN,
-  source: 'log',
-})
 
 interface Props {
   children: ReactElement<any> | null
@@ -190,7 +180,9 @@ function logMeasures({ measures, account, device, page }: {
     return
   }
 
-  splunkLogger.logEvent('Debug', 'Info', 'render', 'render-performance', {...measuresData, device, page}, account)
+  const data = { ...measuresData, device, page}
+
+  logEvent('Debug', 'Info', 'render', 'render-performance', data, account)
 }
 
 interface NavigationState {

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -158,7 +158,8 @@ function logMeasures({ measures, account, device, page }: {
   device: Device,
   page: string
 }) {
-  if (Math.random() > 0.01 && false) {
+  // Log 0.5% of the views, for now
+  if (Math.random() > 0.005) {
     return
   }
 

--- a/react/package.json
+++ b/react/package.json
@@ -33,6 +33,7 @@
     "react-helmet": "^5.2.0",
     "react-json-view": "^1.19.1",
     "route-parser": "^0.0.5",
+    "splunk-events": "^1.6.1-beta",
     "use-media": "^1.4.0"
   },
   "devDependencies": {

--- a/react/utils/splunkLogger.ts
+++ b/react/utils/splunkLogger.ts
@@ -1,0 +1,16 @@
+import SplunkEvents from 'splunk-events'
+
+const SPLUNK_ENDPOINT = 'https://splunk72-heavyforwarder-public.vtex.com:8088'
+const SPLUNK_TOKEN = 'cce4a8e7-6e7a-40a0-aafb-ac45b0e271ba'
+
+const splunkLogger = new SplunkEvents()
+
+splunkLogger.config({
+  endpoint: SPLUNK_ENDPOINT,
+  token: SPLUNK_TOKEN,
+  source: 'log',
+})
+
+const { logEvent } = splunkLogger
+
+export { logEvent }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -7670,6 +7670,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+splunk-events@^1.6.1-beta:
+  version "1.6.1-beta"
+  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.6.1-beta.tgz#9960de0a481fd1f1b30aba82082b1890528063ac"
+  integrity sha512-79dgPedzpNXYjjLI4O0SAkbVRdGxdlsQsKAcD2gvjAmD7OLv6Wzm4fK0i7g5gjNH2g/Mcwi1UJPVAcbiUTJY4g==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"


### PR DESCRIPTION
#### What does this PR do? \*
Adds performance measures for rendering performance, for viewing on dev tools, and logs .5% of them on Splunk.

Depends on https://github.com/vtex/render-server/pull/729, but shouldn't break without it, just the measurements will not work.


#### How to test it? \*

Test on https://www.carrefour.com.br/?workspace=lbebbermeasure6&v=0001&__disablePixels&__debugLogMeasures

With the querystring `__debugLogMeasures` present, it always logs on Splunk.

Open [this Splunk link](https://splunk72.vtex.com/en-US/app/search/search?q=search%20index%3D%22io-browser-render%22%20workflowInstance%3D%22render-performance%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-5m&latest=&display.events.fields=%5B%22workflow_type%22%2C%22workflowInstance%22%2C%22workflow_instance%22%2C%22executing_application%22%2C%22username%22%2C%22method%22%2C%22exception_message%22%2C%22index%22%2C%22path%22%2C%22worker_id%22%2C%22operation_id%22%2C%22from_script_start_to_first_render%22%2C%22first_render%22%2C%22from_body_js_to_first_render%22%2C%22render_start_interval%22%2C%22script_init%22%2C%22account%22%2C%22device%22%5D&sid=1632353805.74120_A3F85911-4F83-421C-A7A6-550D7C413CB5) right after opening the page to see the logs generated by it.

You can see these metrics on the Chrome Dev Tools performance panel as well, under "Timings", after refreshing the page while measuring performance.


https://user-images.githubusercontent.com/5691711/134435896-89cba821-e7db-4c3b-8065-c98707a9d1e7.mov



#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
