### PR TITLE
Feature/increase perf measure samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Increase the performance measurement sampling to 1%.
+- Increase the default performance measurement sampling to 1%, and for specific accounts and pages to 4%.
 
 ## [8.132.0] - 2021-09-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase the performance measurement sampling to 1%.
 
 ## [8.132.0] - 2021-09-23
 ### Added

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -180,8 +180,8 @@ function logMeasures({ measures, account, device, page }: {
   device: Device,
   page: string
 }) {
-  // Log 0.5% of the views, for now
-  if (Math.random() > 0.005 && !(window?.location?.search?.includes?.('__debugLogMeasures'))) {
+  // Log 1% of the views, or if __debugLogMeasures is present on the querystring
+  if (Math.random() > 0.01 && !(window?.location?.search?.includes?.('__debugLogMeasures'))) {
     return
   }
 


### PR DESCRIPTION
#### What does this PR do? \*
Increases the default log sampling rate for the performance measures.

Also allows highlighting certain accounts and pages to increase the sample rate for them specifically, for closer study.

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
