### PR TITLE
Fix/device rerender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevents unnecessary rerender on `withDevice` HOC.
 
 ## [8.132.1] - 2021-09-28
 ### Changed

--- a/react/utils/withDevice.tsx
+++ b/react/utils/withDevice.tsx
@@ -57,23 +57,20 @@ const useDevice = (hints: RenderRuntime['hints']) => {
 export const withDevice = <P extends Props>(
   Component: ComponentType<P & WithDeviceProps>
 ): FC<P> => {
-  const WithDeviceMemo = React.memo(
-    ({ type, isMobile, ...props }: { type: any; isMobile: any }) => (
-      <Component
-        deviceInfo={{ type, isMobile }}
-        {...((props as unknown) as P)}
-      />
+  const MemoizedWithDevice = React.memo(
+    ({ type, isMobile, ...props }: DeviceInfo & Props) => (
+      <Component deviceInfo={{ type, isMobile }} {...(props as P)} />
     )
   )
 
-  WithDeviceMemo.displayName = 'WithDeviceMemo'
+  MemoizedWithDevice.displayName = 'MemoizedWithDevice'
 
   const WithDevice = ({ ...props }: P) => {
     const hints = props.runtime.hints
     const deviceInfo = useDevice(hints)
 
     return (
-      <WithDeviceMemo
+      <MemoizedWithDevice
         type={deviceInfo.type}
         isMobile={deviceInfo.isMobile}
         {...props}

--- a/react/utils/withDevice.tsx
+++ b/react/utils/withDevice.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ComponentType, useMemo, useState } from 'react'
+import React, { FC, ComponentType } from 'react'
 import { useSSR } from '../components/NoSSR'
 import { useMediaLayout } from 'use-media'
 import { RenderRuntime } from '../typings/runtime'

--- a/react/utils/withDevice.tsx
+++ b/react/utils/withDevice.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ComponentType } from 'react'
+import React, { FC, ComponentType, useMemo, useState } from 'react'
 import { useSSR } from '../components/NoSSR'
 import { useMediaLayout } from 'use-media'
 import { RenderRuntime } from '../typings/runtime'
@@ -29,6 +29,7 @@ const useDevice = (hints: RenderRuntime['hints']) => {
   /** These screensizes are hardcoded, based on the default
    * Tachyons breakpoints. They should probably be the ones
    * configured via the style.json file, if available. */
+
   const isScreenMedium = useMediaLayout({ minWidth: '40rem' })
   const isScreenLarge = useMediaLayout({ minWidth: '64.1rem' })
 
@@ -56,11 +57,28 @@ const useDevice = (hints: RenderRuntime['hints']) => {
 export const withDevice = <P extends Props>(
   Component: ComponentType<P & WithDeviceProps>
 ): FC<P> => {
+  const WithDeviceMemo = React.memo(
+    ({ type, isMobile, ...props }: { type: any; isMobile: any }) => (
+      <Component
+        deviceInfo={{ type, isMobile }}
+        {...((props as unknown) as P)}
+      />
+    )
+  )
+
+  WithDeviceMemo.displayName = 'WithDeviceMemo'
+
   const WithDevice = ({ ...props }: P) => {
     const hints = props.runtime.hints
     const deviceInfo = useDevice(hints)
 
-    return <Component deviceInfo={deviceInfo} {...(props as P)} />
+    return (
+      <WithDeviceMemo
+        type={deviceInfo.type}
+        isMobile={deviceInfo.isMobile}
+        {...props}
+      />
+    )
   }
 
   return WithDevice


### PR DESCRIPTION
#### What does this PR do? \*
Prevents an initial re-render on `withDevice` HOC, decreasing the time it takes for the first render tick/hydration.

Before:
<img width="449" alt="Screen Shot 2021-09-29 at 10 13 56" src="https://user-images.githubusercontent.com/5691711/135275525-f5bed921-cff4-4103-87f4-4a4e6d6c4153.png">
<img width="885" alt="Screen Shot 2021-09-29 at 10 13 07" src="https://user-images.githubusercontent.com/5691711/135275556-f7d70187-0e35-4f54-b62a-1ea51c6047de.png">

After:
<img width="379" alt="Screen Shot 2021-09-29 at 10 13 48" src="https://user-images.githubusercontent.com/5691711/135275629-99a99aa8-21dc-4e2f-b033-cd74913fff19.png">
<img width="868" alt="Screen Shot 2021-09-29 at 10 12 58" src="https://user-images.githubusercontent.com/5691711/135275666-064b3f83-0e04-40f2-b1fa-94d773a21e06.png">



#### How to test it? \*
Can be tested here: https://www.carrefour.com.br/?workspace=lbebbertestrr1&v=000100&__disablePixels

Resize the screen from desktop- to mobile-sized to verify that it still loads the mobile version (takes a little while though, but the delay is not related to this PR)

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
