### PR TITLE
change desktop determination to be not mobile

### DIFF
--- a/react/utils/withDevice.tsx
+++ b/react/utils/withDevice.tsx
@@ -30,8 +30,8 @@ const useDevice = (hints: RenderRuntime['hints']) => {
    * Tachyons breakpoints. They should probably be the ones
    * configured via the style.json file, if available. */
 
-  const isScreenMedium = useMediaLayout({ minWidth: '40rem' })
-  const isScreenLarge = useMediaLayout({ minWidth: '64.1rem' })
+  const isTabletScreen = useMediaLayout({ minWidth: '40rem' })
+  const isMobileScreen = useMediaLayout({ maxWidth: '64rem' })
 
   const serverDevice = {
     type: hints.phone
@@ -43,12 +43,12 @@ const useDevice = (hints: RenderRuntime['hints']) => {
   }
 
   const clientDevice = {
-    type: isScreenLarge
-      ? Device.desktop
-      : isScreenMedium
-      ? Device.tablet
-      : Device.phone,
-    isMobile: !isScreenLarge,
+    type: isMobileScreen
+      ? isTabletScreen
+        ? Device.tablet
+        : Device.phone
+      : Device.desktop,
+    isMobile: isMobileScreen,
   }
 
   return isSSR ? serverDevice : clientDevice


### PR DESCRIPTION
#### What does this PR do? \*
Fixes this issue: https://github.com/vtex-apps/render-runtime/issues/635

This is a temporary fix for `render-runtime` displaying mobile at 1025px. A more permanent solution should be sought to ensure that `render-runtime` works better with tachyons (tachyons display all media queries with a mobile first approach, thus rendering `min-width: 64rem` as desktop too.

#### How to test it? \*
resize your browser to 1025px and note that this fix allows that to display as desktop.

#### Describe alternatives you've considered, if any. \*
Alternatives would be to set all css media queries within our app as 64.1rem for desktop.

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
