### PR TITLE
fix(NoSSR): add children typings

### DIFF
--- a/react/components/NoSSR.tsx
+++ b/react/components/NoSSR.tsx
@@ -20,6 +20,7 @@ const useSSR = () => {
 
 interface Props {
   onSSR?: React.ReactNode
+  children?: React.ReactNode
 }
 
 const NoSSR: FunctionComponent<Props> = ({ children, onSSR }) => {


### PR DESCRIPTION
#### What does this PR do? \*

The NoSSR component was missing `children` from its typings, forcing custom components to ts-ignore it.
Children prop already works, this PR simply adds it to Props interface.

#### How to test it? \*

Import NoSSR from a typescript file and pass any children to it. If everything is fine, TypeScript should not complain anymore.

#### Describe alternatives you've considered, if any. \*

Not sure if this fits the question, but I set it as an optional prop, not sure if it should be mandatory.

<!--- Optional -->

#### Related to / Depends on \*

Typings

<!--- Optional -->
