### PR TITLE
Disable automatic link prefetching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.133.2",
+  "version": "8.134.0-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/utils/flags.ts
+++ b/react/utils/flags.ts
@@ -1,7 +1,7 @@
 const flags = {
   RENDER_NAVIGATION: true,
   VTEX_ASSETS_URL: true,
-  PREFETCH: true,
+  PREFETCH: false,
 }
 
 window.flags = flags


### PR DESCRIPTION
#### What does this PR do? \*
Disables the logic that does automatic prefetching. This is a very expensive feature that is not really useful in practice, as the prefetch takes longer than the time for the user to click the links.

#### How to test it? \*
Using [this workspace](https://mairaprefetch--storecomponents.myvtex.com/shirt?_q=shirt&map=ft) follow these steps:
1. Open the Network inspector tab of your browser.
2. Mouse over the page's links (products, categories, brands, etc).
3. Verify that no new requests with the `__pickRuntime` query string are made (**tip**: _filter by `__pickRuntime` in the network tab_).

Doing these exact same steps in the [master workspace](https://storecomponents.myvtex.com/shirt?_q=shirt&map=ft) will show a bunch of new requests with the `__pickRuntime` query string as you mouse over page links.

