### PR TITLE
Fix: return to previous scroll position during back button navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Return to previous scroll position during back button navigation
+
 ## [8.134.0] - 2023-08-10
 
 ## [8.133.2] - 2023-06-07

--- a/react/components/RenderProvider.tsx
+++ b/react/components/RenderProvider.tsx
@@ -680,6 +680,7 @@ export class RenderProvider extends Component<
   public onPageChanged = (location: RenderHistoryLocation) => {
     const {
       runtime: { renderMajor, query: queryFromRuntime, isJanusProxied },
+      history,
     } = this.props
 
     const {
@@ -839,10 +840,13 @@ export class RenderProvider extends Component<
                 settings,
               }),
               () => {
+                const scrollOptions =
+                  history?.action === 'POP' ? false : state.scrollOptions
+
                 this.navigationState = { isNavigating: false }
                 this.replaceRouteClass(matchingPage.routeId)
                 this.sendInfoFromIframe()
-                this.scrollTo(state.scrollOptions)
+                this.scrollTo(scrollOptions)
               }
             )
           }


### PR DESCRIPTION
#### What does this PR do? \*

This PR prevents the page scroll being reset to `top: 0, left: 0` during page navigation if the navigation was initiated by the browser's back button. This allows the user to return to the previous scroll position when going back to the PLP after viewing a PDP, for example. 

#### How to test it? \*

Linked here: https://arthur--renwil.myvtex.com/mirrors?__bindingAddress=www.renwil.com/en

Scroll partway down the page, click on a product to go to the PDP, then click the Back button. You should return to the same scroll position that you were previously viewing.