### PR TITLE
feat(imgs): removing lazy loading from eager images in the first fold

### DIFF
--- a/react/components/LazyImages.tsx
+++ b/react/components/LazyImages.tsx
@@ -43,15 +43,17 @@ const useLazyImagesContext = () => {
 interface MaybeLazyImageProps {
   createElement: typeof React.createElement
   imageProps: Record<string, any>
+  lazyType: string
 }
 
 const MaybeLazyImage: FC<MaybeLazyImageProps> = ({
   createElement = React.createElement,
   imageProps,
+  lazyType,
 }) => {
   const { lazyLoad, method } = useLazyImagesContext()
 
-  if (lazyLoad) {
+  if (lazyLoad && lazyType !== 'eager') {
     let newImageProps = imageProps
 
     switch (method) {

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -347,6 +347,7 @@ function start() {
           {
             createElement: ReactCreateElement,
             imageProps: props,
+            lazyType: props.loading,
           },
         ])
       }


### PR DESCRIPTION
#### What does this PR do? \*

O objetivo é evitar que este app adicione lazy loading nas imagens da primeira dobra.
Por exemplo: uma loja possui uma imagem acima do header.
Por mais que no site editor esteja com a opção "Ao carregar a página", ou seja, loading="eager", este app substitui para loading="lazy" e adiciona as classes "vtex-render-runtime-8-x-lazyload lazyloaded", causando atraso no carregamento e na renderização.
"Qualquer item acima da dobra não deve ser carregado lentamente. Esses recursos precisam ser considerados críticos e, portanto, precisam ser carregados normalmente." - [Práticas recomendadas de carregamento lento](https://web.dev/articles/lazy-loading-best-practices?hl=pt-br)


#### How to test it? \*

Abra uma loja que tenha uma imagem pré-header.
Inspecione a imagem.
Ela vai estar com o atributo loading="lazy" e a classe "vtex-render-runtime-8-x-lazyload lazyloaded"
