### PR TITLE
chore: add admin information to the sentry capture exception event

### DIFF
--- a/react/error.tsx
+++ b/react/error.tsx
@@ -21,6 +21,8 @@ class ErrorPage extends Component {
       this.setState({ enabled: true })
     }, 5000)
 
+    if (!isAdmin()) return
+
     try {
       const error = window?.__ERROR__
       const requestId = window?.__REQUEST_ID__
@@ -30,9 +32,7 @@ class ErrorPage extends Component {
       const runtime = window?.global?.__RUNTIME__ ?? {}
       const errorInfo = this.extractErrorInfo(runtime)
 
-      if (!isAdmin() || errorInfo.admin_production === false) {
-        return
-      }
+      if (errorInfo.admin_production === false) return
 
       getCurrentScope().setTags(errorInfo)
 
@@ -58,7 +58,7 @@ class ErrorPage extends Component {
       production = null,
     } = runtime
 
-    const errorInfo = {
+    return {
       admin_account: account,
       admin_workspace: workspace,
       admin_locale: locale,
@@ -66,8 +66,6 @@ class ErrorPage extends Component {
       admin_device: loadedDevices[0],
       admin_production: production,
     }
-
-    return errorInfo
   }
 
   public render() {

--- a/react/utils/isAdmin.ts
+++ b/react/utils/isAdmin.ts
@@ -9,7 +9,7 @@ export function isAdmin() {
     return false
   }
 
-  const { host } = window.location
+  const { host = '' } = window.location
 
   const isMyvtexDomain = host.includes('myvtex.com')
 
@@ -22,7 +22,7 @@ export function isAdmin() {
     '/_v/segment/admin-login/v1/login', // Let's consider the Admin Login page as an Admin App even though it's technically not.
   ]
 
-  const { pathname } = window.location
+  const { pathname = '' } = window.location
 
   return adminPathnames.some((path) => pathname.startsWith(path))
 }


### PR DESCRIPTION
#### What does this PR do? \*

Add additional information to the sentry admin instrumentation, like: `account`, `workspace`, `device`, whether is in `production`  or not, `locale`, and `path`. 

#### How to test it? \*

In [this workspace](https://lucasan--storecomponents.myvtex.com/admin/catalog) you can open the `console.log` and check the data sent whenever an error on production occurs.

<img width="339" alt="Screenshot 2024-08-08 at 10 05 04" src="https://github.com/user-attachments/assets/730af70f-449b-4bff-93b4-2d12f316ab4c">


#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
