### PR TITLE
Feat/admin sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.134.5-beta] - 2024-08-12
+
 ## [8.134.4] - 2024-07-25
 
 ## [8.134.4-beta] - 2024-07-19
@@ -1642,6 +1644,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix sorting direct children with numeric values.
 
 
-[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.4-beta...HEAD
+[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.5-beta...HEAD
 [8.134.4-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.3-beta...v8.134.4-beta
 [8.134.3-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.2...v8.134.3-beta
+[8.134.5-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.4...v8.134.5-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Admin information to the sentry capture exception events.
+
+### Fixed 
+
+- `isAdmin` invalid regular expression for Safari version 15.6 or less.
+
 ## [8.134.5-beta] - 2024-08-12
 
 ## [8.134.4] - 2024-07-25

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.134.4",
+  "version": "8.134.5-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/components/Sentry.tsx
+++ b/react/components/Sentry.tsx
@@ -1,3 +1,0 @@
-import * as Sentry from '@sentry/react'
-
-export default Sentry

--- a/react/components/Sentry.tsx
+++ b/react/components/Sentry.tsx
@@ -1,0 +1,3 @@
+import * as Sentry from '@sentry/react'
+
+export default Sentry

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -75,7 +75,6 @@ import {
 import { RenderRuntime, Extensions } from '../typings/runtime'
 // We need to keep this import so the types of this modules are kept in the final bundle by the Builder Hub.
 import '../typings/runtime'
-import Sentry from '../components/Sentry'
 
 let emitter: EventEmitter | null = null
 const cssClasses = new Set<string>()
@@ -409,7 +408,6 @@ export {
   LayoutContainer,
   LegacyExtensionContainer,
   Helmet,
-  Sentry,
   Link,
   NoSSR,
   useSSR,

--- a/react/core/main.tsx
+++ b/react/core/main.tsx
@@ -75,6 +75,7 @@ import {
 import { RenderRuntime, Extensions } from '../typings/runtime'
 // We need to keep this import so the types of this modules are kept in the final bundle by the Builder Hub.
 import '../typings/runtime'
+import Sentry from '../components/Sentry'
 
 let emitter: EventEmitter | null = null
 const cssClasses = new Set<string>()
@@ -386,9 +387,6 @@ function start() {
         .catch((error) => {
           console.error('Error during hydration', error)
         })
-      console.log(
-        'Welcome to Render! Want to look under the hood? https://careers.vtex.com'
-      )
     }
   } catch (error) {
     console.error('Unexpected error rendering:', error)
@@ -411,6 +409,7 @@ export {
   LayoutContainer,
   LegacyExtensionContainer,
   Helmet,
+  Sentry,
   Link,
   NoSSR,
   useSSR,


### PR DESCRIPTION
#### What does this PR do? \*

* It adds admin information to the sentry capture exception event - #658 
* fix `isAdmin` invalid regular expression for Safari version 15.6 or less #657  

#### How to test it? \*

You can generate Sentry errors using [this workspace](https://lucasan--storecomponents.myvtex.com/admin)
