### PR TITLE
feat: runtime retrieval fallback to log errors - ADMT-532

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Changes from 8.134.6-beta.
+
 ## [8.134.6-beta] - 2024-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Runtime information retrieval fallback when logging errors.
+
 ## [8.134.5] - 2024-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.134.6-beta] - 2024-08-13
+
 ### Added
 
 - Runtime information retrieval fallback when logging errors.
@@ -1658,7 +1660,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix sorting direct children with numeric values.
 
 
-[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.5-beta...HEAD
+[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.6-beta...HEAD
 [8.134.4-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.3-beta...v8.134.4-beta
 [8.134.3-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.2...v8.134.3-beta
 [8.134.5-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.4...v8.134.5-beta
+
+[8.134.6-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.5...v8.134.6-beta

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.134.5",
+  "version": "8.134.6-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -40,6 +40,7 @@ class ErrorPage extends Component {
 
       const errorInfo = this.extractErrorInfo()
 
+      // Change this condition to true while testing
       if (errorInfo.admin_production === false) return
 
       getCurrentScope().setTags(errorInfo)
@@ -126,10 +127,14 @@ class ErrorPage extends Component {
 
     const { pathname } = window.location
 
+    const locale =
+      navigator?.language ?? Intl.DateTimeFormat().resolvedOptions().locale
+
     return {
       account,
       workspace,
       route: { path: pathname },
+      culture: { locale },
     }
   }
 

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -13,6 +13,15 @@ import style from './error.css'
 import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
 
+interface RuntimeInfo {
+  account: string | null
+  workspace: string | null
+  route: { path: string | null }
+  culture: { locale: string | null }
+  production: boolean | null
+  loadedDevices: Array<string | null>
+}
+
 class ErrorPage extends Component {
   public state = { enabled: false }
 
@@ -29,8 +38,7 @@ class ErrorPage extends Component {
       const defaultError =
         'Render Runtime renderered an error page and there is no error or request id available'
 
-      const runtime = window?.global?.__RUNTIME__ ?? {}
-      const errorInfo = this.extractErrorInfo(runtime)
+      const errorInfo = this.extractErrorInfo()
 
       if (errorInfo.admin_production === false) return
 
@@ -48,7 +56,38 @@ class ErrorPage extends Component {
     }
   }
 
-  private extractErrorInfo(runtime: any): any {
+  private extractErrorInfo() {
+    const {
+      account = null,
+      workspace = null,
+      culture: { locale } = { locale: null },
+      route: { path } = { path: null },
+      loadedDevices = null,
+      production = null,
+      runtimeAvailable,
+    } = this.getRuntimeInfo()
+
+    return {
+      admin_account: account,
+      admin_workspace: workspace,
+      admin_locale: locale,
+      admin_path: path,
+      admin_device: Array.isArray(loadedDevices)
+        ? loadedDevices[0]
+        : loadedDevices,
+      admin_production: production,
+      admin_runtime_available: runtimeAvailable,
+    }
+  }
+
+  /**
+   * Gets the Runtime information from the global __RUNTIME__ object
+   * injected by Render Server, if available, otherwise infer the runtime
+   * information from the window.location.
+   */
+  private getRuntimeInfo = (): RuntimeInfo & { runtimeAvailable: boolean } => {
+    const runtime = window?.global?.__RUNTIME__ ?? this.inferRuntimeInfo()
+
     const {
       account = null,
       workspace = null,
@@ -59,12 +98,38 @@ class ErrorPage extends Component {
     } = runtime
 
     return {
-      admin_account: account,
-      admin_workspace: workspace,
-      admin_locale: locale,
-      admin_path: path,
-      admin_device: loadedDevices[0],
-      admin_production: production,
+      account,
+      workspace,
+      culture: { locale },
+      route: { path },
+      loadedDevices,
+      production,
+      runtimeAvailable: !!window?.global?.__RUNTIME__,
+    }
+  }
+
+  /**
+   * Infer the runtime information from the window.location object.
+   */
+  private inferRuntimeInfo(): Partial<RuntimeInfo> {
+    const { host = '' } = window.location
+    let account = ''
+    let workspace = ''
+
+    if (!host.includes('--')) {
+      account = host.split('.')[0]
+      workspace = 'master'
+    } else {
+      workspace = host.split('--')[0]
+      account = host.split('--')[1].split('.')[0]
+    }
+
+    const { pathname } = window.location
+
+    return {
+      account,
+      workspace,
+      route: { path: pathname },
     }
   }
 


### PR DESCRIPTION
This PR adds a runtime information retrieval fallback while logging errors to Sentry. It adds redundancy to make sure that we have the information we want available to debug our services.

Test environments (development):
- https://sentryiteration2--teamadmin.myvtex.com/admin 
- https://sentryiteration2break--teamadmin.myvtex.com/admin (Render server throws error _with runtime information available_)
- https://sentryiteration2breaknoruntime--teamadmin.myvtex.com/admin (Render server throws error _with **no** runtime information available **relies on fallback**_)

For richer details, reach out on Slack :hugs: 