### PR TITLE
feat: log extra args through auto-instrumentation - ADMT-535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Additions from previous beta release.
+
+### Changed
+
+- Changes from previous beta release.
+
 ## [8.134.7-beta] - 2024-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Mechanism to programatically log events to Sentry via query string (`?forceLogs=true`).
+
+### Changed
+
+- Moved all runtime information retrieval from the error page to the Sentry `beforeSend` middleware.
+
 ## [8.134.6] - 2024-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.134.7-beta] - 2024-08-19
+
 ### Added
 
 - Mechanism to programatically log events to Sentry via query string (`?forceLogs=true`).
@@ -1674,9 +1676,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix sorting direct children with numeric values.
 
 
-[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.6-beta...HEAD
+[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.7-beta...HEAD
 [8.134.4-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.3-beta...v8.134.4-beta
 [8.134.3-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.2...v8.134.3-beta
 [8.134.5-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.4...v8.134.5-beta
 
 [8.134.6-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.5...v8.134.6-beta
+[8.134.7-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.6...v8.134.7-beta

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.134.6",
+  "version": "8.134.7-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/components/ErrorBoundary.tsx
+++ b/react/components/ErrorBoundary.tsx
@@ -2,6 +2,9 @@ import React, { ErrorInfo, FunctionComponent } from 'react'
 import ErrorDisplay from './ExtensionPoint/ErrorDisplay'
 import { useRuntime } from './RenderContext'
 import type { RenderContext } from './RenderContext'
+import { isAdmin } from '../utils/isAdmin'
+import { captureException } from '@sentry/react'
+import { CustomAdminTags } from '../o11y/types'
 
 interface Props {
   runtime: RenderContext
@@ -18,6 +21,14 @@ class ErrorBoundary extends React.Component<Props> {
       error,
       errorInfo,
     })
+
+    if (!isAdmin()) return
+
+    const tags: CustomAdminTags = {
+      admin_render_runtime_page: 'ErrorBoundary',
+    }
+
+    captureException(this.state, { tags })
   }
 
   public render() {

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -12,6 +12,7 @@ import ErrorImg from './images/error-img.png'
 import style from './error.css'
 import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
+import { CustomAdminTags } from './o11y/types'
 
 class ErrorPage extends Component {
   public state = { enabled: false }
@@ -23,6 +24,10 @@ class ErrorPage extends Component {
 
     if (!isAdmin()) return
 
+    const tags: CustomAdminTags = {
+      admin_render_runtime_page: ERROR_PAGE_COMPONENT,
+    }
+
     try {
       const error = window?.__ERROR__
       const requestId = window?.__REQUEST_ID__
@@ -30,14 +35,14 @@ class ErrorPage extends Component {
         'Render Runtime renderered an error page and there is no error or request id available'
 
       if (error) {
-        captureException(error)
+        captureException(error, { tags })
       } else if (requestId) {
-        captureException(requestId)
+        captureException(requestId, { tags })
       } else {
-        captureException(defaultError)
+        captureException(defaultError, { tags })
       }
     } catch (e) {
-      captureException(e)
+      captureException(e, { tags })
     }
   }
 

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -14,6 +14,20 @@ import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
 import { CustomAdminTags } from './o11y/types'
 
+/**
+ * The ErrorPage component is rendered when there is an error on the Render Framework server-side lifecycle.
+ *
+ * Errors that occur on the client-side are caught by the ErrorBoundary component (see react/components/ErrorBoundary.tsx).
+ *
+ * @warning
+ * Updates to this component must be followed by changes to Render Server, specifically the node/middlewares/error.ts file.
+ *
+ * This is required to ensure that the error page rendered during errors on the server-side lifecycle is always up-to-date, as
+ * depending on the error, the Render Server may not be able to fetch the latest version of the ErrorPage component from the
+ * Render Runtime, thus falling back to a hardcoded version that must be always up to date.
+ *
+ * Use this PR as a reference on how to update the Render Server accordingly: https://github.com/vtex/render-server/pull/800.
+ */
 class ErrorPage extends Component {
   public state = { enabled: false }
 

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -1,7 +1,7 @@
 /* global module */
 import React, { Component, Fragment } from 'react'
 import ReactJson from 'react-json-view'
-import { captureException, getCurrentScope } from '@sentry/react'
+import { captureException } from '@sentry/react'
 
 require('myvtex-sse')
 
@@ -12,7 +12,6 @@ import ErrorImg from './images/error-img.png'
 import style from './error.css'
 import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
-import { getExtraArgs } from './o11y/extraArgs'
 
 class ErrorPage extends Component {
   public state = { enabled: false }
@@ -29,13 +28,6 @@ class ErrorPage extends Component {
       const requestId = window?.__REQUEST_ID__
       const defaultError =
         'Render Runtime renderered an error page and there is no error or request id available'
-
-      const errorInfo = getExtraArgs()
-
-      // Change this condition to true while testing
-      if (errorInfo.admin_production === false) return
-
-      getCurrentScope().setTags(errorInfo)
 
       if (error) {
         captureException(error)

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -12,15 +12,7 @@ import ErrorImg from './images/error-img.png'
 import style from './error.css'
 import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
-
-interface RuntimeInfo {
-  account: string | null
-  workspace: string | null
-  route: { path: string | null }
-  culture: { locale: string | null }
-  production: boolean | null
-  loadedDevices: Array<string | null>
-}
+import { getExtraArgs } from './o11y/extraArgs'
 
 class ErrorPage extends Component {
   public state = { enabled: false }
@@ -38,7 +30,7 @@ class ErrorPage extends Component {
       const defaultError =
         'Render Runtime renderered an error page and there is no error or request id available'
 
-      const errorInfo = this.extractErrorInfo()
+      const errorInfo = getExtraArgs()
 
       // Change this condition to true while testing
       if (errorInfo.admin_production === false) return
@@ -54,87 +46,6 @@ class ErrorPage extends Component {
       }
     } catch (e) {
       captureException(e)
-    }
-  }
-
-  private extractErrorInfo() {
-    const {
-      account = null,
-      workspace = null,
-      culture: { locale } = { locale: null },
-      route: { path } = { path: null },
-      loadedDevices = null,
-      production = null,
-      runtimeAvailable,
-    } = this.getRuntimeInfo()
-
-    return {
-      admin_account: account,
-      admin_workspace: workspace,
-      admin_locale: locale,
-      admin_path: path,
-      admin_device: Array.isArray(loadedDevices)
-        ? loadedDevices[0]
-        : loadedDevices,
-      admin_production: production,
-      admin_runtime_available: runtimeAvailable,
-    }
-  }
-
-  /**
-   * Gets the Runtime information from the global __RUNTIME__ object
-   * injected by Render Server, if available, otherwise infer the runtime
-   * information from the window.location.
-   */
-  private getRuntimeInfo = (): RuntimeInfo & { runtimeAvailable: boolean } => {
-    const runtime = window?.global?.__RUNTIME__ ?? this.inferRuntimeInfo()
-
-    const {
-      account = null,
-      workspace = null,
-      culture: { locale } = { locale: null },
-      route: { path } = { path: null },
-      loadedDevices = [null],
-      production = null,
-    } = runtime
-
-    return {
-      account,
-      workspace,
-      culture: { locale },
-      route: { path },
-      loadedDevices,
-      production,
-      runtimeAvailable: !!window?.global?.__RUNTIME__,
-    }
-  }
-
-  /**
-   * Infer the runtime information from the window.location object.
-   */
-  private inferRuntimeInfo(): Partial<RuntimeInfo> {
-    const { host = '' } = window.location
-    let account = ''
-    let workspace = ''
-
-    if (!host.includes('--')) {
-      account = host.split('.')[0]
-      workspace = 'master'
-    } else {
-      workspace = host.split('--')[0]
-      account = host.split('--')[1].split('.')[0]
-    }
-
-    const { pathname } = window.location
-
-    const locale =
-      navigator?.language ?? Intl.DateTimeFormat().resolvedOptions().locale
-
-    return {
-      account,
-      workspace,
-      route: { path: pathname },
-      culture: { locale },
     }
   }
 

--- a/react/o11y/ctx.ts
+++ b/react/o11y/ctx.ts
@@ -1,3 +1,5 @@
+import { AdminTags } from './types'
+
 interface RuntimeInfo {
   account: string | null
   workspace: string | null
@@ -49,7 +51,7 @@ export function getRuntimeInfo(): RuntimeInfo & { runtimeAvailable: boolean } {
     workspace = null,
     culture: { locale } = { locale: null },
     route: { path, blockId } = { path: null, blockId: null },
-    loadedDevices = [null],
+    loadedDevices = null,
     production = null,
   } = runtime
 
@@ -66,9 +68,11 @@ export function getRuntimeInfo(): RuntimeInfo & { runtimeAvailable: boolean } {
 
 /**
  * Retrieves VTEX IO context and adapt it to format expected
- * on Sentry.
+ * by Sentry for the Admin.
  */
-export function getIOContext() {
+export function getIOContext(): AdminTags {
+  const runtime = window?.__RUNTIME__ ?? inferRuntimeInfo()
+
   const {
     account = null,
     workspace = null,
@@ -76,8 +80,7 @@ export function getIOContext() {
     route: { path, blockId } = { path: null, blockId: null },
     loadedDevices = null,
     production = null,
-    runtimeAvailable,
-  } = getRuntimeInfo()
+  } = runtime
 
   return {
     admin_account: account,
@@ -89,6 +92,6 @@ export function getIOContext() {
       ? loadedDevices[0]
       : loadedDevices,
     admin_production: production,
-    admin_runtime_available: runtimeAvailable,
+    admin_runtime_available: !!window?.__RUNTIME__,
   }
 }

--- a/react/o11y/extraArgs.ts
+++ b/react/o11y/extraArgs.ts
@@ -1,0 +1,89 @@
+interface RuntimeInfo {
+  account: string | null
+  workspace: string | null
+  route: { path: string | null }
+  culture: { locale: string | null }
+  production: boolean | null
+  loadedDevices: Array<string | null>
+}
+
+/**
+ * Infer the runtime information from the window.location object.
+ */
+export function inferRuntimeInfo(): Partial<RuntimeInfo> {
+  const { host = '' } = window.location
+  let account = ''
+  let workspace = ''
+
+  if (!host.includes('--')) {
+    account = host.split('.')[0]
+    workspace = 'master'
+  } else {
+    workspace = host.split('--')[0]
+    account = host.split('--')[1].split('.')[0]
+  }
+
+  const { pathname } = window.location
+
+  const locale =
+    navigator?.language ?? Intl.DateTimeFormat().resolvedOptions().locale
+
+  return {
+    account,
+    workspace,
+    route: { path: pathname },
+    culture: { locale },
+  }
+}
+
+/**
+ * Gets the Runtime information from the global __RUNTIME__ object
+ * injected by Render Server, if available, otherwise infer the runtime
+ * information from the window.location.
+ */
+export function getRuntimeInfo(): RuntimeInfo & { runtimeAvailable: boolean } {
+  const runtime = window?.global?.__RUNTIME__ ?? inferRuntimeInfo()
+
+  const {
+    account = null,
+    workspace = null,
+    culture: { locale } = { locale: null },
+    route: { path } = { path: null },
+    loadedDevices = [null],
+    production = null,
+  } = runtime
+
+  return {
+    account,
+    workspace,
+    culture: { locale },
+    route: { path },
+    loadedDevices,
+    production,
+    runtimeAvailable: !!window?.global?.__RUNTIME__,
+  }
+}
+
+export function getExtraArgs() {
+  const {
+    account = null,
+    workspace = null,
+    culture: { locale } = { locale: null },
+    route: { path } = { path: null },
+    loadedDevices = null,
+    production = null,
+    runtimeAvailable,
+  } = getRuntimeInfo()
+
+  return {
+    admin_account: account,
+    admin_workspace: workspace,
+    admin_locale: locale,
+    admin_path: path,
+    admin_device: Array.isArray(loadedDevices)
+      ? loadedDevices[0]
+      : loadedDevices,
+    admin_production: production,
+    admin_runtime_available: runtimeAvailable,
+  }
+}

--- a/react/o11y/extraArgs.ts
+++ b/react/o11y/extraArgs.ts
@@ -1,7 +1,7 @@
 interface RuntimeInfo {
   account: string | null
   workspace: string | null
-  route: { path: string | null }
+  route: { path: string | null; blockId: string | null }
   culture: { locale: string | null }
   production: boolean | null
   loadedDevices: Array<string | null>
@@ -31,7 +31,7 @@ export function inferRuntimeInfo(): Partial<RuntimeInfo> {
   return {
     account,
     workspace,
-    route: { path: pathname },
+    route: { path: pathname, blockId: null },
     culture: { locale },
   }
 }
@@ -42,13 +42,13 @@ export function inferRuntimeInfo(): Partial<RuntimeInfo> {
  * information from the window.location.
  */
 export function getRuntimeInfo(): RuntimeInfo & { runtimeAvailable: boolean } {
-  const runtime = window?.global?.__RUNTIME__ ?? inferRuntimeInfo()
+  const runtime = window?.__RUNTIME__ ?? inferRuntimeInfo()
 
   const {
     account = null,
     workspace = null,
     culture: { locale } = { locale: null },
-    route: { path } = { path: null },
+    route: { path, blockId } = { path: null, blockId: null },
     loadedDevices = [null],
     production = null,
   } = runtime
@@ -57,19 +57,23 @@ export function getRuntimeInfo(): RuntimeInfo & { runtimeAvailable: boolean } {
     account,
     workspace,
     culture: { locale },
-    route: { path },
+    route: { path, blockId },
     loadedDevices,
     production,
-    runtimeAvailable: !!window?.global?.__RUNTIME__,
+    runtimeAvailable: !!window?.__RUNTIME__,
   }
 }
 
-export function getExtraArgs() {
+/**
+ * Retrieves VTEX IO context and adapt it to format expected
+ * on Sentry.
+ */
+export function getIOContext() {
   const {
     account = null,
     workspace = null,
     culture: { locale } = { locale: null },
-    route: { path } = { path: null },
+    route: { path, blockId } = { path: null, blockId: null },
     loadedDevices = null,
     production = null,
     runtimeAvailable,
@@ -80,6 +84,7 @@ export function getExtraArgs() {
     admin_workspace: workspace,
     admin_locale: locale,
     admin_path: path,
+    admin_app_block: blockId, // ex. "vtex.admin-home@3.x:admin.app.home"
     admin_device: Array.isArray(loadedDevices)
       ? loadedDevices[0]
       : loadedDevices,

--- a/react/o11y/instrument.ts
+++ b/react/o11y/instrument.ts
@@ -51,7 +51,7 @@ function makeEventWithCtx(event: any, ctx: any) {
   const eventWithCtx = {
     ...event,
     tags: {
-      ...event.tags,
+      ...event?.tags,
       ...ctx,
     },
   }

--- a/react/o11y/instrument.ts
+++ b/react/o11y/instrument.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { isAdmin } from '../utils/isAdmin'
+import { getExtraArgs } from './extraArgs'
 
 if (isAdmin()) {
   Sentry.init({
@@ -21,5 +22,11 @@ if (isAdmin()) {
     // plus for 50% of sessions with an error
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0.5,
+
+    beforeSend: (event, hint) => {
+      const extraArgs = getExtraArgs()
+
+      return { ...event, ...extraArgs, ...hint }
+    },
   })
 }

--- a/react/o11y/instrument.ts
+++ b/react/o11y/instrument.ts
@@ -32,10 +32,29 @@ if (isAdmin()) {
       // the apps are running under a production or development
       // environment.
       if (ctx.admin_production === false) {
+        const params = new URL(document?.location?.toString())?.searchParams
+        const shouldLog = params.get('forceLogs')
+
+        if (shouldLog === 'true') {
+          return makeEventWithCtx(event, ctx)
+        }
+
         return null
       }
 
-      return { ...event, ...ctx }
+      return makeEventWithCtx(event, ctx)
     },
   })
+}
+
+function makeEventWithCtx(event: any, ctx: any) {
+  const eventWithCtx = {
+    ...event,
+    tags: {
+      ...event.tags,
+      ...ctx,
+    },
+  }
+
+  return eventWithCtx
 }

--- a/react/o11y/instrument.ts
+++ b/react/o11y/instrument.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { isAdmin } from '../utils/isAdmin'
-import { getExtraArgs } from './extraArgs'
+import { getIOContext } from './extraArgs'
 
 if (isAdmin()) {
   Sentry.init({
@@ -23,10 +23,19 @@ if (isAdmin()) {
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0.5,
 
-    beforeSend: (event, hint) => {
-      const extraArgs = getExtraArgs()
+    beforeSend: (event) => {
+      const ctx = getIOContext()
 
-      return { ...event, ...extraArgs, ...hint }
+      // Must check with false, otherwise default null's
+      // value leads to data mistakenly not sent to Sentry,
+      // which can occur if somehow we can't infer whether
+      // the apps are running under a production or development
+      // environment.
+      if (ctx.admin_production === false) {
+        return null
+      }
+
+      return { ...event, ...ctx }
     },
   })
 }

--- a/react/o11y/instrument.ts
+++ b/react/o11y/instrument.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { isAdmin } from '../utils/isAdmin'
-import { getIOContext } from './extraArgs'
+import { getIOContext } from './ctx'
 
 if (isAdmin()) {
   Sentry.init({

--- a/react/o11y/types.ts
+++ b/react/o11y/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Custom Admin tags logged by the Sentry SDK.
+ */
+export type CustomAdminTags = Record<string, any> & {
+  /**
+   * The Render Runtime page component that rendered an error.
+   */
+  admin_render_runtime_page: 'ErrorPage' | 'ErrorBoundary'
+}
+
+/**
+ * Default Admin tags logged by the Sentry SDK.
+ */
+export interface AdminTags {
+  /**
+   * Account running the app.
+   */
+  admin_account: string
+  /**
+   * Workspace running the app.
+   */
+  admin_workspace: string
+  /**
+   * Locale running the app.
+   */
+  admin_locale: string
+  /**
+   * Path of the app.
+   */
+  admin_path: string
+  /**
+   * Block ID of the app.
+   *
+   * @example
+   * "vtex.admin-home@3.x:admin.app.home"
+   */
+  admin_app_block: string
+  /**
+   * Device running the app.
+   *
+   * @example
+   * ["desktop", "tablet"]
+   */
+  admin_device: string
+  /**
+   * Whether the app is running in production.
+   * The values from this variable logged to
+   * Sentry are always true OR null; never false.
+   */
+  admin_production: boolean
+  /**
+   * Whether the runtime information from the
+   * global __RUNTIME__ object is available or not.
+   */
+  admin_runtime_available: boolean
+}


### PR DESCRIPTION
This PR is a follow up from #660 that attempts to ensure that VTEX context is present in every log on Sentry through its auto-instrumentation middleware `beforeSend`. 

It moves all logic that retrieves and inserts VTEX context into the payload to Sentry to the aforementioned hook.

It also creates a mechanism to allow sending events to Sentry on development environments programatically.

[Reach out on Slack for more information on testing these changes](https://vtex.slack.com/archives/C07EHD840N6/p1723661822897809).

Related to:
- https://github.com/vtex/render-server/pull/800