### PR TITLE
feat: add method to index certain errors on Sentry - ADMT-541

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ docs/_book/
 npm-debug.log
 .build/
 lib
+
+# Coverage
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Method to extract keys from error objects recursively so we can index them on Sentry.
+
 ## [8.134.7] - 2024-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.134.8-beta] - 2024-08-20
+
 ### Added
 
 - Method to extract keys from error objects recursively so we can index them on Sentry.
@@ -1690,10 +1692,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix sorting direct children with numeric values.
 
 
-[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.7-beta...HEAD
+[Unreleased]: https://github.com/vtex-apps/render-runtime/compare/v8.134.8-beta...HEAD
 [8.134.4-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.3-beta...v8.134.4-beta
 [8.134.3-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.2...v8.134.3-beta
 [8.134.5-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.4...v8.134.5-beta
 
 [8.134.6-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.5...v8.134.6-beta
 [8.134.7-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.6...v8.134.7-beta
+[8.134.8-beta]: https://github.com/vtex-apps/render-runtime/compare/v8.134.7...v8.134.8-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Additions from previous beta release.
+
 ## [8.134.8-beta] - 2024-08-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.134.7",
+  "version": "8.134.8-beta",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/error.tsx
+++ b/react/error.tsx
@@ -13,6 +13,7 @@ import style from './error.css'
 import { renderReadyPromise } from '.'
 import { isAdmin } from './utils/isAdmin'
 import { CustomAdminTags } from './o11y/types'
+import { extractExtra } from './o11y/extractExtra'
 
 /**
  * The ErrorPage component is rendered when there is an error on the Render Framework server-side lifecycle.
@@ -49,7 +50,7 @@ class ErrorPage extends Component {
         'Render Runtime renderered an error page and there is no error or request id available'
 
       if (error) {
-        captureException(error, { tags })
+        captureException(error, { tags: { ...tags, ...extractExtra(error) } })
       } else if (requestId) {
         captureException(requestId, { tags })
       } else {

--- a/react/o11y/extractExtra.test.ts
+++ b/react/o11y/extractExtra.test.ts
@@ -60,8 +60,8 @@ describe('extractExtra', () => {
 
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_graphqlerrors1: '[Array]',
-      admin_extra_message1: 'messages',
+      admin_extra_gqlerrors1: '[Array]',
+      admin_extra_msg1: 'messages',
       admin_extra_name1: 'Error',
       admin_extra_stack0_0:
         'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:',
@@ -96,10 +96,10 @@ describe('extractExtra', () => {
     const result = extractExtra(err)
     expect(result).toEqual({
       admin_extra_code1: 'ECONNABORTED',
-      admin_extra_isaxioserror1: true,
-      admin_extra_message1: 'timeout of 4000ms exceeded',
+      admin_extra_axios1: true,
+      admin_extra_msg1: 'timeout of 4000ms exceeded',
       admin_extra_name1: 'Error',
-      admin_extra_request1: '[Object]',
+      admin_extra_req1: '[Object]',
       admin_extra_config1: '[Object]',
       admin_extra_stack0_0:
         'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib',
@@ -138,11 +138,11 @@ describe('extractExtra', () => {
     const result = extractExtra(err)
     expect(result).toEqual({
       admin_extra_code1: 'E_HTTP_500',
-      admin_extra_isaxioserror1: true,
-      admin_extra_message1: 'Request failed with status code 500',
+      admin_extra_axios1: true,
+      admin_extra_msg1: 'Request failed with status code 500',
       admin_extra_name1: 'Error',
-      admin_extra_request1: '[Object]',
-      admin_extra_response1: '[Object]',
+      admin_extra_req1: '[Object]',
+      admin_extra_res1: '[Object]',
       admin_extra_config1: '[Object]',
       admin_extra_stack0_0:
         'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:',
@@ -200,5 +200,21 @@ describe('extractExtra', () => {
 
     const result = extractExtra(model)
     expect(result).toEqual({})
+  })
+
+  test('should not grab 32+ character key-value pairs', () => {
+    const err = {
+      superlongkeythathasmorethanthirtytwocharacters: 'value1',
+      b: 'value2',
+      nested: {
+        c: 'value3',
+        anothersuperlongkeythathasmorethanthirtytwocharacters: 'value4',
+      },
+    }
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_b0: 'value2',
+      admin_extra_c1: 'value3',
+    })
   })
 })

--- a/react/o11y/extractExtra.test.ts
+++ b/react/o11y/extractExtra.test.ts
@@ -45,15 +45,17 @@ describe('extractExtra', () => {
     })
   })
 
-  test('real world example #1', () => {
+  test('high fidelity example #1', () => {
     const err = {
       details: {
         graphQLErrors: '[Array]',
         message: 'messages',
         name: 'Error',
-        stack: 'Some error stack',
+        stack:
+          'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
       },
-      stack: 'Some error stack',
+      stack:
+        'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
     }
 
     const result = extractExtra(err)
@@ -61,8 +63,100 @@ describe('extractExtra', () => {
       admin_extra_level_1_graphQLErrors: '[Array]',
       admin_extra_level_1_message: 'messages',
       admin_extra_level_1_name: 'Error',
-      admin_extra_level_1_stack: 'Some error stack',
-      admin_extra_level_0_stack: 'Some error stack',
+      admin_extra_level_0_stack_0:
+        'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:',
+      admin_extra_level_0_stack_1:
+        '23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/',
+      admin_extra_level_0_stack_2:
+        'api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
+      admin_extra_level_1_stack_0:
+        'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:',
+      admin_extra_level_1_stack_1:
+        '23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/',
+      admin_extra_level_1_stack_2:
+        'api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
+    })
+  })
+
+  test('high fidelity example #2', () => {
+    const err = {
+      details: {
+        code: 'ECONNABORTED',
+        config: '[Object]',
+        isAxiosError: true,
+        message: 'timeout of 4000ms exceeded',
+        name: 'Error',
+        request: '[Object]',
+        stack:
+          'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWrapper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/timers:502:7)',
+      },
+      stack:
+        'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWrapper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/timers:502:7)',
+    }
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_1_code: 'ECONNABORTED',
+      admin_extra_level_1_isAxiosError: true,
+      admin_extra_level_1_message: 'timeout of 4000ms exceeded',
+      admin_extra_level_1_name: 'Error',
+      admin_extra_level_1_request: '[Object]',
+      admin_extra_level_1_config: '[Object]',
+      admin_extra_level_0_stack_0:
+        'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib',
+      admin_extra_level_0_stack_1:
+        '/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWr',
+      admin_extra_level_0_stack_2:
+        'apper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/tim',
+      admin_extra_level_0_stack_3: 'ers:502:7)',
+      admin_extra_level_1_stack_0:
+        'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib',
+      admin_extra_level_1_stack_1:
+        '/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWr',
+      admin_extra_level_1_stack_2:
+        'apper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/tim',
+      admin_extra_level_1_stack_3: 'ers:502:7)',
+    })
+  })
+
+  test('high fidelity example #3', () => {
+    const err = {
+      details: {
+        code: 'E_HTTP_500',
+        config: '[Object]',
+        isAxiosError: true,
+        message: 'Request failed with status code 500',
+        name: 'Error',
+        request: '[Object]',
+        response: '[Object]',
+        stack:
+          'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
+      },
+      stack:
+        'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
+    }
+
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_1_code: 'E_HTTP_500',
+      admin_extra_level_1_isAxiosError: true,
+      admin_extra_level_1_message: 'Request failed with status code 500',
+      admin_extra_level_1_name: 'Error',
+      admin_extra_level_1_request: '[Object]',
+      admin_extra_level_1_response: '[Object]',
+      admin_extra_level_1_config: '[Object]',
+      admin_extra_level_0_stack_0:
+        'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:',
+      admin_extra_level_0_stack_1:
+        '12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams',
+      admin_extra_level_0_stack_2:
+        '/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
+
+      admin_extra_level_1_stack_0:
+        'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:',
+      admin_extra_level_1_stack_1:
+        '12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams',
+      admin_extra_level_1_stack_2:
+        '/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
     })
   })
 

--- a/react/o11y/extractExtra.test.ts
+++ b/react/o11y/extractExtra.test.ts
@@ -8,40 +8,40 @@ describe('extractExtra', () => {
   })
 
   test('should extract simple key-value pairs', () => {
-    const err = { key1: 'value1', key2: 'value2' }
+    const err = { a: 'value1', b: 'value2' }
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_0_key1: 'value1',
-      admin_extra_level_0_key2: 'value2',
+      admin_extra_a0: 'value1',
+      admin_extra_b0: 'value2',
     })
   })
 
   test('should extract nested objects', () => {
     const err = {
-      key1: 'value1',
+      a: 'value1',
       nested: {
-        key2: 'value2',
+        b: 'value2',
         deeper: {
-          key3: 'value3',
+          c: 'value3',
         },
       },
     }
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_0_key1: 'value1',
-      admin_extra_level_1_key2: 'value2',
-      admin_extra_level_2_key3: 'value3',
+      admin_extra_a0: 'value1',
+      admin_extra_b1: 'value2',
+      admin_extra_c2: 'value3',
     })
   })
 
   test('should ignore functions', () => {
     const err = {
-      key1: 'value1',
+      a: 'value1',
       func: () => {},
     }
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_0_key1: 'value1',
+      admin_extra_a0: 'value1',
     })
   })
 
@@ -60,20 +60,20 @@ describe('extractExtra', () => {
 
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_1_graphQLErrors: '[Array]',
-      admin_extra_level_1_message: 'messages',
-      admin_extra_level_1_name: 'Error',
-      admin_extra_level_0_stack_0:
+      admin_extra_graphqlerrors1: '[Array]',
+      admin_extra_message1: 'messages',
+      admin_extra_name1: 'Error',
+      admin_extra_stack0_0:
         'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:',
-      admin_extra_level_0_stack_1:
+      admin_extra_stack0_1:
         '23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/',
-      admin_extra_level_0_stack_2:
+      admin_extra_stack0_2:
         'api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
-      admin_extra_level_1_stack_0:
+      admin_extra_stack1_0:
         'Error: messages\n    at throwOnGraphQLErrors (/usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:10:15)\n    at /usr/local/app/node_modules/@vtex/api/lib/HttpClient/GraphQLClient.js:',
-      admin_extra_level_1_stack_1:
+      admin_extra_stack1_1:
         '23:15\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at MessagesGraphQL.translateWithDependencies (/usr/local/app/node_modules/@vtex/',
-      admin_extra_level_1_stack_2:
+      admin_extra_stack1_2:
         'api/lib/clients/apps/MessagesGraphQL.js:66:26)\n    at dataloader_1.default.batch (/usr/local/app/node_modules/@vtex/api/lib/service/worker/runtime/graphql/schema/messagesLoaderV2.js:68:15)',
     })
   })
@@ -95,26 +95,26 @@ describe('extractExtra', () => {
     }
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_1_code: 'ECONNABORTED',
-      admin_extra_level_1_isAxiosError: true,
-      admin_extra_level_1_message: 'timeout of 4000ms exceeded',
-      admin_extra_level_1_name: 'Error',
-      admin_extra_level_1_request: '[Object]',
-      admin_extra_level_1_config: '[Object]',
-      admin_extra_level_0_stack_0:
+      admin_extra_code1: 'ECONNABORTED',
+      admin_extra_isaxioserror1: true,
+      admin_extra_message1: 'timeout of 4000ms exceeded',
+      admin_extra_name1: 'Error',
+      admin_extra_request1: '[Object]',
+      admin_extra_config1: '[Object]',
+      admin_extra_stack0_0:
         'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib',
-      admin_extra_level_0_stack_1:
+      admin_extra_stack0_1:
         '/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWr',
-      admin_extra_level_0_stack_2:
+      admin_extra_stack0_2:
         'apper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/tim',
-      admin_extra_level_0_stack_3: 'ers:502:7)',
-      admin_extra_level_1_stack_0:
+      admin_extra_stack0_3: 'ers:502:7)',
+      admin_extra_stack1_0:
         'Error: timeout of 4000ms exceeded\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at ClientRequest.handleRequestTimeout (/usr/local/app/node_modules/axios/lib',
-      admin_extra_level_1_stack_1:
+      admin_extra_stack1_1:
         '/adapters/http.js:280:16)\n    at Object.onceWrapper (node:events:627:28)\n    at ClientRequest.emit (node:events:513:28)\n    at Socket.emitRequestTimeout (node:_http_client:839:9)\n    at Object.onceWr',
-      admin_extra_level_1_stack_2:
+      admin_extra_stack1_2:
         'apper (node:events:627:28)\n    at Socket.emit (node:events:525:35)\n    at Socket._onTimeout (node:net:550:8)\n    at listOnTimeout (node:internal/timers:559:17)\n    at processTimers (node:internal/tim',
-      admin_extra_level_1_stack_3: 'ers:502:7)',
+      admin_extra_stack1_3: 'ers:502:7)',
     })
   })
 
@@ -137,25 +137,25 @@ describe('extractExtra', () => {
 
     const result = extractExtra(err)
     expect(result).toEqual({
-      admin_extra_level_1_code: 'E_HTTP_500',
-      admin_extra_level_1_isAxiosError: true,
-      admin_extra_level_1_message: 'Request failed with status code 500',
-      admin_extra_level_1_name: 'Error',
-      admin_extra_level_1_request: '[Object]',
-      admin_extra_level_1_response: '[Object]',
-      admin_extra_level_1_config: '[Object]',
-      admin_extra_level_0_stack_0:
+      admin_extra_code1: 'E_HTTP_500',
+      admin_extra_isaxioserror1: true,
+      admin_extra_message1: 'Request failed with status code 500',
+      admin_extra_name1: 'Error',
+      admin_extra_request1: '[Object]',
+      admin_extra_response1: '[Object]',
+      admin_extra_config1: '[Object]',
+      admin_extra_stack0_0:
         'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:',
-      admin_extra_level_0_stack_1:
+      admin_extra_stack0_1:
         '12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams',
-      admin_extra_level_0_stack_2:
+      admin_extra_stack0_2:
         '/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
 
-      admin_extra_level_1_stack_0:
+      admin_extra_stack1_0:
         'Error: Request failed with status code 500\n    at createError (/usr/local/app/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/app/node_modules/axios/lib/core/settle.js:17:',
-      admin_extra_level_1_stack_1:
+      admin_extra_stack1_1:
         '12)\n    at IncomingMessage.handleStreamEnd (/usr/local/app/node_modules/axios/lib/adapters/http.js:260:11)\n    at IncomingMessage.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams',
-      admin_extra_level_1_stack_2:
+      admin_extra_stack1_2:
         '/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)',
     })
   })

--- a/react/o11y/extractExtra.test.ts
+++ b/react/o11y/extractExtra.test.ts
@@ -1,0 +1,110 @@
+import { extractExtra } from './extractExtra'
+
+describe('extractExtra', () => {
+  test('should return an empty object when err is an empty object', () => {
+    const err = {}
+    const result = extractExtra(err)
+    expect(result).toEqual({})
+  })
+
+  test('should extract simple key-value pairs', () => {
+    const err = { key1: 'value1', key2: 'value2' }
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_0_key1: 'value1',
+      admin_extra_level_0_key2: 'value2',
+    })
+  })
+
+  test('should extract nested objects', () => {
+    const err = {
+      key1: 'value1',
+      nested: {
+        key2: 'value2',
+        deeper: {
+          key3: 'value3',
+        },
+      },
+    }
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_0_key1: 'value1',
+      admin_extra_level_1_key2: 'value2',
+      admin_extra_level_2_key3: 'value3',
+    })
+  })
+
+  test('should ignore functions', () => {
+    const err = {
+      key1: 'value1',
+      func: () => {},
+    }
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_0_key1: 'value1',
+    })
+  })
+
+  test('real world example #1', () => {
+    const err = {
+      details: {
+        graphQLErrors: '[Array]',
+        message: 'messages',
+        name: 'Error',
+        stack: 'Some error stack',
+      },
+      stack: 'Some error stack',
+    }
+
+    const result = extractExtra(err)
+    expect(result).toEqual({
+      admin_extra_level_1_graphQLErrors: '[Array]',
+      admin_extra_level_1_message: 'messages',
+      admin_extra_level_1_name: 'Error',
+      admin_extra_level_1_stack: 'Some error stack',
+      admin_extra_level_0_stack: 'Some error stack',
+    })
+  })
+
+  test('should return the original input when it is not an object (string)', () => {
+    const err = 'error'
+    const result = extractExtra(err)
+    expect(result).toEqual(err)
+  })
+
+  test('should return the original input when it is not an object (boolean)', () => {
+    const err = false
+    const result = extractExtra(err)
+    expect(result).toEqual(err)
+  })
+
+  test('should return the original input when it is not an object (undefined)', () => {
+    const result = extractExtra(undefined)
+    expect(result).toEqual(undefined)
+  })
+
+  test('circular references given as input returns an empty object', () => {
+    class Validator {
+      model: any
+
+      constructor(model: any) {
+        this.model = model
+      }
+    }
+
+    class Model {
+      _attributes: any
+      validator: any
+
+      constructor() {
+        this._attributes = {}
+        this.validator = new Validator(this)
+      }
+    }
+
+    const model = new Model()
+
+    const result = extractExtra(model)
+    expect(result).toEqual({})
+  })
+})

--- a/react/o11y/extractExtra.ts
+++ b/react/o11y/extractExtra.ts
@@ -1,0 +1,63 @@
+/**
+ * This method extracts keys from objects iteratively
+ * and adpat them to the format required by Sentry to log
+ * events from the Admin by following our conventions.
+ *
+ * Sentry doesn't log all the keys from an object
+ * when an error is captured, so we need to extract
+ * the keys and values from the error object and
+ * adapt them to the format required by Sentry ourselves
+ * in order to make them indexable and searchable.
+ *
+ * This helps us aggregate and filter errors in Sentry by
+ * dynamically generating keys.
+ */
+export function extractExtra(err: any) {
+  try {
+    const extra: any = {}
+
+    return iterate(err, extra, 0, new Set())
+  } catch (error) {
+    return {}
+  }
+}
+
+/**
+ * This function is recursive and will iterate over the
+ * object's keys and values to extract them and adapt
+ * them to the format required by Sentry.
+ */
+function iterate(
+  err: any,
+  extra: any,
+  iterationNumber: number,
+  seen: Set<any>
+) {
+  if (typeof err === 'object') {
+    // We don't want to rely on the browser's ability
+    // to handle memory leaks when dealing with circular
+    // references, so we need to keep track of the keys
+    // we've already seen to avoid infinite loops.
+    if (seen.has(err)) {
+      throw new Error('Circular reference detected')
+    }
+    seen.add(err)
+
+    for (const key in err) {
+      if (typeof err[key] === 'object') {
+        const updatedExtra = iterate(err[key], extra, iterationNumber + 1, seen)
+        extra = { ...extra, ...updatedExtra }
+      } else {
+        if (typeof err[key] !== 'function') {
+          extra[`admin_extra_level_${iterationNumber}_` + key] = err[key]
+        }
+      }
+
+      seen.delete(err)
+    }
+  } else {
+    return err
+  }
+
+  return extra
+}

--- a/react/o11y/extractExtra.ts
+++ b/react/o11y/extractExtra.ts
@@ -50,7 +50,13 @@ function iterate(
       } else {
         if (typeof err[key] !== 'function') {
           const value = err[key]
-          const tagKey = `admin_extra_${toSnakeCase(key)}${iterationNumber}`
+          const tagKey = `admin_extra_${standardizeKey(key)}${iterationNumber}`
+
+          if (tagKey.length >= 32) {
+            // Skip. Sentry doesn't allow keys longer than 32 characters.
+            // The keys that matter the most are shortened on the standardizeKey function.
+            continue
+          }
 
           // Split values that are too long into as many parts as necessary to fit
           // Sentry's limit of 200 characters per value
@@ -78,6 +84,18 @@ function iterate(
   return extra
 }
 
-function toSnakeCase(str: string) {
-  return str.replace(/-/g, '_').toLowerCase().trim()
+/**
+ * This function standardizes the keys extracted from the error object
+ * to the format required by Sentry (snake_case, lowercase, short).
+ */
+function standardizeKey(str: string) {
+  return str
+    .replace(/-/g, '_')
+    .toLowerCase()
+    .trim()
+    .replace('graphql', 'gql')
+    .replace('message', 'msg')
+    .replace('request', 'req')
+    .replace('response', 'res')
+    .replace('isaxioserror', 'axios')
 }

--- a/react/o11y/extractExtra.ts
+++ b/react/o11y/extractExtra.ts
@@ -50,6 +50,7 @@ function iterate(
       } else {
         if (typeof err[key] !== 'function') {
           const value = err[key]
+          const tagKey = `admin_extra_${toSnakeCase(key)}${iterationNumber}`
 
           // Split values that are too long into as many parts as necessary to fit
           // Sentry's limit of 200 characters per value
@@ -60,12 +61,10 @@ function iterate(
             }
 
             for (let chunk = 0; chunk < chunks.length; chunk++) {
-              extra[
-                `admin_extra_level_${iterationNumber}_` + key + '_' + chunk
-              ] = chunks[chunk]
+              extra[`${tagKey}_` + chunk] = chunks[chunk]
             }
           } else {
-            extra[`admin_extra_level_${iterationNumber}_` + key] = err[key]
+            extra[tagKey] = value
           }
         }
       }
@@ -77,4 +76,8 @@ function iterate(
   }
 
   return extra
+}
+
+function toSnakeCase(str: string) {
+  return str.replace(/-/g, '_').toLowerCase().trim()
 }

--- a/react/o11y/extractExtra.ts
+++ b/react/o11y/extractExtra.ts
@@ -49,7 +49,24 @@ function iterate(
         extra = { ...extra, ...updatedExtra }
       } else {
         if (typeof err[key] !== 'function') {
-          extra[`admin_extra_level_${iterationNumber}_` + key] = err[key]
+          const value = err[key]
+
+          // Split values that are too long into as many parts as necessary to fit
+          // Sentry's limit of 200 characters per value
+          if (value.length >= 200) {
+            const chunks = []
+            for (let chunk = 0; chunk < value.length; chunk += 199) {
+              chunks.push(value.substr(chunk, 199))
+            }
+
+            for (let chunk = 0; chunk < chunks.length; chunk++) {
+              extra[
+                `admin_extra_level_${iterationNumber}_` + key + '_' + chunk
+              ] = chunks[chunk]
+            }
+          } else {
+            extra[`admin_extra_level_${iterationNumber}_` + key] = err[key]
+          }
         }
       }
 


### PR DESCRIPTION
We need to index certain types of errors that are not yet indexed. To do this, we need to transform error objects into a "taggable" structure (such as key:value pairs). This PR adds a method to recursively extract keys from objects and adapt them to the our convention and signature expected on Sentry.

For more details, let's talk on Slack :hugs: 

Tests:

![image](https://github.com/user-attachments/assets/9034415d-aa4b-43ba-81de-af42269c2c88)

Depends on https://github.com/vtex/render-server/pull/801 to take effect.