### PR TITLE
Fix Lazy Load property on images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a conditional to check if the property already exist on images before applying the lazy load property
+
 ## [8.134.11] - 2024-09-30
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "render-runtime",
-  "version": "8.134.11",
+  "version": "8.134.12-beta.0",
   "title": "VTEX Render runtime",
   "description": "The VTEX Render framework runtime",
   "builders": {

--- a/react/components/LazyImages.tsx
+++ b/react/components/LazyImages.tsx
@@ -65,18 +65,21 @@ const MaybeLazyImage: FC<MaybeLazyImageProps> = ({
         /** adds `lazyload` class to enable lazysizes, and moves the image URI
          * from src to data-src. `styles.lazyload` is used to hide the "broken image"
          * symbol while the image hasn't been loaded */
-        newImageProps = {
-          ...imageProps,
-          // explicity key because we need react to re-render the whole img element
-          // in case the src changes (i.e: product-summary + sku)
-          key: imageProps.src,
-          className: `lazyload ${imageProps.className ?? ''} ${
-            styles.lazyload
-          }`,
-          src: undefined,
-          'data-src': imageProps.src,
-          loading: newImageProps.loading ?? 'lazy',
+        if (newImageProps.loading !== 'eager') {
+          newImageProps = {
+            ...imageProps,
+            // explicity key because we need react to re-render the whole img element
+            // in case the src changes (i.e: product-summary + sku)
+            key: imageProps.src,
+            className: `lazyload ${imageProps.className ?? ''} ${
+              styles.lazyload
+            }`,
+            src: undefined,
+            'data-src': imageProps.src,
+            loading: 'lazy',
+          }
         }
+
         break
     }
     return createElement.apply(React, ['img', newImageProps])

--- a/react/components/LazyImages.tsx
+++ b/react/components/LazyImages.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, FC } from 'react'
-import styles from './LazyImages.css'
+import React, { FC, useContext } from 'react'
 import { Helmet } from 'react-helmet'
+import styles from './LazyImages.css'
 
 interface LazyImagesContext {
   lazyLoad: boolean
@@ -75,7 +75,7 @@ const MaybeLazyImage: FC<MaybeLazyImageProps> = ({
           }`,
           src: undefined,
           'data-src': imageProps.src,
-          loading: 'lazy',
+          loading: newImageProps.loading ?? 'lazy',
         }
         break
     }


### PR DESCRIPTION
### Problem

The render runtime replaces the property whatever takes.

If the property already exists it will be skipped.

#### What does this PR do? 

Added a conditional to check if the property already exist on images before applying the lazy load property

#### How to test it? \*

https://artur--gs1usdev.myvtex.com/

<img width="553" alt="image" src="https://github.com/user-attachments/assets/0eb7a140-5983-450a-ae84-5bf1cfb8f8d8">
