### PR TITLE
fix: order used in props overriding of slots and extensions points

### DIFF
--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -1,19 +1,19 @@
 import { mergeDeepRight, reduce } from 'ramda'
 import React, { FC, Fragment, Suspense, useMemo } from 'react'
 
-import ComponentLoader from './ComponentLoader'
-import Loading from '../Loading'
-import { useRuntime } from '../RenderContext'
-import type { RenderContext } from '../RenderContext'
+import { Route } from '../../typings/runtime'
 import { useTreePath } from '../../utils/treePath'
-import NoSSR from '../NoSSR'
 import { withErrorBoundary } from '../ErrorBoundary'
-import GenericPreview from '../Preview/GenericPreview'
-import LoadingBar from '../LoadingBar'
+import FoldableContainer from '../FoldableContainer'
 import { LazyImages } from '../LazyImages'
 import LazyRender from '../LazyRender'
-import FoldableContainer from '../FoldableContainer'
-import { Route } from '../../typings/runtime'
+import Loading from '../Loading'
+import LoadingBar from '../LoadingBar'
+import NoSSR from '../NoSSR'
+import GenericPreview from '../Preview/GenericPreview'
+import type { RenderContext } from '../RenderContext'
+import { useRuntime } from '../RenderContext'
+import ComponentLoader from './ComponentLoader'
 
 // TODO: Export components separately on @vtex/blocks-inspector, so this import can be simplified
 const InspectBlockWrapper = React.lazy(
@@ -225,8 +225,8 @@ const ExtensionPoint: FC<Props> = (props) => {
       /** Props from the blockProps prop, used when the user wants to prevent overriding
        * the native ExtensionPoint props (such as `id`)
        */
-      blockProps || {},
       content,
+      blockProps || {},
       { params, query },
     ])
   }, [

--- a/react/utils/slots.tsx
+++ b/react/utils/slots.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo } from 'react'
 
-import { getChildExtensions } from '../components/ExtensionPoint/index'
 import ComponentLoader from '../components/ExtensionPoint/ComponentLoader'
+import { getChildExtensions } from '../components/ExtensionPoint/index'
 import { useRuntime } from '../components/RenderContext'
 import { Extension } from '../typings/runtime'
 
@@ -30,12 +30,12 @@ export function generateSlot({
 
     const componentLoaderPropsWithContent = useMemo(
       () => ({
-        // Props received by the slot being used directly as a component
-        ...props,
         // Props received by the block referenced by slotValue in a user's theme
         ...componentProps,
         // Content saved in the CMS for this treePath
         ...extensionContent,
+        // Props received by the slot being used directly as a component
+        ...props,
       }),
       [componentProps, extensionContent, props]
     )


### PR DESCRIPTION
#### What does this PR do? \*
A ordem das props usadas em composições com o Blocks e Slots era a de:
- Primeiro as que vinham ser sobrescritas pela customização.
- Depois as que vem por padráo no tema da loja, que no caso envolve as props que possuem valores default.

Isso fazia que caso uma customização não conseguisse sobrescrever uma prop com um valor padrão como o text do rich-text. Limitando o uso de blocks e slots. 

Minha sugestão visa inverter a orde onde as props do tema da loja vem por primeiro e as customizações sáo aplicadas em cima do tema da loja.
