### PR TITLE
[SFOC-95] Feat: add featureFlag to force native browser navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Revert to browser native navigation based on feature flag `useDefaultBrowserNavigation`
+
 ## [8.135.1] - 2024-12-17
 
 ### Added

--- a/react/components/Link.tsx
+++ b/react/components/Link.tsx
@@ -70,10 +70,13 @@ const Link: React.FunctionComponent<Props> = ({
     rootPath = '',
     route: { domain },
     query: queryFromRuntime,
+    getSettings,
   } = useRuntime()
 
   // If workspace is set via querystring, keep it
   const workspace = queryFromRuntime?.workspace
+
+  const storeSettings = getSettings('vtex.store')
 
   const isPrefetchActive = useIsPrefetchActive()
 
@@ -109,7 +112,8 @@ const Link: React.FunctionComponent<Props> = ({
       if (
         isModifiedEvent(event) ||
         !isLeftClickEvent(event) ||
-        (to && (isAbsoluteUrl(to) || isTelephoneUrl(to) || isMailToUrl(to)))
+        (to && (isAbsoluteUrl(to) || isTelephoneUrl(to) || isMailToUrl(to))) ||
+        storeSettings?.useDefaultBrowserNavigation
       ) {
         return
       }
@@ -122,7 +126,14 @@ const Link: React.FunctionComponent<Props> = ({
         event.preventDefault()
       }
     },
-    [to, onClick, navigate, target, options]
+    [
+      to,
+      storeSettings.useDefaultBrowserNavigation,
+      onClick,
+      target,
+      navigate,
+      options,
+    ]
   )
 
   const getHref = () => {


### PR DESCRIPTION
#### What does this PR do? \*

Revert to browser native navigation based on the feature flag `useDefaultBrowserNavigation`, this is causing a behavior in FastStore accounts where a user cannot navigate to different pages without fully reload

<!--- Optional -->

#### Related to / Depends on \*

https://github.com/vtex-apps/store/pull/597

<!--- Optional -->
