### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Shopper#2, Shopper#3)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/render-runtime
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1,Shopper#2,Shopper#3
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: A9XMNEMY
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [8.136.2] - 2026-03-02
 
 ### Added


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Shopper#2,Shopper#3` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Serviço:** bundle React que executa a loja no browser (e dentro dos motores SSR). **Decisão:** skill: hidratação e GraphQL cliente → `graphql-server`; README: runtime IO → cobre PDP/PLP (**Shopper#1**), blocos de carrinho (**Shopper#2**), fluxos logados/perfil (**Shopper#3**) conforme o tema.

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
