### PR TITLE
fix: load minified regenerator runtime in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update DK Catalog platform-flow-id
 
+### Fixed
+
+- Load the minified regenerator runtime in production
+
 ## [8.136.2] - 2026-03-02
 
 ### Added

--- a/react/externals.json
+++ b/react/externals.json
@@ -98,7 +98,7 @@
         "serverOnly": true
       },
       {
-        "path": "npm:regenerator-runtime@0.11.1/runtime.min.js"
+        "path": "runtime:regenerator-runtime"
       },
       {
         "global": "PropTypes",

--- a/react/externals.json
+++ b/react/externals.json
@@ -98,7 +98,7 @@
         "serverOnly": true
       },
       {
-        "path": "npm:regenerator-runtime@0.11.1/runtime.js"
+        "path": "npm:regenerator-runtime@0.11.1/runtime.min.js"
       },
       {
         "global": "PropTypes",

--- a/react/package.json
+++ b/react/package.json
@@ -33,6 +33,7 @@
     "react-apollo": "^3.1.2",
     "react-helmet": "^5.2.0",
     "react-json-view": "^1.19.1",
+    "regenerator-runtime": "0.11.1",
     "route-parser": "^0.0.5",
     "use-media": "^1.4.0"
   },
@@ -78,7 +79,6 @@
     "react-hot-loader": "^4.3.12",
     "react-intl": "^3.9.1",
     "react-no-ssr": "^1.1.0",
-    "regenerator-runtime": "^0.13.1",
     "ts-jest": "^24.0.1",
     "typescript": "3.9.7"
   },

--- a/react/regenerator-runtime.ts
+++ b/react/regenerator-runtime.ts
@@ -1,0 +1,1 @@
+import 'regenerator-runtime/runtime'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -7229,7 +7229,7 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@0.11.1, regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==


### PR DESCRIPTION
#### What does this PR do? \*

Production storefronts load `regenerator-runtime@0.11.1/runtime.js` through the VTEX npm asset proxy. Lighthouse flags the 6.6 KiB transferred script as unminified JavaScript and estimates about 3.8 KiB savings. The same asset and audit were reproduced across five Store Framework storefronts.

Following [Iago's suggestion](https://github.com/vtex-apps/render-runtime/pull/685#issuecomment-5543945862), this PR now adds a local `react/regenerator-runtime.ts` entrypoint importing `regenerator-runtime/runtime`, pins the dependency to `0.11.1`, and points the production external at `runtime:regenerator-runtime`. Development keeps the existing npm `runtime.js` external.

The local entrypoint lets the VTEX React builder bundle and minify the runtime for production and serve it as a separate external from VTEX assets. This is expected to address Lighthouse's unminified JavaScript finding; the final gzip savings still need to be measured from the actual VTEX production output.

<img width="942" height="283" alt="pagespeed-regenerator-runtime-audit" src="https://github.com/user-attachments/assets/e1514b6b-ddf0-41e0-9644-8caa87bef2fa" />

#### How to test it? \*

I could not link this app in my workspace; it appears that linking `vtex.render-runtime` requires VTEX access that I do not have. Validation of the new bundle is still pending and needs help from a maintainer with the required access.

1. Link the app in an authorized workspace or publish and install a beta version, then load a storefront using the production output.
2. Confirm that the `runtime:regenerator-runtime` asset loads before React/apps and exposes the `regeneratorRuntime` global in both the browser and SSR; check generator behavior and rendering for regressions.
3. Measure the production asset's gzip size against the existing approximately 6.8 KiB runtime, including the bundle wrapper, and rerun Lighthouse to verify the unminified JavaScript finding.
4. Confirm that development still loads the existing npm `runtime.js` external.

#### Describe alternatives you've considered, if any. \*

Superseded approach:

~~Change only the production external path to `runtime.min.js`. Although `regenerator-runtime@0.11.1` does not publish that file, jsDelivr generates missing `.min.js` variants on demand, and the VTEX npm asset proxy serves it through its jsDelivr fallback.~~

The PR now uses the locally imported, pinned runtime through the VTEX builder, as suggested by Iago, removing the dependency on jsDelivr's on-demand minification.

The previous measurements below apply **only to the superseded jsDelivr approach**, not to the new VTEX bundle:

- Existing runtime: 24,200 raw / about 6,833 gzip bytes.
- ~~jsDelivr minified variant: 6,674 raw / about 2,617 gzip bytes; about 4.2 KiB transferred savings.~~
- ~~The original and jsDelivr-minified responses exposed the same eight regenerator APIs and passed the same generator behavior probe.~~

#### Related to / Depends on \*

[Review suggestion and pending validation](https://github.com/vtex-apps/render-runtime/pull/685#issuecomment-5543945862).
