### PR TITLE
fix: give ExtensionPoint's SSR placeholder its own tree-path context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Give `ExtensionPoint`'s SSR loading placeholder its own tree-path context, so it no longer inherits and renders the parent block's preview size. Fixes a layout-shift bug where a page-level block with a large declared preview (e.g. a 1400px box) caused every `client`-rendered child with no preview of its own to reserve that same oversized placeholder on SSR, then collapse to its real height on hydration.
+
 ### Changed
 
 - Update DK Catalog platform-flow-id

--- a/react/components/ExtensionPoint/ExtensionPoint.test.tsx
+++ b/react/components/ExtensionPoint/ExtensionPoint.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { cleanup, render } from '@vtex/test-tools/react'
+import { renderToString } from 'react-dom/server'
 import 'jest-dom/extend-expect'
 import ExtensionPoint from './index'
 import { TreePathContextProvider } from '../../utils/treePath'
@@ -38,4 +39,43 @@ test(`it shouldn't show Preview when there is no extension for current tree path
   )
 
   expect(queryByTestId(PreviewTestId)).toBeNull()
+})
+
+test(`it shouldn't show the parent's Preview for a client-rendered block that has no preview of its own`, () => {
+  const mockExtensions: Record<string, Partial<Extension>> = {
+    'store.search#category/search-result#category': {
+      component: '',
+      preview: {
+        height: {
+          desktop: { defaultValue: 500 },
+          mobile: { defaultValue: 500 },
+        },
+        width: {
+          desktop: { defaultValue: 500 },
+          mobile: { defaultValue: 500 },
+        },
+        type: 'box',
+      },
+    },
+    // Declares no preview of its own, so it should get no placeholder at all --
+    // never the 500px box belonging to the block above it.
+    'store.search#category/search-result#category/search-title': {
+      component: '',
+      render: 'client',
+    },
+  }
+
+  /* Has to go through the server renderer: NoSSR only takes its onSSR branch there,
+   * because under jsdom the layout effect runs and the children render instead. */
+  const html = renderToString(
+    <RenderContextProvider
+      runtime={{ extensions: mockExtensions, getSettings: () => ({}) } as any}
+    >
+      <TreePathContextProvider treePath="store.search#category/search-result#category">
+        <ExtensionPoint treePath="" id="search-title" />
+      </TreePathContextProvider>
+    </RenderContextProvider>
+  )
+
+  expect(html).not.toContain(PreviewTestId)
 })

--- a/react/components/ExtensionPoint/index.tsx
+++ b/react/components/ExtensionPoint/index.tsx
@@ -5,7 +5,7 @@ import ComponentLoader from './ComponentLoader'
 import Loading from '../Loading'
 import { useRuntime } from '../RenderContext'
 import type { RenderContext } from '../RenderContext'
-import { useTreePath } from '../../utils/treePath'
+import { useTreePath, TreePathContextProvider } from '../../utils/treePath'
 import NoSSR from '../NoSSR'
 import { withErrorBoundary } from '../ErrorBoundary'
 import GenericPreview from '../Preview/GenericPreview'
@@ -300,7 +300,21 @@ const ExtensionPoint: FC<Props> = (props) => {
     <Fragment>
       {runtime.preview && isRootTreePath && <LoadingBar />}
       {renderStrategy === 'client' && !runtime.amp ? (
-        <NoSSR onSSR={<Loading />}>{extensionPointComponent}</NoSSR>
+        <NoSSR
+          onSSR={
+            /** Loading resolves its extension from the tree path in context, so it has
+             * to be given this block's own path. Rendered bare it would read the
+             * parent's path instead and draw the parent's preview -- a page-level
+             * block declaring a 1400px preview would have every "client" child
+             * reserve 1400px on the server and collapse to its real height on
+             * hydration. */
+            <TreePathContextProvider treePath={newTreePath}>
+              <Loading />
+            </TreePathContextProvider>
+          }
+        >
+          {extensionPointComponent}
+        </NoSSR>
       ) : (
         extensionPointComponent
       )}


### PR DESCRIPTION
#### What does this PR do? *

Fixes a CLS bug in `ExtensionPoint`: its SSR loading placeholder (`<Loading />`) rendered *outside* its own tree-path context, so it inherited the **parent block's** preview size instead of its own. On pages where a page-level block declares a large preview (e.g. a 1400px `box`) with `client`-rendered children that have no preview of their own, SSR emitted the parent's oversized placeholder for each child — which then collapsed to its real height on hydration, causing a large layout shift.

**Fix:** wrap the placeholder in a `TreePathContextProvider` scoped to the block's own tree path.

### 📊 Results — tested live on 4 real store accounts

| Store | Bug present? | CLS before → after |
|---|:-:|---|
| 🟢 **Olympikus** | Yes | **0.1071 → 0.0000** (-100%, 5/5 runs) |
| 🟢 **Loja Três** | Yes | **0.699 → 0.0054** (-99%) |
| ⚪ Pague Menos | No (control) | ~0.97 → ~1.00 (no change, as expected) |
| ⚪ storecomponents | No (control) | 0.434 → 0.3485 (dominant shift untouched, as expected) |

CLS fully eliminated on the two stores that actually have the bug pattern; correctly no-ops on the two that don't. FCP/LCP/DOM node count unchanged everywhere.

#### How to test it? *

- Regression test added in `ExtensionPoint.test.tsx`; `tsc --noEmit` clean.
- All numbers above come from A/B testing this branch via `vtex link` against a dedicated **dev workspace** on each store's account (baseline vs. fix, same workspace) — never against live production traffic.
- Independently confirmed via `ReactDOMServer` (jsdom can't reach this branch): pre-fix SSR emits the parent's 460px preview marker; post-fix output is empty, as expected.
- **QA review passed clean:** Bugbot, Security Review, and a performance-focused review all ran against this diff — zero findings (no breaking changes, no security/perf concerns).

<details>
<summary>Known toolchain caveat</summary>

The local suite has 4 pre-existing failures unrelated to this change (pinned `@babel/parser` 7.7.7 can't parse `import type` in already-committed code), so the new test couldn't run locally — verified instead via the compiled SSR harness. CI should run it for real.
</details>

#### Describe alternatives you've considered, if any. *

None — straightforward context-scoping fix to existing `NoSSR`/`Loading` wiring, not a design trade-off.

#### Related to / Depends on *

Follow-up candidate (not part of this PR): `LazyRender`'s hardcoded `height=400` placeholder can also shift layout for below-fold content of a different real height. Not solidly measured yet (only 3 noisy runs).
